### PR TITLE
feature: Scaffold zksettle-types shared crate

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -9123,6 +9123,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksettle-types"
+version = "0.1.0"
+dependencies = [
+ "borsh 1.6.1",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
-    "programs/*"
+    "programs/*",
+    "crates/*",
 ]
 resolver = "2"
 

--- a/backend/crates/zksettle-types/Cargo.toml
+++ b/backend/crates/zksettle-types/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "zksettle-types"
+version = "0.1.0"
+edition = "2021"
+description = "Shared type definitions for ZKSettle on-chain and off-chain components"
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+borsh = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -14,9 +14,7 @@ use crate::{Hash32, Pubkey};
 /// Off-chain mirror of the on-chain `Issuer` account.
 ///
 /// Layout: `authority (32) + merkle_root (32) + root_slot (8) + bump (1)` = 73 bytes.
-#[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct Issuer {
     pub authority: Pubkey,
     pub merkle_root: Hash32,
@@ -56,9 +54,7 @@ impl Nullifier {
 ///
 /// Layout: `issuer (32) + nullifier_hash (32) + merkle_root (32) + slot (8)
 /// + payer (32) + bump (1)` = 137 bytes.
-#[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct Attestation {
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -12,7 +12,6 @@ pub struct Issuer {
 }
 
 impl Issuer {
-    // authority (32) + merkle_root (32) + root_slot (8) + bump (1)
     pub const LEN: usize = 32 + 32 + 8 + 1;
 }
 

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -1,19 +1,8 @@
-//! Off-chain mirrors of the Anchor account layouts in
-//! `backend/programs/zksettle/src/state/`. Field order and types are chosen
-//! so the Borsh byte representation matches the on-chain format.
-//!
-//! `CompressedNullifier` and `CompressedAttestation` mirror Light Protocol
-//! compressed accounts — they carry no Anchor discriminator and are not
-//! rent-funded PDAs.
-
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::{Hash32, Pubkey};
 
-/// Off-chain mirror of the on-chain `Issuer` account.
-///
-/// Layout: `authority (32) + merkle_root (32) + root_slot (8) + bump (1)` = 73 bytes.
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct Issuer {
     pub authority: Pubkey,
@@ -23,14 +12,12 @@ pub struct Issuer {
 }
 
 impl Issuer {
-    /// Payload size in bytes, excluding Anchor's 8-byte discriminator.
+    // authority (32) + merkle_root (32) + root_slot (8) + bump (1)
     pub const LEN: usize = 32 + 32 + 8 + 1;
 }
 
-/// Off-chain mirror of the on-chain `CompressedNullifier` Light-compressed account.
-///
-/// Carries no data — its mere existence at the derived compressed address
-/// proves the nullifier has been spent for the bound issuer.
+/// Discriminator-only marker: presence at the derived compressed address
+/// proves the nullifier was spent for the bound issuer.
 #[derive(
     Clone,
     Copy,
@@ -45,10 +32,6 @@ impl Issuer {
 )]
 pub struct CompressedNullifier;
 
-/// Off-chain mirror of the on-chain `CompressedAttestation` Light-compressed
-/// account written by `verify_proof` on successful verification.
-///
-/// Field order matches `backend/programs/zksettle/src/state/compressed.rs`.
 #[derive(
     Clone, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
 )]
@@ -68,10 +51,8 @@ pub struct CompressedAttestation {
 mod tests {
     use super::*;
 
-    // Pinned to the on-chain layouts in `backend/programs/zksettle/src/state/`.
-    // Any divergence fails CI and forces both sides to stay in sync.
     const ON_CHAIN_ISSUER_LEN: usize = 73;
-    const ON_CHAIN_COMPRESSED_ATTESTATION_PAYLOAD_LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
+    const COMPRESSED_ATTESTATION_PAYLOAD_LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
 
     #[test]
     fn issuer_len_matches_on_chain() {
@@ -113,7 +94,7 @@ mod tests {
             payer: [8u8; 32],
         };
         let bytes = borsh::to_vec(&original).expect("serialize");
-        assert_eq!(bytes.len(), ON_CHAIN_COMPRESSED_ATTESTATION_PAYLOAD_LEN);
+        assert_eq!(bytes.len(), COMPRESSED_ATTESTATION_PAYLOAD_LEN);
         let decoded = CompressedAttestation::try_from_slice(&bytes).expect("deserialize");
         assert_eq!(decoded, original);
     }

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -72,3 +72,60 @@ impl Attestation {
     /// Payload size in bytes, excluding Anchor's 8-byte discriminator.
     pub const LEN: usize = 32 + 32 + 32 + 8 + 32 + 1;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These length constants are pinned to the on-chain layout in
+    // `backend/programs/zksettle/src/state/`. If the program side changes,
+    // these tests will fail and the mirror MUST be updated to match.
+    const ON_CHAIN_ISSUER_LEN: usize = 73;
+    const ON_CHAIN_ATTESTATION_LEN: usize = 137;
+    const ON_CHAIN_NULLIFIER_LEN: usize = 0;
+
+    #[test]
+    fn issuer_len_matches_on_chain() {
+        assert_eq!(Issuer::LEN, ON_CHAIN_ISSUER_LEN);
+    }
+
+    #[test]
+    fn nullifier_len_matches_on_chain() {
+        assert_eq!(Nullifier::LEN, ON_CHAIN_NULLIFIER_LEN);
+    }
+
+    #[test]
+    fn attestation_len_matches_on_chain() {
+        assert_eq!(Attestation::LEN, ON_CHAIN_ATTESTATION_LEN);
+    }
+
+    #[test]
+    fn issuer_borsh_roundtrip_preserves_layout() {
+        let original = Issuer {
+            authority: [1u8; 32],
+            merkle_root: [2u8; 32],
+            root_slot: 0x0123_4567_89ab_cdef,
+            bump: 255,
+        };
+        let bytes = borsh::to_vec(&original).expect("serialize");
+        assert_eq!(bytes.len(), Issuer::LEN);
+        let decoded = Issuer::try_from_slice(&bytes).expect("deserialize");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn attestation_borsh_roundtrip_preserves_layout() {
+        let original = Attestation {
+            issuer: [3u8; 32],
+            nullifier_hash: [4u8; 32],
+            merkle_root: [5u8; 32],
+            slot: 42,
+            payer: [6u8; 32],
+            bump: 7,
+        };
+        let bytes = borsh::to_vec(&original).expect("serialize");
+        assert_eq!(bytes.len(), Attestation::LEN);
+        let decoded = Attestation::try_from_slice(&bytes).expect("deserialize");
+        assert_eq!(decoded, original);
+    }
+}

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -1,0 +1,74 @@
+//! Off-chain mirrors of the Anchor account layouts defined in
+//! `backend/programs/zksettle/src/state/`. Field order and types are chosen to
+//! match the on-chain Borsh byte representation exactly so off-chain services
+//! can decode raw account data fetched from the RPC.
+//!
+//! The `LEN` constants mirror the program-side values and do **not** include
+//! the 8-byte Anchor discriminator that prefixes every Anchor account.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+use crate::{Hash32, Pubkey};
+
+/// Off-chain mirror of the on-chain `Issuer` account.
+///
+/// Layout: `authority (32) + merkle_root (32) + root_slot (8) + bump (1)` = 73 bytes.
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct Issuer {
+    pub authority: Pubkey,
+    pub merkle_root: Hash32,
+    pub root_slot: u64,
+    pub bump: u8,
+}
+
+impl Issuer {
+    /// Payload size in bytes, excluding Anchor's 8-byte discriminator.
+    pub const LEN: usize = 32 + 32 + 8 + 1;
+}
+
+/// Off-chain mirror of the on-chain `Nullifier` marker account.
+///
+/// The account carries no data — its mere existence at the derived PDA
+/// proves the nullifier has been spent for the bound issuer.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    BorshSerialize,
+    BorshDeserialize,
+    Serialize,
+    Deserialize,
+)]
+pub struct Nullifier;
+
+impl Nullifier {
+    pub const LEN: usize = 0;
+}
+
+/// Off-chain mirror of the on-chain `Attestation` account written by
+/// `verify_proof` on successful verification.
+///
+/// Layout: `issuer (32) + nullifier_hash (32) + merkle_root (32) + slot (8)
+/// + payer (32) + bump (1)` = 137 bytes.
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct Attestation {
+    pub issuer: Pubkey,
+    pub nullifier_hash: Hash32,
+    pub merkle_root: Hash32,
+    pub slot: u64,
+    pub payer: Pubkey,
+    pub bump: u8,
+}
+
+impl Attestation {
+    /// Payload size in bytes, excluding Anchor's 8-byte discriminator.
+    pub const LEN: usize = 32 + 32 + 32 + 8 + 32 + 1;
+}

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -1,10 +1,10 @@
-//! Off-chain mirrors of the Anchor account layouts defined in
-//! `backend/programs/zksettle/src/state/`. Field order and types are chosen to
-//! match the on-chain Borsh byte representation exactly so off-chain services
-//! can decode raw account data fetched from the RPC.
+//! Off-chain mirrors of the Anchor account layouts in
+//! `backend/programs/zksettle/src/state/`. Field order and types are chosen
+//! so the Borsh byte representation matches the on-chain format.
 //!
-//! The `LEN` constants mirror the program-side values and do **not** include
-//! the 8-byte Anchor discriminator that prefixes every Anchor account.
+//! `CompressedNullifier` and `CompressedAttestation` mirror Light Protocol
+//! compressed accounts — they carry no Anchor discriminator and are not
+//! rent-funded PDAs.
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
@@ -27,9 +27,9 @@ impl Issuer {
     pub const LEN: usize = 32 + 32 + 8 + 1;
 }
 
-/// Off-chain mirror of the on-chain `Nullifier` marker account.
+/// Off-chain mirror of the on-chain `CompressedNullifier` Light-compressed account.
 ///
-/// The account carries no data — its mere existence at the derived PDA
+/// Carries no data — its mere existence at the derived compressed address
 /// proves the nullifier has been spent for the bound issuer.
 #[derive(
     Clone,
@@ -43,56 +43,39 @@ impl Issuer {
     Serialize,
     Deserialize,
 )]
-pub struct Nullifier;
+pub struct CompressedNullifier;
 
-impl Nullifier {
-    pub const LEN: usize = 0;
-}
-
-/// Off-chain mirror of the on-chain `Attestation` account written by
-/// `verify_proof` on successful verification.
+/// Off-chain mirror of the on-chain `CompressedAttestation` Light-compressed
+/// account written by `verify_proof` on successful verification.
 ///
-/// Layout: `issuer (32) + nullifier_hash (32) + merkle_root (32) + slot (8)
-/// + payer (32) + bump (1)` = 137 bytes.
-#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
-pub struct Attestation {
+/// Field order matches `backend/programs/zksettle/src/state/compressed.rs`.
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct CompressedAttestation {
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,
     pub merkle_root: Hash32,
+    pub mint: Pubkey,
+    pub recipient: Pubkey,
+    pub amount: u64,
+    pub epoch: u64,
     pub slot: u64,
     pub payer: Pubkey,
-    pub bump: u8,
-}
-
-impl Attestation {
-    /// Payload size in bytes, excluding Anchor's 8-byte discriminator.
-    pub const LEN: usize = 32 + 32 + 32 + 8 + 32 + 1;
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // These length constants are pinned to the on-chain layout in
-    // `backend/programs/zksettle/src/state/`. If the program side changes,
-    // these tests will fail and the mirror MUST be updated to match.
+    // Pinned to the on-chain layouts in `backend/programs/zksettle/src/state/`.
+    // Any divergence fails CI and forces both sides to stay in sync.
     const ON_CHAIN_ISSUER_LEN: usize = 73;
-    const ON_CHAIN_ATTESTATION_LEN: usize = 137;
-    const ON_CHAIN_NULLIFIER_LEN: usize = 0;
+    const ON_CHAIN_COMPRESSED_ATTESTATION_PAYLOAD_LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
 
     #[test]
     fn issuer_len_matches_on_chain() {
         assert_eq!(Issuer::LEN, ON_CHAIN_ISSUER_LEN);
-    }
-
-    #[test]
-    fn nullifier_len_matches_on_chain() {
-        assert_eq!(Nullifier::LEN, ON_CHAIN_NULLIFIER_LEN);
-    }
-
-    #[test]
-    fn attestation_len_matches_on_chain() {
-        assert_eq!(Attestation::LEN, ON_CHAIN_ATTESTATION_LEN);
     }
 
     #[test]
@@ -110,18 +93,28 @@ mod tests {
     }
 
     #[test]
-    fn attestation_borsh_roundtrip_preserves_layout() {
-        let original = Attestation {
+    fn compressed_nullifier_borsh_roundtrip_is_zero_bytes() {
+        let bytes = borsh::to_vec(&CompressedNullifier).expect("serialize");
+        assert_eq!(bytes.len(), 0);
+        CompressedNullifier::try_from_slice(&bytes).expect("deserialize");
+    }
+
+    #[test]
+    fn compressed_attestation_borsh_roundtrip_preserves_layout() {
+        let original = CompressedAttestation {
             issuer: [3u8; 32],
             nullifier_hash: [4u8; 32],
             merkle_root: [5u8; 32],
-            slot: 42,
-            payer: [6u8; 32],
-            bump: 7,
+            mint: [6u8; 32],
+            recipient: [7u8; 32],
+            amount: 1_000_000,
+            epoch: 42,
+            slot: 123_456,
+            payer: [8u8; 32],
         };
         let bytes = borsh::to_vec(&original).expect("serialize");
-        assert_eq!(bytes.len(), Attestation::LEN);
-        let decoded = Attestation::try_from_slice(&bytes).expect("deserialize");
+        assert_eq!(bytes.len(), ON_CHAIN_COMPRESSED_ATTESTATION_PAYLOAD_LEN);
+        let decoded = CompressedAttestation::try_from_slice(&bytes).expect("deserialize");
         assert_eq!(decoded, original);
     }
 }

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -31,6 +31,8 @@ impl Issuer {
 )]
 pub struct CompressedNullifier;
 
+/// Persisted compressed account state (LightDiscriminator). Same fields as ProofSettled
+/// but represents account data, not an event payload.
 #[derive(
     Clone, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
 )]
@@ -46,13 +48,15 @@ pub struct CompressedAttestation {
     pub payer: Pubkey,
 }
 
+impl CompressedAttestation {
+    pub const LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     const ON_CHAIN_ISSUER_LEN: usize = 73;
-    const COMPRESSED_ATTESTATION_PAYLOAD_LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
-
     #[test]
     fn issuer_len_matches_on_chain() {
         assert_eq!(Issuer::LEN, ON_CHAIN_ISSUER_LEN);
@@ -93,7 +97,7 @@ mod tests {
             payer: [8u8; 32],
         };
         let bytes = borsh::to_vec(&original).expect("serialize");
-        assert_eq!(bytes.len(), COMPRESSED_ATTESTATION_PAYLOAD_LEN);
+        assert_eq!(bytes.len(), CompressedAttestation::LEN);
         let decoded = CompressedAttestation::try_from_slice(&bytes).expect("deserialize");
         assert_eq!(decoded, original);
     }

--- a/backend/crates/zksettle-types/src/credential.rs
+++ b/backend/crates/zksettle-types/src/credential.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Hash32, Pubkey};
 
-/// Signed after KYC. Transported as JSON; only its Poseidon commitment
-/// lands on-chain (as a leaf of the issuer's Merkle tree).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Credential {
     pub schema_version: u32,

--- a/backend/crates/zksettle-types/src/credential.rs
+++ b/backend/crates/zksettle-types/src/credential.rs
@@ -1,40 +1,16 @@
-//! Credential schema — what an issuer signs for a user after KYC.
-//!
-//! Credentials never live on-chain in their raw form; only their Poseidon
-//! commitment does (as a leaf of the issuer's Merkle tree). Off-chain
-//! services transport credentials as JSON, which is why this module only
-//! derives `serde` traits and not `borsh`.
-
 use serde::{Deserialize, Serialize};
 
 use crate::{Hash32, Pubkey};
 
-/// A compliance credential issued by a KYC provider after vetting a user.
-///
-/// The Poseidon commitment of this struct is what lands in the issuer's
-/// Merkle tree and later gets proven privately inside the Noir circuit.
+/// Signed after KYC. Transported as JSON; only its Poseidon commitment
+/// lands on-chain (as a leaf of the issuer's Merkle tree).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Credential {
-    /// Credential schema version — exposed as a public input per ADR-010 so
-    /// the program can enforce which schema versions are currently accepted.
     pub schema_version: u32,
-
-    /// Solana wallet the credential is bound to.
     pub wallet: Pubkey,
-
-    /// ISO-3166 alpha-2 country code (e.g. "US", "BR"). Hashed into a
-    /// jurisdiction set per ADR-013.
     pub jurisdiction: String,
-
-    /// Unix timestamp (seconds) after which the credential must be rejected.
     pub expiry: u64,
-
-    /// True if the user cleared the issuer's sanctions screening at issuance.
     pub sanctions_clear: bool,
 }
 
-/// Poseidon hash of a `Credential`, used as the leaf value in the issuer's
-/// Merkle tree. The Poseidon implementation lives in the separate
-/// `zksettle-crypto` crate (issue #20); this is just the type alias consumers
-/// use when they need to name "the commitment."
 pub type CredentialCommitment = Hash32;

--- a/backend/crates/zksettle-types/src/credential.rs
+++ b/backend/crates/zksettle-types/src/credential.rs
@@ -1,0 +1,40 @@
+//! Credential schema — what an issuer signs for a user after KYC.
+//!
+//! Credentials never live on-chain in their raw form; only their Poseidon
+//! commitment does (as a leaf of the issuer's Merkle tree). Off-chain
+//! services transport credentials as JSON, which is why this module only
+//! derives `serde` traits and not `borsh`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Hash32, Pubkey};
+
+/// A compliance credential issued by a KYC provider after vetting a user.
+///
+/// The Poseidon commitment of this struct is what lands in the issuer's
+/// Merkle tree and later gets proven privately inside the Noir circuit.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Credential {
+    /// Credential schema version — exposed as a public input per ADR-010 so
+    /// the program can enforce which schema versions are currently accepted.
+    pub schema_version: u32,
+
+    /// Solana wallet the credential is bound to.
+    pub wallet: Pubkey,
+
+    /// ISO-3166 alpha-2 country code (e.g. "US", "BR"). Hashed into a
+    /// jurisdiction set per ADR-013.
+    pub jurisdiction: String,
+
+    /// Unix timestamp (seconds) after which the credential must be rejected.
+    pub expiry: u64,
+
+    /// True if the user cleared the issuer's sanctions screening at issuance.
+    pub sanctions_clear: bool,
+}
+
+/// Poseidon hash of a `Credential`, used as the leaf value in the issuer's
+/// Merkle tree. The Poseidon implementation lives in the separate
+/// `zksettle-crypto` crate (issue #20); this is just the type alias consumers
+/// use when they need to name "the commitment."
+pub type CredentialCommitment = Hash32;

--- a/backend/crates/zksettle-types/src/credential.rs
+++ b/backend/crates/zksettle-types/src/credential.rs
@@ -6,6 +6,7 @@ use crate::{Hash32, Pubkey};
 pub struct Credential {
     pub schema_version: u32,
     pub wallet: Pubkey,
+    /// ISO 3166-1 alpha-2 country code (e.g. "US", "BR").
     pub jurisdiction: String,
     pub expiry: u64,
     pub sanctions_clear: bool,

--- a/backend/crates/zksettle-types/src/error.rs
+++ b/backend/crates/zksettle-types/src/error.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ZksettleError {
     // Mirrors of on-chain `ZkSettleError` variants.
     #[error("proof or witness bytes are malformed")]

--- a/backend/crates/zksettle-types/src/error.rs
+++ b/backend/crates/zksettle-types/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ZksettleError {
-    // Mirrors of on-chain `ZkSettleError` variants.
+    // Mirrors on-chain `ZkSettleError` (capital K) — lowercase here per Rust convention.
     #[error("proof or witness bytes are malformed")]
     MalformedProof,
     #[error("proof verification failed")]

--- a/backend/crates/zksettle-types/src/error.rs
+++ b/backend/crates/zksettle-types/src/error.rs
@@ -18,6 +18,46 @@ pub enum ZksettleError {
     NullifierMismatch,
     #[error("witness has fewer public inputs than required")]
     WitnessTooShort,
+    #[error("issuer merkle root is stale; re-publish before verifying")]
+    RootStale,
+    #[error("nullifier hash must be non-zero")]
+    ZeroNullifier,
+    #[error("witness mint limbs do not match instruction argument")]
+    MintMismatch,
+    #[error("witness epoch does not match instruction argument")]
+    EpochMismatch,
+    #[error("witness recipient limbs do not match instruction argument")]
+    RecipientMismatch,
+    #[error("witness amount does not match instruction argument")]
+    AmountMismatch,
+    #[error("proof epoch is in the future relative to on-chain clock")]
+    EpochInFuture,
+    #[error("proof epoch is older than allowed freshness window")]
+    EpochStale,
+    #[error("attestation has expired beyond the validity window")]
+    AttestationExpired,
+    #[error("on-chain clock returned a negative unix timestamp")]
+    NegativeClock,
+    #[error("light protocol tree pubkey lookup failed")]
+    LightTreeLookupFailed,
+    #[error("packing a compressed account for light CPI failed")]
+    LightAccountPackFailed,
+    #[error("light protocol CPI invoke failed")]
+    LightInvokeFailed,
+    #[error("compressed account address is invalid")]
+    InvalidLightAddress,
+    #[error("hook payload is malformed or too large")]
+    HookPayloadInvalid,
+    #[error("transfer amount must be non-zero")]
+    InvalidTransferAmount,
+    #[error("hook payload issuer does not match issuer account")]
+    IssuerMismatch,
+    #[error("source token account is not owned by token-2022")]
+    NotToken2022,
+    #[error("transfer hook invoked outside an active token-2022 transfer")]
+    NotInTransfer,
+    #[error("source token account owner does not match hook owner")]
+    OwnerMismatch,
 
     // Off-chain only.
     #[error("credential expired")]

--- a/backend/crates/zksettle-types/src/error.rs
+++ b/backend/crates/zksettle-types/src/error.rs
@@ -1,46 +1,28 @@
-//! Shared error enum for ZKSettle off-chain components.
-//!
-//! On-chain variants mirror `ZkSettleError` in
-//! `backend/programs/zksettle/src/error.rs` so services that surface an RPC
-//! error back to the caller can translate program error codes into a typed
-//! variant. Off-chain-only variants cover failures that never reach the
-//! program (HTTP, serialization, policy pre-checks).
-
 use thiserror::Error;
 
-/// Errors that can surface when handling ZKSettle credentials, proofs, or
-/// attestations outside the on-chain program.
 #[derive(Debug, Error)]
 pub enum ZksettleError {
-    // --- Mirrors of on-chain error codes -----------------------------------
+    // Mirrors of on-chain `ZkSettleError` variants.
     #[error("proof or witness bytes are malformed")]
     MalformedProof,
-
     #[error("proof verification failed")]
     ProofInvalid,
-
     #[error("merkle root must be non-zero")]
     ZeroMerkleRoot,
-
     #[error("signer is not the issuer authority")]
     UnauthorizedIssuer,
-
     #[error("witness merkle_root does not match issuer PDA")]
     MerkleRootMismatch,
-
     #[error("witness nullifier does not match instruction argument")]
     NullifierMismatch,
-
     #[error("witness has fewer public inputs than required")]
     WitnessTooShort,
 
-    // --- Off-chain-only variants -------------------------------------------
+    // Off-chain only.
     #[error("credential expired")]
     CredentialExpired,
-
     #[error("jurisdiction not permitted by policy")]
     JurisdictionDenied,
-
     #[error("serialization failed: {0}")]
     Serialization(String),
 }

--- a/backend/crates/zksettle-types/src/error.rs
+++ b/backend/crates/zksettle-types/src/error.rs
@@ -1,0 +1,46 @@
+//! Shared error enum for ZKSettle off-chain components.
+//!
+//! On-chain variants mirror `ZkSettleError` in
+//! `backend/programs/zksettle/src/error.rs` so services that surface an RPC
+//! error back to the caller can translate program error codes into a typed
+//! variant. Off-chain-only variants cover failures that never reach the
+//! program (HTTP, serialization, policy pre-checks).
+
+use thiserror::Error;
+
+/// Errors that can surface when handling ZKSettle credentials, proofs, or
+/// attestations outside the on-chain program.
+#[derive(Debug, Error)]
+pub enum ZksettleError {
+    // --- Mirrors of on-chain error codes -----------------------------------
+    #[error("proof or witness bytes are malformed")]
+    MalformedProof,
+
+    #[error("proof verification failed")]
+    ProofInvalid,
+
+    #[error("merkle root must be non-zero")]
+    ZeroMerkleRoot,
+
+    #[error("signer is not the issuer authority")]
+    UnauthorizedIssuer,
+
+    #[error("witness merkle_root does not match issuer PDA")]
+    MerkleRootMismatch,
+
+    #[error("witness nullifier does not match instruction argument")]
+    NullifierMismatch,
+
+    #[error("witness has fewer public inputs than required")]
+    WitnessTooShort,
+
+    // --- Off-chain-only variants -------------------------------------------
+    #[error("credential expired")]
+    CredentialExpired,
+
+    #[error("jurisdiction not permitted by policy")]
+    JurisdictionDenied,
+
+    #[error("serialization failed: {0}")]
+    Serialization(String),
+}

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -21,3 +21,28 @@ pub struct ProofSettled {
     pub slot: u64,
     pub payer: Pubkey,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialized size of the Anchor event payload (no discriminator here —
+    /// Anchor events are prefixed by an 8-byte discriminator in the program
+    /// log entry, but the payload itself is just the Borsh-encoded fields).
+    const EXPECTED_PAYLOAD_LEN: usize = 32 + 32 + 32 + 8 + 32;
+
+    #[test]
+    fn proof_settled_borsh_roundtrip() {
+        let original = ProofSettled {
+            issuer: [9u8; 32],
+            nullifier_hash: [8u8; 32],
+            merkle_root: [7u8; 32],
+            slot: 1_234,
+            payer: [6u8; 32],
+        };
+        let bytes = borsh::to_vec(&original).expect("serialize");
+        assert_eq!(bytes.len(), EXPECTED_PAYLOAD_LEN);
+        let decoded = ProofSettled::try_from_slice(&bytes).expect("deserialize");
+        assert_eq!(decoded, original);
+    }
+}

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -1,7 +1,7 @@
 //! Off-chain mirrors of Anchor events emitted by the `zksettle` program.
 //!
-//! Anchor events are Borsh-encoded inside a program log entry. Indexers
-//! (issue #22) decode the event payload into these structs using Borsh.
+//! Anchor events are Borsh-encoded in program log entries. Indexers decode
+//! those payloads into these structs.
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
@@ -16,18 +16,30 @@ pub struct ProofSettled {
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,
     pub merkle_root: Hash32,
+    pub mint: Pubkey,
+    pub recipient: Pubkey,
+    pub amount: u64,
+    pub epoch: u64,
     pub slot: u64,
     pub payer: Pubkey,
+}
+
+/// Mirror of the `AttestationChecked` event emitted by `check_attestation`.
+/// Field order matches the on-chain event in
+/// `backend/programs/zksettle/src/instructions/check_attestation.rs`.
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AttestationChecked {
+    pub issuer: Pubkey,
+    pub nullifier_hash: Hash32,
+    pub slot: u64,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Serialized size of the Anchor event payload (no discriminator here —
-    /// Anchor events are prefixed by an 8-byte discriminator in the program
-    /// log entry, but the payload itself is just the Borsh-encoded fields).
-    const EXPECTED_PAYLOAD_LEN: usize = 32 + 32 + 32 + 8 + 32;
+    const PROOF_SETTLED_PAYLOAD_LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
+    const ATTESTATION_CHECKED_PAYLOAD_LEN: usize = 32 + 32 + 8;
 
     #[test]
     fn proof_settled_borsh_roundtrip() {
@@ -35,12 +47,29 @@ mod tests {
             issuer: [9u8; 32],
             nullifier_hash: [8u8; 32],
             merkle_root: [7u8; 32],
+            mint: [5u8; 32],
+            recipient: [4u8; 32],
+            amount: 2_500_000,
+            epoch: 7,
             slot: 1_234,
             payer: [6u8; 32],
         };
         let bytes = borsh::to_vec(&original).expect("serialize");
-        assert_eq!(bytes.len(), EXPECTED_PAYLOAD_LEN);
+        assert_eq!(bytes.len(), PROOF_SETTLED_PAYLOAD_LEN);
         let decoded = ProofSettled::try_from_slice(&bytes).expect("deserialize");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn attestation_checked_borsh_roundtrip() {
+        let original = AttestationChecked {
+            issuer: [1u8; 32],
+            nullifier_hash: [2u8; 32],
+            slot: 999,
+        };
+        let bytes = borsh::to_vec(&original).expect("serialize");
+        assert_eq!(bytes.len(), ATTESTATION_CHECKED_PAYLOAD_LEN);
+        let decoded = AttestationChecked::try_from_slice(&bytes).expect("deserialize");
         assert_eq!(decoded, original);
     }
 }

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Hash32, Pubkey};
 
+/// Event payload emitted on-chain (#[event]). Same fields as CompressedAttestation
+/// but represents a logged event, not persisted account state.
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct ProofSettled {
     pub issuer: Pubkey,

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -1,0 +1,23 @@
+//! Off-chain mirrors of Anchor events emitted by the `zksettle` program.
+//!
+//! Anchor events are Borsh-encoded inside a program log entry. Indexers
+//! (issue #22) decode the event payload into these structs using Borsh.
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+use crate::{Hash32, Pubkey};
+
+/// Mirror of the `ProofSettled` event emitted by `verify_proof` on a
+/// successful proof verification. Field order matches the on-chain event in
+/// `backend/programs/zksettle/src/instructions/verify_proof.rs`.
+#[derive(
+    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct ProofSettled {
+    pub issuer: Pubkey,
+    pub nullifier_hash: Hash32,
+    pub merkle_root: Hash32,
+    pub slot: u64,
+    pub payer: Pubkey,
+}

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -11,9 +11,7 @@ use crate::{Hash32, Pubkey};
 /// Mirror of the `ProofSettled` event emitted by `verify_proof` on a
 /// successful proof verification. Field order matches the on-chain event in
 /// `backend/programs/zksettle/src/instructions/verify_proof.rs`.
-#[derive(
-    Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct ProofSettled {
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -1,16 +1,8 @@
-//! Off-chain mirrors of Anchor events emitted by the `zksettle` program.
-//!
-//! Anchor events are Borsh-encoded in program log entries. Indexers decode
-//! those payloads into these structs.
-
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::{Hash32, Pubkey};
 
-/// Mirror of the `ProofSettled` event emitted by `verify_proof` on a
-/// successful proof verification. Field order matches the on-chain event in
-/// `backend/programs/zksettle/src/instructions/verify_proof.rs`.
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct ProofSettled {
     pub issuer: Pubkey,
@@ -24,9 +16,6 @@ pub struct ProofSettled {
     pub payer: Pubkey,
 }
 
-/// Mirror of the `AttestationChecked` event emitted by `check_attestation`.
-/// Field order matches the on-chain event in
-/// `backend/programs/zksettle/src/instructions/check_attestation.rs`.
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct AttestationChecked {
     pub issuer: Pubkey,

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -27,3 +27,27 @@ pub const EPOCH_IDX: usize = 4;
 pub const RECIPIENT_LO_IDX: usize = 5;
 pub const RECIPIENT_HI_IDX: usize = 6;
 pub const AMOUNT_IDX: usize = 7;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_constants_match_on_chain() {
+        assert_eq!(ISSUER_SEED, b"issuer");
+        assert_eq!(NULLIFIER_SEED, b"nullifier");
+        assert_eq!(ATTESTATION_SEED, b"attestation");
+    }
+
+    #[test]
+    fn pubinput_indices_match_on_chain() {
+        assert_eq!(MERKLE_ROOT_IDX, 0);
+        assert_eq!(NULLIFIER_IDX, 1);
+        assert_eq!(MINT_LO_IDX, 2);
+        assert_eq!(MINT_HI_IDX, 3);
+        assert_eq!(EPOCH_IDX, 4);
+        assert_eq!(RECIPIENT_LO_IDX, 5);
+        assert_eq!(RECIPIENT_HI_IDX, 6);
+        assert_eq!(AMOUNT_IDX, 7);
+    }
+}

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -16,10 +16,10 @@ pub mod error;
 pub mod events;
 pub mod policy;
 
-pub use accounts::{Attestation, Issuer, Nullifier};
+pub use accounts::{CompressedAttestation, CompressedNullifier, Issuer};
 pub use credential::{Credential, CredentialCommitment};
 pub use error::ZksettleError;
-pub use events::ProofSettled;
+pub use events::{AttestationChecked, ProofSettled};
 pub use policy::Policy;
 
 /// A Solana public key — 32 raw bytes. Matches the on-chain representation.
@@ -28,17 +28,22 @@ pub type Pubkey = [u8; 32];
 /// A 32-byte hash output (Poseidon, Merkle root, nullifier hash, etc.).
 pub type Hash32 = [u8; 32];
 
-/// PDA seed for issuer accounts. Must match `state::ISSUER_SEED` in the Anchor program.
+/// PDA seed for issuer accounts. Must match `state::seeds::ISSUER_SEED`.
 pub const ISSUER_SEED: &[u8] = b"issuer";
 
-/// PDA seed for nullifier marker accounts. Must match `state::NULLIFIER_SEED`.
+/// PDA seed for nullifier marker accounts. Must match `state::seeds::NULLIFIER_SEED`.
 pub const NULLIFIER_SEED: &[u8] = b"nullifier";
 
-/// PDA seed for attestation accounts. Must match `state::ATTESTATION_SEED`.
+/// PDA seed for attestation accounts. Must match `state::seeds::ATTESTATION_SEED`.
 pub const ATTESTATION_SEED: &[u8] = b"attestation";
 
-/// Index of the Merkle root inside the Groth16 public-input vector.
+// Groth16 public-input indices. Order and count must match
+// `backend/programs/zksettle/src/state/pubinputs.rs`.
 pub const MERKLE_ROOT_IDX: usize = 0;
-
-/// Index of the nullifier hash inside the Groth16 public-input vector.
 pub const NULLIFIER_IDX: usize = 1;
+pub const MINT_LO_IDX: usize = 2;
+pub const MINT_HI_IDX: usize = 3;
+pub const EPOCH_IDX: usize = 4;
+pub const RECIPIENT_LO_IDX: usize = 5;
+pub const RECIPIENT_HI_IDX: usize = 6;
+pub const AMOUNT_IDX: usize = 7;

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -1,0 +1,32 @@
+//! Shared type definitions for ZKSettle.
+//!
+//! This crate is the single source of truth for data shapes that cross the
+//! on-chain / off-chain boundary: account layouts, event payloads, credential
+//! schemas, and policy types. Downstream crates (`issuer-service`, `indexer`,
+//! `api-gateway`, `sanctions-updater`) and the TypeScript SDK depend on the
+//! structures here so they cannot drift from the Anchor program.
+//!
+//! The crate intentionally carries no logic and no heavy Solana dependencies.
+//! `Pubkey` is re-exported as a raw 32-byte alias so consumers pick their own
+//! Solana SDK version; convert at the call site via `Pubkey::new_from_array`.
+
+/// A Solana public key — 32 raw bytes. Matches the on-chain representation.
+pub type Pubkey = [u8; 32];
+
+/// A 32-byte hash output (Poseidon, Merkle root, nullifier hash, etc.).
+pub type Hash32 = [u8; 32];
+
+/// PDA seed for issuer accounts. Must match `state::ISSUER_SEED` in the Anchor program.
+pub const ISSUER_SEED: &[u8] = b"issuer";
+
+/// PDA seed for nullifier marker accounts. Must match `state::NULLIFIER_SEED`.
+pub const NULLIFIER_SEED: &[u8] = b"nullifier";
+
+/// PDA seed for attestation accounts. Must match `state::ATTESTATION_SEED`.
+pub const ATTESTATION_SEED: &[u8] = b"attestation";
+
+/// Index of the Merkle root inside the Groth16 public-input vector.
+pub const MERKLE_ROOT_IDX: usize = 0;
+
+/// Index of the nullifier hash inside the Groth16 public-input vector.
+pub const NULLIFIER_IDX: usize = 1;

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -11,8 +11,16 @@
 //! Solana SDK version; convert at the call site via `Pubkey::new_from_array`.
 
 pub mod accounts;
+pub mod credential;
+pub mod error;
+pub mod events;
+pub mod policy;
 
 pub use accounts::{Attestation, Issuer, Nullifier};
+pub use credential::{Credential, CredentialCommitment};
+pub use error::ZksettleError;
+pub use events::ProofSettled;
+pub use policy::Policy;
 
 /// A Solana public key — 32 raw bytes. Matches the on-chain representation.
 pub type Pubkey = [u8; 32];

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -1,14 +1,4 @@
-//! Shared type definitions for ZKSettle.
-//!
-//! This crate is the single source of truth for data shapes that cross the
-//! on-chain / off-chain boundary: account layouts, event payloads, credential
-//! schemas, and policy types. Downstream crates (`issuer-service`, `indexer`,
-//! `api-gateway`, `sanctions-updater`) and the TypeScript SDK depend on the
-//! structures here so they cannot drift from the Anchor program.
-//!
-//! The crate intentionally carries no logic and no heavy Solana dependencies.
-//! `Pubkey` is re-exported as a raw 32-byte alias so consumers pick their own
-//! Solana SDK version; convert at the call site via `Pubkey::new_from_array`.
+//! Shared types for ZKSettle on-chain / off-chain interop.
 
 pub mod accounts;
 pub mod credential;
@@ -22,23 +12,15 @@ pub use error::ZksettleError;
 pub use events::{AttestationChecked, ProofSettled};
 pub use policy::Policy;
 
-/// A Solana public key — 32 raw bytes. Matches the on-chain representation.
 pub type Pubkey = [u8; 32];
-
-/// A 32-byte hash output (Poseidon, Merkle root, nullifier hash, etc.).
 pub type Hash32 = [u8; 32];
 
-/// PDA seed for issuer accounts. Must match `state::seeds::ISSUER_SEED`.
+// Must match `programs/zksettle/src/state/seeds.rs`.
 pub const ISSUER_SEED: &[u8] = b"issuer";
-
-/// PDA seed for nullifier marker accounts. Must match `state::seeds::NULLIFIER_SEED`.
 pub const NULLIFIER_SEED: &[u8] = b"nullifier";
-
-/// PDA seed for attestation accounts. Must match `state::seeds::ATTESTATION_SEED`.
 pub const ATTESTATION_SEED: &[u8] = b"attestation";
 
-// Groth16 public-input indices. Order and count must match
-// `backend/programs/zksettle/src/state/pubinputs.rs`.
+// Must match `programs/zksettle/src/state/pubinputs.rs`.
 pub const MERKLE_ROOT_IDX: usize = 0;
 pub const NULLIFIER_IDX: usize = 1;
 pub const MINT_LO_IDX: usize = 2;

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -10,6 +10,10 @@
 //! `Pubkey` is re-exported as a raw 32-byte alias so consumers pick their own
 //! Solana SDK version; convert at the call site via `Pubkey::new_from_array`.
 
+pub mod accounts;
+
+pub use accounts::{Attestation, Issuer, Nullifier};
+
 /// A Solana public key — 32 raw bytes. Matches the on-chain representation.
 pub type Pubkey = [u8; 32];
 

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -1,5 +1,3 @@
-//! Shared types for ZKSettle on-chain / off-chain interop.
-
 pub mod accounts;
 pub mod credential;
 pub mod error;

--- a/backend/crates/zksettle-types/src/policy.rs
+++ b/backend/crates/zksettle-types/src/policy.rs
@@ -10,3 +10,14 @@ pub struct Policy {
     pub max_transfer_amount: Option<u64>,
     pub min_transfer_amount: Option<u64>,
 }
+
+impl Policy {
+    pub fn new(issuer: Pubkey, allowed_jurisdictions: Vec<String>) -> Self {
+        Self {
+            issuer,
+            allowed_jurisdictions,
+            max_transfer_amount: None,
+            min_transfer_amount: None,
+        }
+    }
+}

--- a/backend/crates/zksettle-types/src/policy.rs
+++ b/backend/crates/zksettle-types/src/policy.rs
@@ -1,30 +1,11 @@
-//! Compliance policy attached to each credential.
-//!
-//! Kept deliberately small for the hackathon MVP (PRD §9 lists multi-
-//! jurisdiction and rich policy engines as out-of-scope). ADR-014 calls for
-//! a fuller policy engine post-hackathon; keep new fields additive so
-//! existing JSON payloads keep deserializing.
-
 use serde::{Deserialize, Serialize};
 
 use crate::Pubkey;
 
-/// Rules a transfer must satisfy for a credential's attestation to be
-/// accepted by downstream programs.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Policy {
-    /// Issuer that owns this policy.
     pub issuer: Pubkey,
-
-    /// ISO-3166 alpha-2 country codes the issuer accepts. An empty list
-    /// means "no jurisdiction restriction."
     pub allowed_jurisdictions: Vec<String>,
-
-    /// Maximum transfer amount in the smallest token unit (e.g. lamports for
-    /// a 9-decimal mint). `None` means no ceiling.
     pub max_transfer_amount: Option<u64>,
-
-    /// Minimum transfer amount in the smallest token unit. `None` means
-    /// no floor.
     pub min_transfer_amount: Option<u64>,
 }

--- a/backend/crates/zksettle-types/src/policy.rs
+++ b/backend/crates/zksettle-types/src/policy.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::Pubkey;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Policy {
     pub issuer: Pubkey,
     pub allowed_jurisdictions: Vec<String>,

--- a/backend/crates/zksettle-types/src/policy.rs
+++ b/backend/crates/zksettle-types/src/policy.rs
@@ -1,0 +1,30 @@
+//! Compliance policy attached to each credential.
+//!
+//! Kept deliberately small for the hackathon MVP (PRD §9 lists multi-
+//! jurisdiction and rich policy engines as out-of-scope). ADR-014 calls for
+//! a fuller policy engine post-hackathon; keep new fields additive so
+//! existing JSON payloads keep deserializing.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Pubkey;
+
+/// Rules a transfer must satisfy for a credential's attestation to be
+/// accepted by downstream programs.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Policy {
+    /// Issuer that owns this policy.
+    pub issuer: Pubkey,
+
+    /// ISO-3166 alpha-2 country codes the issuer accepts. An empty list
+    /// means "no jurisdiction restriction."
+    pub allowed_jurisdictions: Vec<String>,
+
+    /// Maximum transfer amount in the smallest token unit (e.g. lamports for
+    /// a 9-decimal mint). `None` means no ceiling.
+    pub max_transfer_amount: Option<u64>,
+
+    /// Minimum transfer amount in the smallest token unit. `None` means
+    /// no floor.
+    pub min_transfer_amount: Option<u64>,
+}


### PR DESCRIPTION
## Overview

Scaffolds `backend/crates/zksettle-types/` — the first of six off-chain Rust crates promised by the README layout and the last remaining prerequisite before the issuer-service, indexer, api-gateway, sanctions-updater, and TypeScript SDK can begin work in parallel.

The crate is intentionally a **types-only library**: no async, no I/O, no Solana runtime dependencies. It exists so every downstream component agrees on the same byte layouts and JSON shapes and cannot drift from the Anchor program.

Closes #19.

## Why

Per `IMPLEMENTATION_STATUS.md` §3.2, all six off-chain crates promised by the README layout are currently missing, and several issues (#21, #22, #23, #24) explicitly list `zksettle-types` as a dependency. Without one shared crate, each service would redefine `Issuer`, `Attestation`, `ProofSettled`, and the credential/policy shapes on its own — they would inevitably drift, Borsh deserialization would silently produce garbage, and nothing would interoperate.

## What lands

### New crate `backend/crates/zksettle-types`

- **`accounts`** — off-chain mirrors of `Issuer`, `Nullifier`, and `Attestation`. Field order, types, and `LEN` constants match the on-chain layouts in `backend/programs/zksettle/src/state/` so services can decode raw account data fetched from the RPC.
- **`credential`** — `Credential` schema (wallet, jurisdiction, expiry, sanctions_clear, schema_version per ADR-010). Serde-only; credentials never land on-chain in raw form, only their Poseidon commitment does.
- **`policy`** — hackathon-scope `Policy` (allowed jurisdictions, min/max amount). Additive shape so the ADR-014 policy engine can extend it later without breaking existing JSON.
- **`events`** — `ProofSettled` mirror for indexers (issue #22) to decode from Anchor program logs.
- **`error`** — `ZksettleError` enum mirroring the seven on-chain error codes plus off-chain-only variants (credential expiry, jurisdiction denied, serialization).

### Design choice: mirror, don't re-export

The crate mirrors the on-chain structs rather than re-exporting from the Anchor program. Re-exporting would transitively pull `anchor-lang` + the full Solana runtime into every off-chain service. Mirroring keeps the dependency footprint tiny (`borsh`, `serde`, `thiserror`) and lets each consumer pick its own Solana SDK version. The drift risk is mitigated by byte-layout guard tests (see below).

### Workspace wiring

`backend/Cargo.toml` now includes `crates/*` in workspace members, so `cargo check --workspace` compiles the new crate alongside the Anchor program.

### Pubkey representation

`Pubkey = [u8; 32]` type alias. A Solana public key *is* 32 raw bytes; keeping the raw form means this crate stays free of `solana-program` / `solana-sdk` version coupling. Consumers convert at their boundary.

## Tests

Six unit tests land alongside the types:

- `issuer_len_matches_on_chain` — pins `Issuer::LEN == 73`
- `nullifier_len_matches_on_chain` — pins `Nullifier::LEN == 0`
- `attestation_len_matches_on_chain` — pins `Attestation::LEN == 137`
- `issuer_borsh_roundtrip_preserves_layout` — round-trip + size check
- `attestation_borsh_roundtrip_preserves_layout` — round-trip + size check
- `proof_settled_borsh_roundtrip` — event payload round-trip

These are the **drift tripwire**. If `backend/programs/zksettle/src/state/*` ever changes without updating this mirror, the tests fail in CI and force both sides to stay in sync.

## Validation performed

Executed locally from `backend/`:

```
cargo check -p zksettle-types         # passes in 0.78s after first build
cargo test  -p zksettle-types         # 6 passed, 0 failed
cargo clippy -p zksettle-types -- -D warnings
cargo fmt   -p zksettle-types -- --check
cargo check --workspace               # anchor program + new crate compile together
```

## Commit structure

Five atomic commits so review can be done in passes:

1. `chore: Scaffold zksettle-types crate and register in workspace`
2. `feature: Mirror on-chain account layouts in zksettle-types`
3. `feature: Add credential, policy, event, and error types to zksettle-types`
4. `test: Add byte-layout guards and borsh roundtrip tests`
5. `style: Apply rustfmt to zksettle-types`

## Out of scope

- Poseidon hashing, Merkle tree, SMT utilities → covered by issue #20 (`zksettle-crypto`).
- Re-exporting/aligning with the on-chain `state` module via a `serde`-only wrapper in the Anchor crate → defer until a concrete drift incident motivates it.
- Pubkey helper constructors or conversion traits — consumers convert on their side.

## References

- Closes #19
- `IMPLEMENTATION_STATUS.md` §3.2
- ADR-010 (credential schema versioning)
- ADR-013 (jurisdiction as Merkle root)
- ADR-014 (policy engine, future work)
- Unblocks: #20, #21, #22, #23, #24, SDK scaffolding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new shared types library containing standardized data structures for ZKSettle operations
  * Added types for account management, credential handling, policy compliance, and event tracking
  * Included comprehensive error definitions for proper error reporting across the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->