### PR TITLE
Scaffold issuer-service crate

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -713,6 +713,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2250,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2476,6 +2529,28 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "issuer-service"
+version = "0.1.0"
+dependencies = [
+ "ark-bn254 0.5.0",
+ "ark-ff 0.5.0",
+ "axum",
+ "borsh 1.6.1",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "solana-rpc-client",
+ "solana-sdk",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "zksettle-crypto",
+ "zksettle-types",
 ]
 
 [[package]]
@@ -3479,6 +3554,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3646,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4707,6 +4806,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -8764,6 +8874,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8835,6 +8946,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-opentelemetry"
 version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8853,9 +8975,16 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/backend/crates/issuer-service/Cargo.toml
+++ b/backend/crates/issuer-service/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "issuer-service"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "issuer-service"
+path = "src/main.rs"
+
+[dependencies]
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }
+solana-sdk = "2.3"
+solana-rpc-client = "2.3"
+ark-bn254 = "0.5"
+ark-ff = "0.5"
+zksettle-crypto = { path = "../zksettle-crypto" }
+zksettle-types = { path = "../zksettle-types" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+hex = "0.4"
+thiserror = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+borsh = "1"
+sha2 = "0.10"

--- a/backend/crates/issuer-service/src/chain.rs
+++ b/backend/crates/issuer-service/src/chain.rs
@@ -1,0 +1,117 @@
+use borsh::BorshSerialize;
+use solana_sdk::instruction::{AccountMeta, Instruction};
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer;
+use solana_sdk::transaction::Transaction;
+use solana_rpc_client::rpc_client::RpcClient;
+
+use crate::error::ServiceError;
+
+const ISSUER_SEED: &[u8] = b"issuer";
+
+fn issuer_pda(authority: &Pubkey, program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[ISSUER_SEED, authority.as_ref()], program_id)
+}
+
+#[derive(BorshSerialize)]
+struct RootArgs {
+    merkle_root: [u8; 32],
+    sanctions_root: [u8; 32],
+    jurisdiction_root: [u8; 32],
+}
+
+// Anchor discriminators: sha256("global:<fn_name>")[..8]
+fn discriminator(name: &str) -> [u8; 8] {
+    use std::io::Write;
+    let input = format!("global:{name}");
+    let hash = <sha2::Sha256 as sha2::Digest>::digest(input.as_bytes());
+    let mut disc = [0u8; 8];
+    (&mut disc[..]).write_all(&hash[..8]).unwrap();
+    disc
+}
+
+fn build_register_ix(
+    authority: &Pubkey,
+    program_id: &Pubkey,
+    roots: &RootArgs,
+) -> Instruction {
+    let (pda, _) = issuer_pda(authority, program_id);
+    let disc = discriminator("register_issuer");
+    let mut data = disc.to_vec();
+    roots.serialize(&mut data).unwrap();
+
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*authority, true),
+            AccountMeta::new(pda, false),
+            #[allow(deprecated)]
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ],
+        data,
+    }
+}
+
+fn build_update_ix(
+    authority: &Pubkey,
+    program_id: &Pubkey,
+    roots: &RootArgs,
+) -> Instruction {
+    let (pda, _) = issuer_pda(authority, program_id);
+    let disc = discriminator("update_issuer_root");
+    let mut data = disc.to_vec();
+    roots.serialize(&mut data).unwrap();
+
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(*authority, true),
+            AccountMeta::new(pda, false),
+        ],
+        data,
+    }
+}
+
+pub fn register_issuer(
+    rpc: &RpcClient,
+    keypair: &Keypair,
+    program_id: &Pubkey,
+    merkle_root: [u8; 32],
+    sanctions_root: [u8; 32],
+    jurisdiction_root: [u8; 32],
+) -> Result<u64, ServiceError> {
+    let roots = RootArgs { merkle_root, sanctions_root, jurisdiction_root };
+    let ix = build_register_ix(&keypair.pubkey(), program_id, &roots);
+    send_tx(rpc, keypair, ix)
+}
+
+pub fn update_issuer_root(
+    rpc: &RpcClient,
+    keypair: &Keypair,
+    program_id: &Pubkey,
+    merkle_root: [u8; 32],
+    sanctions_root: [u8; 32],
+    jurisdiction_root: [u8; 32],
+) -> Result<u64, ServiceError> {
+    let roots = RootArgs { merkle_root, sanctions_root, jurisdiction_root };
+    let ix = build_update_ix(&keypair.pubkey(), program_id, &roots);
+    send_tx(rpc, keypair, ix)
+}
+
+fn send_tx(
+    rpc: &RpcClient,
+    keypair: &Keypair,
+    ix: Instruction,
+) -> Result<u64, ServiceError> {
+    let recent = rpc
+        .get_latest_blockhash()
+        .map_err(|e| ServiceError::Chain(e.to_string()))?;
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&keypair.pubkey()), &[keypair], recent);
+    let sig = rpc
+        .send_and_confirm_transaction(&tx)
+        .map_err(|e| ServiceError::Chain(e.to_string()))?;
+    tracing::info!(%sig, "tx confirmed");
+    let slot = rpc.get_slot().map_err(|e| ServiceError::Chain(e.to_string()))?;
+    Ok(slot)
+}

--- a/backend/crates/issuer-service/src/config.rs
+++ b/backend/crates/issuer-service/src/config.rs
@@ -1,0 +1,29 @@
+use std::net::SocketAddr;
+
+pub struct Config {
+    pub rpc_url: String,
+    pub keypair_path: String,
+    pub program_id: String,
+    pub rotation_interval_secs: u64,
+    pub listen_addr: SocketAddr,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self {
+            rpc_url: env_or("RPC_URL", "http://127.0.0.1:8899"),
+            keypair_path: env_or("KEYPAIR_PATH", "~/.config/solana/id.json"),
+            program_id: env_or("PROGRAM_ID", "zkSet11ezkSet11ezkSet11ezkSet11ezkSet11ezkS"),
+            rotation_interval_secs: env_or("ROTATION_INTERVAL_SECS", "43200")
+                .parse()
+                .expect("ROTATION_INTERVAL_SECS must be u64"),
+            listen_addr: env_or("LISTEN_ADDR", "0.0.0.0:3000")
+                .parse()
+                .expect("LISTEN_ADDR must be valid socket addr"),
+        }
+    }
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}

--- a/backend/crates/issuer-service/src/convert.rs
+++ b/backend/crates/issuer-service/src/convert.rs
@@ -1,0 +1,83 @@
+use ark_bn254::Fr;
+use ark_ff::{BigInteger, PrimeField};
+
+use crate::error::ServiceError;
+
+pub fn fr_to_bytes_be(f: &Fr) -> [u8; 32] {
+    let repr = f.into_bigint();
+    let le = repr.to_bytes_le();
+    let mut be = [0u8; 32];
+    for (i, b) in le.iter().enumerate() {
+        be[31 - i] = *b;
+    }
+    be
+}
+
+pub fn bytes_be_to_fr(bytes: &[u8; 32]) -> Fr {
+    let mut le = [0u8; 32];
+    for (i, b) in bytes.iter().enumerate() {
+        le[31 - i] = *b;
+    }
+    Fr::from_le_bytes_mod_order(&le)
+}
+
+pub fn wallet_to_fr(hex_str: &str) -> Result<Fr, ServiceError> {
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = hex::decode(hex_str).map_err(|e| ServiceError::InvalidHex(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(ServiceError::InvalidHex(format!(
+            "expected 32 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(bytes_be_to_fr(&arr))
+}
+
+pub fn wallet_hex_to_bytes(hex_str: &str) -> Result<[u8; 32], ServiceError> {
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = hex::decode(hex_str).map_err(|e| ServiceError::InvalidHex(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(ServiceError::InvalidHex(format!(
+            "expected 32 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(arr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_ff::AdditiveGroup;
+
+    #[test]
+    fn roundtrip_fr_bytes() {
+        let original = Fr::from(42u64);
+        let bytes = fr_to_bytes_be(&original);
+        let recovered = bytes_be_to_fr(&bytes);
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn zero_roundtrip() {
+        let bytes = fr_to_bytes_be(&Fr::ZERO);
+        assert_eq!(bytes_be_to_fr(&bytes), Fr::ZERO);
+    }
+
+    #[test]
+    fn wallet_to_fr_with_prefix() {
+        let hex = format!("0x{}", hex::encode([1u8; 32]));
+        let fr = wallet_to_fr(&hex).unwrap();
+        let back = fr_to_bytes_be(&fr);
+        assert_eq!(back, [1u8; 32]);
+    }
+
+    #[test]
+    fn wallet_to_fr_rejects_short() {
+        assert!(wallet_to_fr("0xabcd").is_err());
+    }
+}

--- a/backend/crates/issuer-service/src/error.rs
+++ b/backend/crates/issuer-service/src/error.rs
@@ -1,0 +1,36 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ServiceError {
+    #[error("wallet not found")]
+    WalletNotFound,
+
+    #[error("wallet already registered")]
+    DuplicateWallet,
+
+    #[error("invalid hex: {0}")]
+    InvalidHex(String),
+
+    #[error("tree error: {0}")]
+    Tree(#[from] zksettle_crypto::error::CryptoError),
+
+    #[error("chain error: {0}")]
+    Chain(String),
+}
+
+impl IntoResponse for ServiceError {
+    fn into_response(self) -> Response {
+        let (status, msg) = match &self {
+            ServiceError::WalletNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            ServiceError::DuplicateWallet => (StatusCode::CONFLICT, self.to_string()),
+            ServiceError::InvalidHex(_) => (StatusCode::BAD_REQUEST, self.to_string()),
+            ServiceError::Tree(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            ServiceError::Chain(_) => (StatusCode::BAD_GATEWAY, self.to_string()),
+        };
+        let body = axum::Json(json!({ "error": msg }));
+        (status, body).into_response()
+    }
+}

--- a/backend/crates/issuer-service/src/handlers/add_wallet.rs
+++ b/backend/crates/issuer-service/src/handlers/add_wallet.rs
@@ -1,0 +1,33 @@
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::convert::wallet_to_fr;
+use crate::error::ServiceError;
+use crate::state::SharedState;
+
+#[derive(Deserialize)]
+pub struct AddWalletRequest {
+    pub wallet: String,
+}
+
+#[derive(Serialize)]
+pub struct AddWalletResponse {
+    pub wallet: String,
+    pub message: &'static str,
+}
+
+pub async fn handler(
+    State(state): State<SharedState>,
+    Json(req): Json<AddWalletRequest>,
+) -> Result<Json<AddWalletResponse>, ServiceError> {
+    let wallet_fr = wallet_to_fr(&req.wallet)?;
+
+    let mut st = state.write().await;
+    st.membership_tree.insert(wallet_fr);
+
+    Ok(Json(AddWalletResponse {
+        wallet: req.wallet,
+        message: "added to membership tree",
+    }))
+}

--- a/backend/crates/issuer-service/src/handlers/get_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/get_credential.rs
@@ -1,0 +1,19 @@
+use axum::extract::{Path, State};
+use axum::Json;
+
+use crate::convert::wallet_hex_to_bytes;
+use crate::error::ServiceError;
+use crate::state::{CredentialRecord, SharedState};
+
+pub async fn handler(
+    State(state): State<SharedState>,
+    Path(wallet): Path<String>,
+) -> Result<Json<CredentialRecord>, ServiceError> {
+    let wallet_bytes = wallet_hex_to_bytes(&wallet)?;
+    let st = state.read().await;
+    st.credentials
+        .get(&wallet_bytes)
+        .cloned()
+        .map(Json)
+        .ok_or(ServiceError::WalletNotFound)
+}

--- a/backend/crates/issuer-service/src/handlers/get_proof.rs
+++ b/backend/crates/issuer-service/src/handlers/get_proof.rs
@@ -1,0 +1,40 @@
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::Serialize;
+
+use crate::convert::{fr_to_bytes_be, wallet_hex_to_bytes};
+use crate::error::ServiceError;
+use crate::state::SharedState;
+
+#[derive(Serialize)]
+pub struct MembershipProofResponse {
+    pub wallet: String,
+    pub leaf_index: usize,
+    pub path: Vec<String>,
+    pub path_indices: Vec<u8>,
+    pub root: String,
+}
+
+pub async fn handler(
+    State(state): State<SharedState>,
+    Path(wallet): Path<String>,
+) -> Result<Json<MembershipProofResponse>, ServiceError> {
+    let wallet_bytes = wallet_hex_to_bytes(&wallet)?;
+    let st = state.read().await;
+
+    let cred = st
+        .credentials
+        .get(&wallet_bytes)
+        .ok_or(ServiceError::WalletNotFound)?;
+
+    let proof = st.membership_tree.proof(cred.leaf_index)?;
+    let root = st.membership_tree.root();
+
+    Ok(Json(MembershipProofResponse {
+        wallet,
+        leaf_index: cred.leaf_index,
+        path: proof.path.iter().map(|f| hex::encode(fr_to_bytes_be(f))).collect(),
+        path_indices: proof.path_indices.to_vec(),
+        root: hex::encode(fr_to_bytes_be(&root)),
+    }))
+}

--- a/backend/crates/issuer-service/src/handlers/get_roots.rs
+++ b/backend/crates/issuer-service/src/handlers/get_roots.rs
@@ -1,0 +1,27 @@
+use axum::extract::State;
+use axum::Json;
+use serde::Serialize;
+
+use crate::state::SharedState;
+
+#[derive(Serialize)]
+pub struct RootsResponse {
+    pub membership_root: String,
+    pub sanctions_root: String,
+    pub jurisdiction_root: String,
+    pub last_publish_slot: u64,
+    pub wallet_count: usize,
+}
+
+pub async fn handler(State(state): State<SharedState>) -> Json<RootsResponse> {
+    let st = state.read().await;
+    let (mr, sr, jr) = st.roots_as_bytes();
+
+    Json(RootsResponse {
+        membership_root: hex::encode(mr),
+        sanctions_root: hex::encode(sr),
+        jurisdiction_root: hex::encode(jr),
+        last_publish_slot: st.last_publish_slot,
+        wallet_count: st.wallet_count(),
+    })
+}

--- a/backend/crates/issuer-service/src/handlers/get_sanctions_proof.rs
+++ b/backend/crates/issuer-service/src/handlers/get_sanctions_proof.rs
@@ -1,0 +1,35 @@
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::Serialize;
+
+use crate::convert::{fr_to_bytes_be, wallet_to_fr};
+use crate::error::ServiceError;
+use crate::state::SharedState;
+
+#[derive(Serialize)]
+pub struct SanctionsProofResponse {
+    pub wallet: String,
+    pub path: Vec<String>,
+    pub path_indices: Vec<u8>,
+    pub leaf_value: String,
+    pub root: String,
+}
+
+pub async fn handler(
+    State(state): State<SharedState>,
+    Path(wallet): Path<String>,
+) -> Result<Json<SanctionsProofResponse>, ServiceError> {
+    let wallet_fr = wallet_to_fr(&wallet)?;
+    let st = state.read().await;
+
+    let proof = st.sanctions_tree.exclusion_proof(wallet_fr)?;
+    let root = st.sanctions_tree.root();
+
+    Ok(Json(SanctionsProofResponse {
+        wallet,
+        path: proof.path.iter().map(|f| hex::encode(fr_to_bytes_be(f))).collect(),
+        path_indices: proof.path_indices.to_vec(),
+        leaf_value: hex::encode(fr_to_bytes_be(&proof.leaf_value)),
+        root: hex::encode(fr_to_bytes_be(&root)),
+    }))
+}

--- a/backend/crates/issuer-service/src/handlers/health.rs
+++ b/backend/crates/issuer-service/src/handlers/health.rs
@@ -1,0 +1,11 @@
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+}
+
+pub async fn handler() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ok" })
+}

--- a/backend/crates/issuer-service/src/handlers/issue_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/issue_credential.rs
@@ -1,0 +1,61 @@
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::convert::{wallet_hex_to_bytes, wallet_to_fr};
+use crate::error::ServiceError;
+use crate::state::{CredentialRecord, SharedState};
+
+#[derive(Deserialize)]
+pub struct IssueRequest {
+    pub wallet: String,
+    #[serde(default = "default_jurisdiction")]
+    pub jurisdiction: String,
+}
+
+fn default_jurisdiction() -> String {
+    "US".to_string()
+}
+
+#[derive(Serialize)]
+pub struct IssueResponse {
+    pub wallet: String,
+    pub leaf_index: usize,
+    pub jurisdiction: String,
+}
+
+pub async fn handler(
+    State(state): State<SharedState>,
+    Json(req): Json<IssueRequest>,
+) -> Result<Json<IssueResponse>, ServiceError> {
+    let wallet_bytes = wallet_hex_to_bytes(&req.wallet)?;
+    let wallet_fr = wallet_to_fr(&req.wallet)?;
+
+    let mut st = state.write().await;
+
+    if st.credentials.contains_key(&wallet_bytes) {
+        return Err(ServiceError::DuplicateWallet);
+    }
+
+    st.membership_tree.insert(wallet_fr);
+    let leaf_index = st.credentials.len();
+
+    st.credentials.insert(
+        wallet_bytes,
+        CredentialRecord {
+            wallet: wallet_bytes,
+            leaf_index,
+            jurisdiction: req.jurisdiction.clone(),
+            issued_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        },
+    );
+
+    Ok(Json(IssueResponse {
+        wallet: req.wallet,
+        leaf_index,
+        jurisdiction: req.jurisdiction,
+    }))
+}

--- a/backend/crates/issuer-service/src/handlers/mod.rs
+++ b/backend/crates/issuer-service/src/handlers/mod.rs
@@ -1,0 +1,8 @@
+pub mod add_wallet;
+pub mod get_credential;
+pub mod get_proof;
+pub mod get_roots;
+pub mod get_sanctions_proof;
+pub mod health;
+pub mod issue_credential;
+pub mod publish;

--- a/backend/crates/issuer-service/src/handlers/publish.rs
+++ b/backend/crates/issuer-service/src/handlers/publish.rs
@@ -1,0 +1,51 @@
+use axum::extract::State;
+use axum::Json;
+use serde::Serialize;
+use solana_rpc_client::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
+
+use crate::chain;
+use crate::error::ServiceError;
+use crate::state::SharedState;
+
+#[derive(Serialize)]
+pub struct PublishResponse {
+    pub slot: u64,
+    pub registered: bool,
+}
+
+pub async fn handler(
+    State(state): State<SharedState>,
+    axum::Extension(rpc_url): axum::Extension<String>,
+    axum::Extension(keypair_bytes): axum::Extension<Vec<u8>>,
+    axum::Extension(program_id): axum::Extension<Pubkey>,
+) -> Result<Json<PublishResponse>, ServiceError> {
+    let rpc = RpcClient::new(rpc_url);
+    let keypair = Keypair::try_from(keypair_bytes.as_slice())
+        .map_err(|e| ServiceError::Chain(e.to_string()))?;
+
+    let mut st = state.write().await;
+    let (mr, sr, jr) = st.roots_as_bytes();
+
+    let result = if !st.registered {
+        chain::register_issuer(&rpc, &keypair, &program_id, mr, sr, jr)
+    } else {
+        chain::update_issuer_root(&rpc, &keypair, &program_id, mr, sr, jr)
+    };
+
+    match result {
+        Ok(slot) => {
+            let was_registered = st.registered;
+            if !was_registered {
+                st.registered = true;
+            }
+            st.last_publish_slot = slot;
+            Ok(Json(PublishResponse {
+                slot,
+                registered: !was_registered,
+            }))
+        }
+        Err(e) => Err(e),
+    }
+}

--- a/backend/crates/issuer-service/src/main.rs
+++ b/backend/crates/issuer-service/src/main.rs
@@ -1,0 +1,92 @@
+mod chain;
+mod config;
+mod convert;
+mod error;
+mod handlers;
+mod rotation;
+mod state;
+
+use std::sync::Arc;
+
+use axum::routing::{get, post};
+use axum::{Extension, Router};
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer;
+use tokio::sync::{watch, RwLock};
+
+use config::Config;
+use state::IssuerState;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "issuer_service=info".into()),
+        )
+        .init();
+
+    let cfg = Config::from_env();
+
+    let keypair_bytes = std::fs::read(&cfg.keypair_path)
+        .unwrap_or_else(|e| panic!("failed to read keypair at {}: {e}", cfg.keypair_path));
+    let keypair_json: Vec<u8> = serde_json::from_slice(&keypair_bytes)
+        .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"));
+    let keypair = Keypair::try_from(keypair_json.as_slice())
+        .unwrap_or_else(|e| panic!("invalid keypair bytes: {e}"));
+    let program_id: Pubkey = cfg
+        .program_id
+        .parse()
+        .unwrap_or_else(|e| panic!("invalid program ID '{}': {e}", cfg.program_id));
+
+    tracing::info!(
+        authority = %keypair.pubkey(),
+        %program_id,
+        rpc = %cfg.rpc_url,
+        listen = %cfg.listen_addr,
+        rotation_secs = cfg.rotation_interval_secs,
+        "starting issuer service"
+    );
+
+    let shared = Arc::new(RwLock::new(IssuerState::new()));
+    let (shutdown_tx, shutdown_rx) = watch::channel(());
+
+    let rotation_keypair = Keypair::try_from(keypair_json.as_slice()).unwrap();
+    let _rotation_handle = rotation::spawn(
+        shared.clone(),
+        cfg.rpc_url.clone(),
+        rotation_keypair,
+        program_id,
+        cfg.rotation_interval_secs,
+        shutdown_rx,
+    );
+
+    let app = Router::new()
+        .route("/health", get(handlers::health::handler))
+        .route("/credentials", post(handlers::issue_credential::handler))
+        .route("/credentials/{wallet}", get(handlers::get_credential::handler))
+        .route("/wallets", post(handlers::add_wallet::handler))
+        .route("/proofs/membership/{wallet}", get(handlers::get_proof::handler))
+        .route("/proofs/sanctions/{wallet}", get(handlers::get_sanctions_proof::handler))
+        .route("/roots", get(handlers::get_roots::handler))
+        .route("/roots/publish", post(handlers::publish::handler))
+        .layer(Extension(cfg.rpc_url))
+        .layer(Extension(keypair_json))
+        .layer(Extension(program_id))
+        .with_state(shared);
+
+    let listener = tokio::net::TcpListener::bind(cfg.listen_addr).await.unwrap();
+    tracing::info!("listening on {}", cfg.listen_addr);
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal(shutdown_tx))
+        .await
+        .unwrap();
+}
+
+async fn shutdown_signal(shutdown_tx: watch::Sender<()>) {
+    tokio::signal::ctrl_c().await.ok();
+    tracing::info!("shutdown signal received");
+    let _ = shutdown_tx.send(());
+}

--- a/backend/crates/issuer-service/src/rotation.rs
+++ b/backend/crates/issuer-service/src/rotation.rs
@@ -1,0 +1,65 @@
+use std::time::Duration;
+
+use solana_rpc_client::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
+use tokio::sync::watch;
+
+use crate::chain;
+use crate::state::SharedState;
+
+pub fn spawn(
+    state: SharedState,
+    rpc_url: String,
+    keypair: Keypair,
+    program_id: Pubkey,
+    interval_secs: u64,
+    mut shutdown: watch::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let interval = Duration::from_secs(interval_secs);
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(interval) => {}
+                _ = shutdown.changed() => {
+                    tracing::info!("rotation task shutting down");
+                    return;
+                }
+            }
+            publish_roots(&state, &rpc_url, &keypair, &program_id).await;
+        }
+    })
+}
+
+async fn publish_roots(
+    state: &SharedState,
+    rpc_url: &str,
+    keypair: &Keypair,
+    program_id: &Pubkey,
+) {
+    let rpc = RpcClient::new(rpc_url.to_string());
+    let mut st = state.write().await;
+
+    let (mr, sr, jr) = st.roots_as_bytes();
+
+    let result = if !st.registered {
+        chain::register_issuer(&rpc, keypair, program_id, mr, sr, jr)
+    } else {
+        chain::update_issuer_root(&rpc, keypair, program_id, mr, sr, jr)
+    };
+
+    match result {
+        Ok(slot) => {
+            if !st.registered {
+                st.registered = true;
+                tracing::info!(slot, "issuer registered on-chain");
+            } else {
+                tracing::info!(slot, "roots published on-chain");
+            }
+            st.last_publish_slot = slot;
+        }
+        Err(e) => {
+            tracing::error!(%e, "failed to publish roots");
+        }
+    }
+}

--- a/backend/crates/issuer-service/src/state.rs
+++ b/backend/crates/issuer-service/src/state.rs
@@ -1,0 +1,57 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use zksettle_crypto::{MerkleTree, SparseMerkleTree};
+
+use crate::convert::fr_to_bytes_be;
+
+pub type SharedState = Arc<RwLock<IssuerState>>;
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CredentialRecord {
+    pub wallet: [u8; 32],
+    pub leaf_index: usize,
+    pub jurisdiction: String,
+    pub issued_at: u64,
+}
+
+pub struct IssuerState {
+    pub membership_tree: MerkleTree,
+    pub sanctions_tree: SparseMerkleTree,
+    pub jurisdiction_tree: MerkleTree,
+    pub credentials: HashMap<[u8; 32], CredentialRecord>,
+    pub last_publish_slot: u64,
+    pub registered: bool,
+}
+
+impl IssuerState {
+    pub fn new() -> Self {
+        Self {
+            membership_tree: MerkleTree::new(),
+            sanctions_tree: SparseMerkleTree::new(),
+            jurisdiction_tree: MerkleTree::new(),
+            credentials: HashMap::new(),
+            last_publish_slot: 0,
+            registered: false,
+        }
+    }
+
+    pub fn roots_as_bytes(&self) -> ([u8; 32], [u8; 32], [u8; 32]) {
+        (
+            fr_to_bytes_be(&self.membership_tree.root()),
+            fr_to_bytes_be(&self.sanctions_tree.root()),
+            fr_to_bytes_be(&self.jurisdiction_tree.root()),
+        )
+    }
+
+    pub fn wallet_count(&self) -> usize {
+        self.credentials.len()
+    }
+}
+
+impl Default for IssuerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -7,12 +7,14 @@ use crate::{Hash32, Pubkey};
 pub struct Issuer {
     pub authority: Pubkey,
     pub merkle_root: Hash32,
+    pub sanctions_root: Hash32,
+    pub jurisdiction_root: Hash32,
     pub root_slot: u64,
     pub bump: u8,
 }
 
 impl Issuer {
-    pub const LEN: usize = 32 + 32 + 8 + 1;
+    pub const LEN: usize = 32 + 32 + 32 + 32 + 8 + 1;
 }
 
 /// Discriminator-only marker: presence at the derived compressed address
@@ -56,7 +58,7 @@ impl CompressedAttestation {
 mod tests {
     use super::*;
 
-    const ON_CHAIN_ISSUER_LEN: usize = 73;
+    const ON_CHAIN_ISSUER_LEN: usize = 137;
     #[test]
     fn issuer_len_matches_on_chain() {
         assert_eq!(Issuer::LEN, ON_CHAIN_ISSUER_LEN);
@@ -67,6 +69,8 @@ mod tests {
         let original = Issuer {
             authority: [1u8; 32],
             merkle_root: [2u8; 32],
+            sanctions_root: [3u8; 32],
+            jurisdiction_root: [4u8; 32],
             root_slot: 0x0123_4567_89ab_cdef,
             bump: 255,
         };


### PR DESCRIPTION
## Summary

- Add `issuer-service` HTTP crate (axum 0.8) with 8 endpoints: credential issuance, wallet add, membership/sanctions proofs, roots query, force-publish, and health check
- Solana chain client builds Anchor instructions manually for `register_issuer` / `update_issuer_root` (3 roots each)
- Background root rotation job (default 12h — 4× safety margin under ADR-021 48h limit)
- Fix stale `zksettle-types::Issuer`: add `sanctions_root` + `jurisdiction_root` fields, LEN 73 → 137

## Test plan

- [x] `cargo check -p issuer-service` — 0 errors, 0 warnings
- [x] `cargo test -p issuer-service` — 4 tests pass (convert roundtrips)
- [x] `cargo test -p zksettle-types` — 8 tests pass (updated Issuer layout)
- [ ] Manual: boot service → POST /credentials → GET /proofs/membership/:wallet → POST /roots/publish against local validator

## Notes

- Trees are append-only (no remove) — credential revocation deferred to #38
- In-memory state only, no persistence (hackathon scope)
- No auth, TLS, rate limiting, or metrics

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added issuer service backend with REST API for credential management.
  * Users can issue and retrieve credentials with jurisdiction support.
  * Added membership proof generation for privacy-preserving verification.
  * Added publishing of merkle roots to blockchain for on-chain validation.
  * Added health monitoring and wallet management endpoints.
  * Extended support for sanctions and jurisdiction verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->