### PR TITLE
feature: bubblegum cnft attestation

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # ZKSettle — Implementation Status
 
-**Snapshot date:** 2026-04-20
+**Snapshot date:** 2026-04-22
 **Week:** 2 of 5 (PRD §12)
 **Submission target:** 2026-05-11 (21 days remaining)
 **Branch at snapshot:** `feat/light-compression`
@@ -22,8 +22,8 @@ This document is the ground truth for what exists in the repository today versus
 | On-chain | Token-2022 Transfer Hook | **DONE (partial)** (staging + settle + execute + atomicity gate wired; fixtures pending) |
 | On-chain | `check_attestation` ix | **DONE** |
 | On-chain | Light Protocol compression (real) | **DONE** (write path + read path migrated; integration fixtures TODO) |
-| On-chain | Bubblegum cNFT attestation | **TODO** |
-| Crate | `zksettle-types` | **TODO** |
+| On-chain | Bubblegum cNFT attestation | **DONE** (`init_attestation_tree` + post-Light `MintV1` CPI; ADR-019) |
+| Crate | `zksettle-types` | **PARTIAL** (`CompressedAttestation` / `ProofSettled` aligned to on-chain; broader schema TBD) |
 | Crate | `zksettle-crypto` | **TODO** |
 | Crate | `issuer-service` | **TODO** |
 | Crate | `indexer` | **TODO** |
@@ -100,9 +100,9 @@ ADR-006 / ADR-007 call for Light Protocol ZK Compression. `verify_proof` now wri
 
 What's still missing: **integration-test coverage of the Light-CPI paths**. `tests/light_smoke.rs` only exercises the pure-Anchor instructions (`register_issuer`, `update_issuer_root`) through `LightProgramTest`. `verify_proof` / `check_attestation` need a dedicated fixture crate wiring gnark proof + witness bytes into a compressed-account setup with a running prover server. Tracked as ADR-006 follow-up.
 
-### 2.3 Attestation record = PDA, not cNFT
+### 2.3 Light compressed attestation + Bubblegum cNFT (ADR-019)
 
-`verify_proof` now writes an `Attestation` PDA and emits `ProofSettled` — RF-02 and UC-01.7 satisfied at the Anchor-account level. Bubblegum cNFT form (ADR-019) is still future work. Indexer consumes `ProofSettled` event; no CPI contract yet for consumer programs (see §3.1 `check_attestation`).
+`verify_proof` and the hook settlement path write **Light** compressed nullifier + `CompressedAttestation`, then mint a **Bubblegum** compressed NFT to `recipient` in the same instruction. The cNFT is a wallet-visible supplement (DAS); authoritative replay binding remains the Light nullifier + compressed attestation layout in `state/compressed.rs`. Indexers should treat **DAS / Merkle proofs** as the read model for the cNFT; on-chain programs that need a hard gate continue to use `check_attestation` or policy on supplied proofs.
 
 ---
 
@@ -117,7 +117,7 @@ What's still missing: **integration-test coverage of the Light-CPI paths**. `tes
 - **Token-2022 Transfer Hook** (ADR-005, RF-03). `transfer_hook`, `settle_hook`, `set_hook_payload`, and `init_extra_account_meta_list` instructions wired in `lib.rs`. Two-phase flow: client stages proof + Light args via `set_hook_payload` and Token-2022 Execute (or direct `settle_hook`) consumes the payload, runs `verify_bundle`, and mints compressed nullifier + attestation via Light CPI. Atomicity enforced via `spl_token_2022::extension::transfer_hook::TransferHookAccount.transferring` gate + source-token owner-program + base-owner checks. Known trade-offs: single outstanding payload per authority (TLV resolution only sees `amount: u64` + account keys, so PDAs cannot be nullifier-seeded); hook-path payload PDA is not closed (SPL passes `owner` as `new_readonly`, blocking `close = owner` — rent reclaim deferred, tracked as follow-up). **DONE (partial).** Remaining gap: gnark fixture + Token-2022 mint configured with the hook to lift the `#[ignore]` on `transfer_hook_smoke.rs`; hook-path CU measurement vs ADR-022 ceiling (probe feature `hook-cu-probe` exists, value unrecorded).
 - **`check_attestation(nullifier_hash)`** instruction (PRD §7 Componente 2, RF-02). Validates attestation PDA freshness within `MAX_ROOT_AGE_SLOTS`; emits `AttestationChecked` event. CPI-callable by transfer hooks / other programs. **DONE.**
 - **Light Protocol integration** (ADR-006). Write + read paths migrated; integration fixtures (gnark proof bytes + compressed-account setup + prover server) are the remaining gap — see §2.2.
-- **Bubblegum cNFT attestation** (ADR-019 / README Components row).
+- ~~**Bubblegum cNFT attestation** (ADR-019 / README Components row).~~ **DONE:** `init_attestation_tree`, registry PDA, raw Bubblegum CPI module, `verify_proof` + `settle_hook` + `transfer_hook` (TLV tail) wiring. **Remaining:** end-to-end harness with Bubblegum programs loaded + gnark fixture to assert mint in CI; `cargo test --features light-tests` integration tests are **Unix-only** dev-deps (`light-program-test` pulls OpenSSL; Windows devs use WSL or omit the feature).
 
 ### 3.2 Rust crates — `backend/crates/` (directory does not exist)
 
@@ -222,7 +222,7 @@ For each divergence between the repository and `README.md` / `zksettle_prd.md` /
 | 1 | README L123 warns circuit is `x*x == y` placeholder; actual `main.nr` is Merkle + nullifier slice (commit `ce658e2`). | **Code** | Remove the warning paragraph; keep the VK-regen note. |
 | 2 | `update_issuer_root` instruction shipped (commit `19fddce`) but not listed in PRD RF-02 or README Components row. | **Code** | Add `update_issuer_root` to PRD RF-02 and to the README Components row for the Anchor program. |
 | 3 | Nullifier and attestation use vanilla Anchor PDAs; ADR-006 / ADR-007 mandate Light Protocol ZK Compression. | **Docs (long-term)** | Keep PDA stand-ins through the hackathon demo; open a migration ticket before mainnet. Rent at 50 k proofs/month = ~100 SOL/month, not acceptable at scale. |
-| 4 | ~~`verify_proof` emits no attestation.~~ | **Resolved** | `Attestation` PDA + `ProofSettled` event implemented. Bubblegum cNFT form (ADR-019) still on roadmap. |
+| 4 | ~~`verify_proof` emits no attestation.~~ | **Resolved** | Light compressed nullifier + attestation + `ProofSettled` event. Bubblegum cNFT mint (ADR-019) implemented after Light CPI. |
 | 5 | `scripts/fixture-noir/` ships a fixture generator; not in README repo-layout tree. | **Code** | Add `scripts/fixture-noir/` to the README layout block. |
 | 6 | README §Technology stack + repo layout call the dashboard "Vite + React"; PRD §8 calls it "Next.js + TypeScript". No frontend code yet. | **Doc self-conflict** | Pick **Vite + React** (SPA dashboard, no SSR requirement, smaller bundle, faster dev loop). Update PRD §8 to match README before scaffolding. |
 | 7 | ~~`check_attestation(wallet)` absent from `lib.rs`.~~ | **Resolved** | `check_attestation(nullifier_hash)` implemented. Validates attestation freshness via `MAX_ROOT_AGE_SLOTS`, emits `AttestationChecked`. CPI-ready for transfer hooks. |

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -7460,6 +7460,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "spl-account-compression"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71829fad7a8bd049131b603bc5ae193882285694bcef8f786c5e60df19d1216a"
+dependencies = [
+ "anchor-lang",
+ "bytemuck",
+ "solana-program",
+ "solana-security-txt",
+ "spl-concurrent-merkle-tree",
+ "spl-noop",
+]
+
+[[package]]
 name = "spl-associated-token-account"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7499,6 +7513,17 @@ checksum = "d6f8349dbcbe575f354f9a533a21f272f3eb3808a49e2fdc1c34393b88ba76cb"
 dependencies = [
  "solana-instruction 2.3.3",
  "solana-pubkey 2.4.0",
+]
+
+[[package]]
+name = "spl-concurrent-merkle-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b961b37626729dc8cb8e3aedab8ad8bdeb249666280faaf012d38484dc84ae0b"
+dependencies = [
+ "bytemuck",
+ "solana-program",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7607,6 +7632,15 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error 2.2.2",
  "solana-pubkey 2.4.0",
+]
+
+[[package]]
+name = "spl-noop"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c3bc351f7543a46f6807c231fc29ef2c4912c79bd6a4fb7d038cba6836f0fd7"
+dependencies = [
+ "solana-program",
 ]
 
 [[package]]
@@ -9856,6 +9890,7 @@ dependencies = [
  "solana-instruction 2.3.3",
  "solana-keypair",
  "solana-signer 2.2.1",
+ "spl-account-compression",
  "spl-tlv-account-resolution 0.11.1",
  "spl-transfer-hook-interface 2.1.0",
  "tokio",

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -7,12 +7,14 @@ use crate::{Hash32, Pubkey};
 pub struct Issuer {
     pub authority: Pubkey,
     pub merkle_root: Hash32,
+    pub sanctions_root: Hash32,
+    pub jurisdiction_root: Hash32,
     pub root_slot: u64,
     pub bump: u8,
 }
 
 impl Issuer {
-    pub const LEN: usize = 32 + 32 + 8 + 1;
+    pub const LEN: usize = 32 + 32 + 32 + 32 + 8 + 1;
 }
 
 /// Discriminator-only marker: presence at the derived compressed address
@@ -59,7 +61,7 @@ impl CompressedAttestation {
 mod tests {
     use super::*;
 
-    const ON_CHAIN_ISSUER_LEN: usize = 73;
+    const ON_CHAIN_ISSUER_LEN: usize = 137;
     #[test]
     fn issuer_len_matches_on_chain() {
         assert_eq!(Issuer::LEN, ON_CHAIN_ISSUER_LEN);
@@ -70,6 +72,8 @@ mod tests {
         let original = Issuer {
             authority: [1u8; 32],
             merkle_root: [2u8; 32],
+            sanctions_root: [11u8; 32],
+            jurisdiction_root: [12u8; 32],
             root_slot: 0x0123_4567_89ab_cdef,
             bump: 255,
         };

--- a/backend/crates/zksettle-types/src/accounts.rs
+++ b/backend/crates/zksettle-types/src/accounts.rs
@@ -31,8 +31,8 @@ impl Issuer {
 )]
 pub struct CompressedNullifier;
 
-/// Persisted compressed account state (LightDiscriminator). Same fields as ProofSettled
-/// but represents account data, not an event payload.
+/// Persisted compressed account state (Light discriminator layout in program).
+/// Field order and sizes match `programs/zksettle/src/state/compressed.rs`.
 #[derive(
     Clone, Debug, Default, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
 )]
@@ -40,16 +40,19 @@ pub struct CompressedAttestation {
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,
     pub merkle_root: Hash32,
+    pub sanctions_root: Hash32,
+    pub jurisdiction_root: Hash32,
     pub mint: Pubkey,
     pub recipient: Pubkey,
     pub amount: u64,
     pub epoch: u64,
+    pub timestamp: u64,
     pub slot: u64,
     pub payer: Pubkey,
 }
 
 impl CompressedAttestation {
-    pub const LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
+    pub const LEN: usize = 32 * 8 + 8 * 4;
 }
 
 #[cfg(test)]
@@ -89,10 +92,13 @@ mod tests {
             issuer: [3u8; 32],
             nullifier_hash: [4u8; 32],
             merkle_root: [5u8; 32],
+            sanctions_root: [9u8; 32],
+            jurisdiction_root: [10u8; 32],
             mint: [6u8; 32],
             recipient: [7u8; 32],
             amount: 1_000_000,
             epoch: 42,
+            timestamp: 1_700_000_000,
             slot: 123_456,
             payer: [8u8; 32],
         };

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -3,19 +3,27 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Hash32, Pubkey};
 
-/// Event payload emitted on-chain (#[event]). Same fields as CompressedAttestation
-/// but represents a logged event, not persisted account state.
+/// Event payload emitted on-chain (`#[event]` in `verify_proof` / hook settlement).
+/// Field order matches the program `ProofSettled` event (same binding tuple as
+/// `CompressedAttestation` in `zksettle-types` / on-chain compressed layout).
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 pub struct ProofSettled {
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,
     pub merkle_root: Hash32,
+    pub sanctions_root: Hash32,
+    pub jurisdiction_root: Hash32,
     pub mint: Pubkey,
     pub recipient: Pubkey,
     pub amount: u64,
     pub epoch: u64,
+    pub timestamp: u64,
     pub slot: u64,
     pub payer: Pubkey,
+}
+
+impl ProofSettled {
+    pub const LEN: usize = 32 * 8 + 8 * 4;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
@@ -29,7 +37,7 @@ pub struct AttestationChecked {
 mod tests {
     use super::*;
 
-    const PROOF_SETTLED_PAYLOAD_LEN: usize = 32 + 32 + 32 + 32 + 32 + 8 + 8 + 8 + 32;
+    const PROOF_SETTLED_PAYLOAD_LEN: usize = ProofSettled::LEN;
     const ATTESTATION_CHECKED_PAYLOAD_LEN: usize = 32 + 32 + 8;
 
     #[test]
@@ -38,10 +46,13 @@ mod tests {
             issuer: [9u8; 32],
             nullifier_hash: [8u8; 32],
             merkle_root: [7u8; 32],
+            sanctions_root: [11u8; 32],
+            jurisdiction_root: [12u8; 32],
             mint: [5u8; 32],
             recipient: [4u8; 32],
             amount: 2_500_000,
             epoch: 7,
+            timestamp: 1_700_000_001,
             slot: 1_234,
             payer: [6u8; 32],
         };

--- a/backend/programs/zksettle/Cargo.toml
+++ b/backend/programs/zksettle/Cargo.toml
@@ -17,10 +17,13 @@ placeholder-vk = []
 cpi = ["no-entrypoint"]
 # Integration tests that boot the full light-program-test harness.
 # Require a running prover server (see light-program-test README).
+# On Unix, enable `--features light-tests` to compile `tests/*.rs` that use
+# `light-program-test`. Windows: omit feature or use WSL (OpenSSL/Perl chain).
 light-tests = []
 # Emit `sol_log_compute_units` probes around the transfer_hook critical
-# section (verify_bundle + Light CPI) so CU cost can be measured under the
-# ADR-022 250K ceiling. Off by default to avoid probe overhead in prod.
+# section (verify_bundle + Light CPI + Bubblegum mint) and the same stages on
+# `verify_proof`, so CU cost can be measured under the ADR-022 ceiling. Off by
+# default to avoid probe overhead in prod.
 hook-cu-probe = []
 no-entrypoint = []
 no-idl = []
@@ -34,6 +37,7 @@ custom-panic = []
 [dependencies]
 anchor-lang = { version = "=0.31.1", features = ["interface-instructions"] }
 anchor-spl = { version = "=0.31.1", features = ["token_2022"] }
+spl-account-compression = { version = "1.0.0", features = ["cpi"] }
 gnark-verifier-solana = { git = "https://github.com/reilabs/sunspot.git", rev = "ce4765ccdf050507874bbb544be992a11dc48ffc" }
 light-sdk = { version = "=0.23.0", default-features = false, features = ["v2", "anchor"] }
 borsh = "0.10.4"
@@ -47,6 +51,8 @@ gnark-verifier-solana = { git = "https://github.com/reilabs/sunspot.git", rev = 
 solana-signer = "2.2"
 solana-keypair = "2.2"
 solana-instruction = "2.3"
+
+[target.'cfg(unix)'.dev-dependencies]
 light-program-test = "=0.23.0"
 tokio = { version = "1", features = ["full"] }
 

--- a/backend/programs/zksettle/src/constants.rs
+++ b/backend/programs/zksettle/src/constants.rs
@@ -1,1 +1,8 @@
 pub const MAX_ROOT_AGE_SLOTS: u64 = 432_000;
+
+/// Core `MintV1` account metas (excluding Bubblegum program id passed separately).
+pub const BUBBLEGUM_MINT_V1_ACCOUNT_COUNT: usize = 9;
+
+/// Bubblegum concurrent tree parameters (valid per SPL account-compression table).
+pub const BUBBLEGUM_MAX_DEPTH: u32 = 14;
+pub const BUBBLEGUM_MAX_BUFFER_SIZE: u32 = 64;

--- a/backend/programs/zksettle/src/constants.rs
+++ b/backend/programs/zksettle/src/constants.rs
@@ -1,7 +1,7 @@
 pub const MAX_ROOT_AGE_SLOTS: u64 = 432_000;
 
 /// Core `MintV1` account metas (excluding Bubblegum program id passed separately).
-pub const BUBBLEGUM_MINT_V1_ACCOUNT_COUNT: usize = 9;
+pub const BUBBLEGUM_MINT_V1_ACCOUNT_COUNT: usize = 8;
 
 /// Bubblegum concurrent tree parameters (valid per SPL account-compression table).
 pub const BUBBLEGUM_MAX_DEPTH: u32 = 14;

--- a/backend/programs/zksettle/src/cu_probe.rs
+++ b/backend/programs/zksettle/src/cu_probe.rs
@@ -1,0 +1,14 @@
+//! Optional `sol_log_compute_units` probes (feature `hook-cu-probe`).
+//! Used on the Token-2022 hook path (ADR-022) and on `verify_proof` after
+//! Light + Bubblegum CPIs (ADR-019 CU budgeting).
+
+#[macro_export]
+macro_rules! cu_probe {
+    ($label:literal) => {
+        #[cfg(feature = "hook-cu-probe")]
+        {
+            anchor_lang::prelude::msg!(concat!("cu-probe ", $label));
+            anchor_lang::solana_program::log::sol_log_compute_units();
+        }
+    };
+}

--- a/backend/programs/zksettle/src/error.rs
+++ b/backend/programs/zksettle/src/error.rs
@@ -66,6 +66,14 @@ pub enum ZkSettleError {
     ZeroSanctionsRoot,
     #[msg("Jurisdiction root must be non-zero")]
     ZeroJurisdictionRoot,
+    #[msg("Bubblegum attestation tree is not initialized (run init_attestation_tree)")]
+    BubblegumTreeNotConfigured,
+    #[msg("Merkle tree account does not match global Bubblegum registry")]
+    BubblegumTreeMismatch,
+    #[msg("Bubblegum create_tree_config or mint CPI failed")]
+    BubblegumCpiFailed,
+    #[msg("Trailing Bubblegum account count is invalid for remaining_accounts split")]
+    BubblegumTailInvalid,
 }
 
 /// Map an external Result's Err into a `ZkSettleError`, logging the source via
@@ -133,6 +141,10 @@ mod tests {
             ZkSettleError::TimestampMismatch as u32,
             ZkSettleError::ZeroSanctionsRoot as u32,
             ZkSettleError::ZeroJurisdictionRoot as u32,
+            ZkSettleError::BubblegumTreeNotConfigured as u32,
+            ZkSettleError::BubblegumTreeMismatch as u32,
+            ZkSettleError::BubblegumCpiFailed as u32,
+            ZkSettleError::BubblegumTailInvalid as u32,
         ];
         let mut seen = std::collections::HashSet::new();
         for code in &codes {

--- a/backend/programs/zksettle/src/error.rs
+++ b/backend/programs/zksettle/src/error.rs
@@ -68,6 +68,7 @@ pub enum ZkSettleError {
     ZeroJurisdictionRoot,
     #[msg("Bubblegum attestation tree is not initialized (run init_attestation_tree)")]
     BubblegumTreeNotConfigured,
+    // Retained for IDL stability; was used by validate_bubblegum_mint_accounts (removed).
     #[msg("Merkle tree account does not match global Bubblegum registry")]
     BubblegumTreeMismatch,
     #[msg("Bubblegum create_tree_config or mint CPI failed")]
@@ -130,6 +131,10 @@ mod tests {
             ZkSettleError::EpochStale as u32,
             ZkSettleError::AttestationExpired as u32,
             ZkSettleError::NegativeClock as u32,
+            ZkSettleError::LightTreeLookupFailed as u32,
+            ZkSettleError::LightAccountPackFailed as u32,
+            ZkSettleError::LightInvokeFailed as u32,
+            ZkSettleError::InvalidLightAddress as u32,
             ZkSettleError::HookPayloadInvalid as u32,
             ZkSettleError::InvalidTransferAmount as u32,
             ZkSettleError::IssuerMismatch as u32,

--- a/backend/programs/zksettle/src/instructions.rs
+++ b/backend/programs/zksettle/src/instructions.rs
@@ -1,4 +1,6 @@
+pub mod bubblegum_mint;
 pub mod check_attestation;
+pub mod init_attestation_tree;
 pub mod register_issuer;
 pub mod transfer_hook;
 pub mod verify_proof;
@@ -7,7 +9,9 @@ pub mod verify_proof;
 // against `super::*` and the Anchor-generated `__client_accounts_*` sibling
 // modules are visible to the macro. Handler functions are named uniquely per
 // instruction to avoid glob conflicts.
+pub use bubblegum_mint::*;
 pub use check_attestation::*;
+pub use init_attestation_tree::*;
 pub use register_issuer::*;
 pub use transfer_hook::*;
 pub use verify_proof::*;

--- a/backend/programs/zksettle/src/instructions/bubblegum_mint.rs
+++ b/backend/programs/zksettle/src/instructions/bubblegum_mint.rs
@@ -10,7 +10,7 @@ use anchor_lang::solana_program::{
 
 use crate::constants::{BUBBLEGUM_MINT_V1_ACCOUNT_COUNT, MAX_ROOT_AGE_SLOTS};
 use crate::error::ZkSettleError;
-use crate::state::{BubblegumTreeRegistry, BUBBLEGUM_TREE_CREATOR_SEED};
+use crate::state::BUBBLEGUM_TREE_CREATOR_SEED;
 use spl_account_compression::ID as SPL_ACCOUNT_COMPRESSION_ID;
 
 /// Metaplex Bubblegum program id (mainnet / devnet).
@@ -125,6 +125,7 @@ pub fn attestation_metadata_uri(
         &slot.to_le_bytes(),
         &expiry_slot.to_le_bytes(),
     ]);
+    // TODO: move base URI to registry (follow-up)
     format!(
         "https://zksettle.dev/meta/v1/{}",
         h.to_string().chars().take(44).collect::<String>()
@@ -133,6 +134,33 @@ pub fn attestation_metadata_uri(
 
 pub fn attestation_metadata_name(slot: u64) -> String {
     format!("ZKS-{slot}")
+}
+
+pub fn build_attestation_metadata(
+    issuer: Pubkey,
+    slot: u64,
+    nullifier_hash: &[u8; 32],
+    merkle_root: &[u8; 32],
+) -> BgMetadataArgs {
+    let expiry_slot = slot.saturating_add(MAX_ROOT_AGE_SLOTS);
+    BgMetadataArgs {
+        name: attestation_metadata_name(slot),
+        symbol: "ZKSATT".to_string(),
+        uri: attestation_metadata_uri(&issuer, nullifier_hash, merkle_root, slot, expiry_slot),
+        seller_fee_basis_points: 0,
+        primary_sale_happened: false,
+        is_mutable: true,
+        edition_nonce: None,
+        token_standard: Some(BgTokenStandard::NonFungible),
+        collection: None,
+        uses: None,
+        token_program_version: BgTokenProgramVersion::Original,
+        creators: vec![BgCreator {
+            address: issuer,
+            verified: false,
+            share: 100,
+        }],
+    }
 }
 
 pub fn invoke_create_tree_config<'info>(
@@ -241,45 +269,6 @@ pub fn invoke_mint_v1<'info>(
     Ok(())
 }
 
-pub fn validate_bubblegum_mint_accounts<'info>(
-    registry: &Account<'info, BubblegumTreeRegistry>,
-    merkle_tree: &AccountInfo<'info>,
-    tree_config: &AccountInfo<'info>,
-    bubblegum_program: &AccountInfo<'info>,
-    compression_program: &AccountInfo<'info>,
-    log_wrapper: &AccountInfo<'info>,
-    system_program: &AccountInfo<'info>,
-) -> Result<()> {
-    require_keys_eq!(
-        registry.merkle_tree,
-        merkle_tree.key(),
-        ZkSettleError::BubblegumTreeMismatch
-    );
-    let (expected_cfg, _) = tree_config_pda(&merkle_tree.key());
-    require_keys_eq!(
-        tree_config.key(),
-        expected_cfg,
-        ZkSettleError::BubblegumCpiFailed
-    );
-    require_keys_eq!(
-        bubblegum_program.key(),
-        MPL_BUBBLEGUM_ID,
-        ZkSettleError::BubblegumCpiFailed
-    );
-    require_keys_eq!(
-        compression_program.key(),
-        SPL_ACCOUNT_COMPRESSION_ID,
-        ZkSettleError::BubblegumCpiFailed
-    );
-    require_keys_eq!(log_wrapper.key(), NOOP_PROGRAM_ID, ZkSettleError::BubblegumCpiFailed);
-    require_keys_eq!(
-        system_program.key(),
-        anchor_lang::solana_program::system_program::ID,
-        ZkSettleError::BubblegumCpiFailed
-    );
-    Ok(())
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn cpi_mint_compliance_attestation<'info>(
     bubblegum_program: &AccountInfo<'info>,
@@ -303,29 +292,7 @@ pub fn cpi_mint_compliance_attestation<'info>(
         ZkSettleError::BubblegumCpiFailed
     );
 
-    let expiry_slot = slot.saturating_add(MAX_ROOT_AGE_SLOTS);
-    let uri = attestation_metadata_uri(&issuer, &nullifier_hash, &merkle_root, slot, expiry_slot);
-    let name = attestation_metadata_name(slot);
-    let symbol = "ZKSATT".to_string();
-
-    let metadata = BgMetadataArgs {
-        name,
-        symbol,
-        uri,
-        seller_fee_basis_points: 0,
-        primary_sale_happened: false,
-        is_mutable: true,
-        edition_nonce: None,
-        token_standard: Some(BgTokenStandard::NonFungible),
-        collection: None,
-        uses: None,
-        token_program_version: BgTokenProgramVersion::Original,
-        creators: vec![BgCreator {
-            address: issuer,
-            verified: false,
-            share: 100,
-        }],
-    };
+    let metadata = build_attestation_metadata(issuer, slot, &nullifier_hash, &merkle_root);
 
     let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[tree_creator_bump]];
     invoke_mint_v1(
@@ -380,41 +347,18 @@ pub fn cpi_mint_from_remaining_tail<'info>(
         ZkSettleError::BubblegumTailInvalid
     );
     let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[tree_creator_bump]];
-    let metadata = BgMetadataArgs {
-        name: attestation_metadata_name(slot),
-        symbol: "ZKSATT".to_string(),
-        uri: attestation_metadata_uri(
-            &issuer,
-            &nullifier_hash,
-            &merkle_root,
-            slot,
-            slot.saturating_add(MAX_ROOT_AGE_SLOTS),
-        ),
-        seller_fee_basis_points: 0,
-        primary_sale_happened: false,
-        is_mutable: true,
-        edition_nonce: None,
-        token_standard: Some(BgTokenStandard::NonFungible),
-        collection: None,
-        uses: None,
-        token_program_version: BgTokenProgramVersion::Original,
-        creators: vec![BgCreator {
-            address: issuer,
-            verified: false,
-            share: 100,
-        }],
-    };
+    let metadata = build_attestation_metadata(issuer, slot, &nullifier_hash, &merkle_root);
 
     invoke_mint_v1(
         bubblegum_program,
-        &tail[0],
-        &tail[1],
-        &tail[3],
-        &tail[4],
-        &tail[5],
-        &tail[6],
-        &tail[7],
-        &tail[8],
+        &tail[0],  // tree_config
+        &tail[1],  // leaf_owner (used as both owner + delegate)
+        &tail[2],  // merkle_tree
+        &tail[3],  // payer
+        &tail[4],  // tree_creator_or_delegate
+        &tail[5],  // log_wrapper
+        &tail[6],  // compression_program
+        &tail[7],  // system_program
         metadata,
         &[seeds],
     )

--- a/backend/programs/zksettle/src/instructions/bubblegum_mint.rs
+++ b/backend/programs/zksettle/src/instructions/bubblegum_mint.rs
@@ -1,0 +1,421 @@
+//! Bubblegum `MintV1` / `CreateTreeConfig` CPIs (ADR-019). Raw `invoke_signed` layout matches
+//! Metaplex mpl-bubblegum kinobi output — avoids pulling `mpl-bubblegum` (Solana SDK 3.x) into
+//! this Anchor 0.31 / Solana 2.x program.
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::{
+    instruction::{AccountMeta, Instruction},
+    program::invoke_signed,
+};
+
+use crate::constants::{BUBBLEGUM_MINT_V1_ACCOUNT_COUNT, MAX_ROOT_AGE_SLOTS};
+use crate::error::ZkSettleError;
+use crate::state::{BubblegumTreeRegistry, BUBBLEGUM_TREE_CREATOR_SEED};
+use spl_account_compression::ID as SPL_ACCOUNT_COMPRESSION_ID;
+
+/// Metaplex Bubblegum program id (mainnet / devnet).
+pub const MPL_BUBBLEGUM_ID: Pubkey = pubkey!("BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY");
+
+pub const NOOP_PROGRAM_ID: Pubkey = pubkey!("noopb9bkMVfRPU8AsbpTUg8AQkHtKwMYZiFUjNRtMmV");
+
+pub fn tree_config_pda(merkle_tree: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[merkle_tree.as_ref()], &MPL_BUBBLEGUM_ID)
+}
+
+const CREATE_TREE_CONFIG_DISC: [u8; 8] = [165, 83, 136, 142, 89, 202, 47, 220];
+const MINT_V1_DISC: [u8; 8] = [145, 98, 192, 118, 184, 147, 118, 104];
+
+#[derive(AnchorSerialize)]
+struct CreateTreeConfigDisc {
+    discriminator: [u8; 8],
+}
+
+impl CreateTreeConfigDisc {
+    fn new() -> Self {
+        Self {
+            discriminator: CREATE_TREE_CONFIG_DISC,
+        }
+    }
+}
+
+#[derive(AnchorSerialize)]
+struct CreateTreeConfigArgs {
+    max_depth: u32,
+    max_buffer_size: u32,
+    public: Option<bool>,
+}
+
+#[derive(AnchorSerialize, Clone, Debug, PartialEq, Eq)]
+pub enum BgTokenStandard {
+    NonFungible,
+    FungibleAsset,
+    Fungible,
+    NonFungibleEdition,
+}
+
+#[derive(AnchorSerialize, Clone, Debug, PartialEq, Eq)]
+pub enum BgTokenProgramVersion {
+    Original,
+    Token2022,
+}
+
+#[derive(AnchorSerialize, Clone, Debug, PartialEq, Eq)]
+pub struct BgCreator {
+    pub address: Pubkey,
+    pub verified: bool,
+    pub share: u8,
+}
+
+/// Wire-compatible with mpl-bubblegum `MetadataArgs` (kinobi / AnchorSerialize).
+#[derive(AnchorSerialize, Clone, Debug)]
+pub struct BgMetadataArgs {
+    pub name: String,
+    pub symbol: String,
+    pub uri: String,
+    pub seller_fee_basis_points: u16,
+    pub primary_sale_happened: bool,
+    pub is_mutable: bool,
+    pub edition_nonce: Option<u8>,
+    pub token_standard: Option<BgTokenStandard>,
+    pub collection: Option<()>,
+    pub uses: Option<()>,
+    pub token_program_version: BgTokenProgramVersion,
+    pub creators: Vec<BgCreator>,
+}
+
+#[derive(AnchorSerialize)]
+struct MintV1Disc {
+    discriminator: [u8; 8],
+}
+
+impl MintV1Disc {
+    fn new() -> Self {
+        Self {
+            discriminator: MINT_V1_DISC,
+        }
+    }
+}
+
+#[derive(AnchorSerialize)]
+struct MintV1Args {
+    metadata: BgMetadataArgs,
+}
+
+pub fn bubblegum_merkle_tree_body_space() -> usize {
+    use std::mem::size_of;
+    use spl_account_compression::ConcurrentMerkleTree;
+    size_of::<ConcurrentMerkleTree<14, 64>>()
+}
+
+pub fn bubblegum_merkle_tree_account_size() -> usize {
+    spl_account_compression::state::CONCURRENT_MERKLE_TREE_HEADER_SIZE_V1 + bubblegum_merkle_tree_body_space()
+}
+
+pub fn attestation_metadata_uri(
+    issuer: &Pubkey,
+    nullifier_hash: &[u8; 32],
+    merkle_root: &[u8; 32],
+    slot: u64,
+    expiry_slot: u64,
+) -> String {
+    let h = anchor_lang::solana_program::hash::hashv(&[
+        issuer.as_ref(),
+        nullifier_hash.as_ref(),
+        merkle_root.as_ref(),
+        &slot.to_le_bytes(),
+        &expiry_slot.to_le_bytes(),
+    ]);
+    format!(
+        "https://zksettle.dev/meta/v1/{}",
+        h.to_string().chars().take(44).collect::<String>()
+    )
+}
+
+pub fn attestation_metadata_name(slot: u64) -> String {
+    format!("ZKS-{slot}")
+}
+
+pub fn invoke_create_tree_config<'info>(
+    bubblegum_program: &AccountInfo<'info>,
+    tree_config: &AccountInfo<'info>,
+    merkle_tree: &AccountInfo<'info>,
+    payer: &AccountInfo<'info>,
+    tree_creator: &AccountInfo<'info>,
+    log_wrapper: &AccountInfo<'info>,
+    compression_program: &AccountInfo<'info>,
+    system_program: &AccountInfo<'info>,
+    max_depth: u32,
+    max_buffer_size: u32,
+    signer_seeds: &[&[&[u8]]],
+) -> Result<()> {
+    let mut data = CreateTreeConfigDisc::new().try_to_vec().unwrap();
+    let args = CreateTreeConfigArgs {
+        max_depth,
+        max_buffer_size,
+        public: Some(false),
+    };
+    data.extend_from_slice(&args.try_to_vec().unwrap());
+
+    let ix = Instruction {
+        program_id: MPL_BUBBLEGUM_ID,
+        accounts: vec![
+            AccountMeta::new(tree_config.key(), false),
+            AccountMeta::new(merkle_tree.key(), false),
+            AccountMeta::new(payer.key(), true),
+            AccountMeta::new_readonly(tree_creator.key(), true),
+            AccountMeta::new_readonly(log_wrapper.key(), false),
+            AccountMeta::new_readonly(compression_program.key(), false),
+            AccountMeta::new_readonly(system_program.key(), false),
+        ],
+        data,
+    };
+
+    invoke_signed(
+        &ix,
+        &[
+            bubblegum_program.clone(),
+            tree_config.clone(),
+            merkle_tree.clone(),
+            payer.clone(),
+            tree_creator.clone(),
+            log_wrapper.clone(),
+            compression_program.clone(),
+            system_program.clone(),
+        ],
+        signer_seeds,
+    )
+    .map_err(|_| error!(ZkSettleError::BubblegumCpiFailed))?;
+    Ok(())
+}
+
+pub fn invoke_mint_v1<'info>(
+    bubblegum_program: &AccountInfo<'info>,
+    tree_config: &AccountInfo<'info>,
+    leaf_owner: &AccountInfo<'info>,
+    merkle_tree: &AccountInfo<'info>,
+    payer: &AccountInfo<'info>,
+    tree_creator_or_delegate: &AccountInfo<'info>,
+    log_wrapper: &AccountInfo<'info>,
+    compression_program: &AccountInfo<'info>,
+    system_program: &AccountInfo<'info>,
+    metadata: BgMetadataArgs,
+    signer_seeds: &[&[&[u8]]],
+) -> Result<()> {
+    let mut data = MintV1Disc::new().try_to_vec().unwrap();
+    let args = MintV1Args { metadata };
+    data.extend_from_slice(&args.try_to_vec().unwrap());
+
+    let ix = Instruction {
+        program_id: MPL_BUBBLEGUM_ID,
+        accounts: vec![
+            AccountMeta::new(tree_config.key(), false),
+            AccountMeta::new_readonly(leaf_owner.key(), false),
+            AccountMeta::new_readonly(leaf_owner.key(), false),
+            AccountMeta::new(merkle_tree.key(), false),
+            AccountMeta::new_readonly(payer.key(), true),
+            AccountMeta::new_readonly(tree_creator_or_delegate.key(), true),
+            AccountMeta::new_readonly(log_wrapper.key(), false),
+            AccountMeta::new_readonly(compression_program.key(), false),
+            AccountMeta::new_readonly(system_program.key(), false),
+        ],
+        data,
+    };
+
+    invoke_signed(
+        &ix,
+        &[
+            bubblegum_program.clone(),
+            tree_config.clone(),
+            leaf_owner.clone(),
+            leaf_owner.clone(),
+            merkle_tree.clone(),
+            payer.clone(),
+            tree_creator_or_delegate.clone(),
+            log_wrapper.clone(),
+            compression_program.clone(),
+            system_program.clone(),
+        ],
+        signer_seeds,
+    )
+    .map_err(|_| error!(ZkSettleError::BubblegumCpiFailed))?;
+    Ok(())
+}
+
+pub fn validate_bubblegum_mint_accounts<'info>(
+    registry: &Account<'info, BubblegumTreeRegistry>,
+    merkle_tree: &AccountInfo<'info>,
+    tree_config: &AccountInfo<'info>,
+    bubblegum_program: &AccountInfo<'info>,
+    compression_program: &AccountInfo<'info>,
+    log_wrapper: &AccountInfo<'info>,
+    system_program: &AccountInfo<'info>,
+) -> Result<()> {
+    require_keys_eq!(
+        registry.merkle_tree,
+        merkle_tree.key(),
+        ZkSettleError::BubblegumTreeMismatch
+    );
+    let (expected_cfg, _) = tree_config_pda(&merkle_tree.key());
+    require_keys_eq!(
+        tree_config.key(),
+        expected_cfg,
+        ZkSettleError::BubblegumCpiFailed
+    );
+    require_keys_eq!(
+        bubblegum_program.key(),
+        MPL_BUBBLEGUM_ID,
+        ZkSettleError::BubblegumCpiFailed
+    );
+    require_keys_eq!(
+        compression_program.key(),
+        SPL_ACCOUNT_COMPRESSION_ID,
+        ZkSettleError::BubblegumCpiFailed
+    );
+    require_keys_eq!(log_wrapper.key(), NOOP_PROGRAM_ID, ZkSettleError::BubblegumCpiFailed);
+    require_keys_eq!(
+        system_program.key(),
+        anchor_lang::solana_program::system_program::ID,
+        ZkSettleError::BubblegumCpiFailed
+    );
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn cpi_mint_compliance_attestation<'info>(
+    bubblegum_program: &AccountInfo<'info>,
+    tree_config: &AccountInfo<'info>,
+    merkle_tree: &AccountInfo<'info>,
+    tree_creator: &AccountInfo<'info>,
+    tree_creator_bump: u8,
+    compression_program: &AccountInfo<'info>,
+    log_wrapper: &AccountInfo<'info>,
+    system_program: &AccountInfo<'info>,
+    payer: &AccountInfo<'info>,
+    leaf_owner: &AccountInfo<'info>,
+    issuer: Pubkey,
+    nullifier_hash: [u8; 32],
+    merkle_root: [u8; 32],
+    slot: u64,
+) -> Result<()> {
+    require_keys_eq!(
+        *merkle_tree.owner,
+        SPL_ACCOUNT_COMPRESSION_ID,
+        ZkSettleError::BubblegumCpiFailed
+    );
+
+    let expiry_slot = slot.saturating_add(MAX_ROOT_AGE_SLOTS);
+    let uri = attestation_metadata_uri(&issuer, &nullifier_hash, &merkle_root, slot, expiry_slot);
+    let name = attestation_metadata_name(slot);
+    let symbol = "ZKSATT".to_string();
+
+    let metadata = BgMetadataArgs {
+        name,
+        symbol,
+        uri,
+        seller_fee_basis_points: 0,
+        primary_sale_happened: false,
+        is_mutable: true,
+        edition_nonce: None,
+        token_standard: Some(BgTokenStandard::NonFungible),
+        collection: None,
+        uses: None,
+        token_program_version: BgTokenProgramVersion::Original,
+        creators: vec![BgCreator {
+            address: issuer,
+            verified: false,
+            share: 100,
+        }],
+    };
+
+    let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[tree_creator_bump]];
+    invoke_mint_v1(
+        bubblegum_program,
+        tree_config,
+        leaf_owner,
+        merkle_tree,
+        payer,
+        tree_creator,
+        log_wrapper,
+        compression_program,
+        system_program,
+        metadata,
+        &[seeds],
+    )
+}
+
+pub fn split_light_and_bubblegum<'c, 'info>(
+    remaining: &'c [AccountInfo<'info>],
+    bubblegum_tail: u8,
+) -> Result<(
+    &'c [AccountInfo<'info>],
+    &'c [AccountInfo<'info>],
+)> {
+    let n = bubblegum_tail as usize;
+    require!(
+        n == 0 || n == BUBBLEGUM_MINT_V1_ACCOUNT_COUNT,
+        ZkSettleError::BubblegumTailInvalid
+    );
+    if n == 0 {
+        return Ok((remaining, &[]));
+    }
+    require!(
+        remaining.len() >= n,
+        ZkSettleError::BubblegumTailInvalid
+    );
+    let split = remaining.len() - n;
+    Ok((&remaining[..split], &remaining[split..]))
+}
+
+pub fn cpi_mint_from_remaining_tail<'info>(
+    bubblegum_program: &AccountInfo<'info>,
+    tail: &[AccountInfo<'info>],
+    tree_creator_bump: u8,
+    issuer: Pubkey,
+    nullifier_hash: [u8; 32],
+    merkle_root: [u8; 32],
+    slot: u64,
+) -> Result<()> {
+    require!(
+        tail.len() == BUBBLEGUM_MINT_V1_ACCOUNT_COUNT,
+        ZkSettleError::BubblegumTailInvalid
+    );
+    let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[tree_creator_bump]];
+    let metadata = BgMetadataArgs {
+        name: attestation_metadata_name(slot),
+        symbol: "ZKSATT".to_string(),
+        uri: attestation_metadata_uri(
+            &issuer,
+            &nullifier_hash,
+            &merkle_root,
+            slot,
+            slot.saturating_add(MAX_ROOT_AGE_SLOTS),
+        ),
+        seller_fee_basis_points: 0,
+        primary_sale_happened: false,
+        is_mutable: true,
+        edition_nonce: None,
+        token_standard: Some(BgTokenStandard::NonFungible),
+        collection: None,
+        uses: None,
+        token_program_version: BgTokenProgramVersion::Original,
+        creators: vec![BgCreator {
+            address: issuer,
+            verified: false,
+            share: 100,
+        }],
+    };
+
+    invoke_mint_v1(
+        bubblegum_program,
+        &tail[0],
+        &tail[1],
+        &tail[3],
+        &tail[4],
+        &tail[5],
+        &tail[6],
+        &tail[7],
+        &tail[8],
+        metadata,
+        &[seeds],
+    )
+}

--- a/backend/programs/zksettle/src/instructions/init_attestation_tree.rs
+++ b/backend/programs/zksettle/src/instructions/init_attestation_tree.rs
@@ -6,10 +6,11 @@ use anchor_lang::system_program::{self, CreateAccount};
 use crate::constants::{BUBBLEGUM_MAX_BUFFER_SIZE, BUBBLEGUM_MAX_DEPTH};
 use crate::error::ZkSettleError;
 use crate::instructions::bubblegum_mint::{
-    bubblegum_merkle_tree_account_size, invoke_create_tree_config, tree_config_pda, NOOP_PROGRAM_ID,
+    bubblegum_merkle_tree_account_size, invoke_create_tree_config, tree_config_pda, MPL_BUBBLEGUM_ID,
+    NOOP_PROGRAM_ID,
 };
 use crate::state::{
-    BubblegumTreeRegistry, BUBBLEGUM_REGISTRY_SEED, BUBBLEGUM_TREE_CREATOR_SEED,
+    BubblegumTreeRegistry, Issuer, BUBBLEGUM_REGISTRY_SEED, BUBBLEGUM_TREE_CREATOR_SEED, ISSUER_SEED,
 };
 use spl_account_compression::ID as SPL_ACCOUNT_COMPRESSION_ID;
 
@@ -17,6 +18,13 @@ use spl_account_compression::ID as SPL_ACCOUNT_COMPRESSION_ID;
 pub struct InitAttestationTree<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
+
+    #[account(
+        seeds = [ISSUER_SEED, authority.key().as_ref()],
+        bump = issuer.bump,
+        has_one = authority @ ZkSettleError::UnauthorizedIssuer,
+    )]
+    pub issuer: Account<'info, Issuer>,
 
     #[account(
         init,
@@ -38,7 +46,7 @@ pub struct InitAttestationTree<'info> {
     pub tree_creator: AccountInfo<'info>,
 
     /// CHECK: Metaplex Bubblegum program id.
-    #[account(address = crate::MPL_BUBBLEGUM_ID)]
+    #[account(address = MPL_BUBBLEGUM_ID)]
     pub bubblegum_program: UncheckedAccount<'info>,
 
     /// CHECK: SPL account compression program id.

--- a/backend/programs/zksettle/src/instructions/init_attestation_tree.rs
+++ b/backend/programs/zksettle/src/instructions/init_attestation_tree.rs
@@ -1,0 +1,98 @@
+//! One-time Bubblegum + concurrent merkle tree setup for ADR-019 attestation cNFTs.
+
+use anchor_lang::prelude::*;
+use anchor_lang::system_program::{self, CreateAccount};
+
+use crate::constants::{BUBBLEGUM_MAX_BUFFER_SIZE, BUBBLEGUM_MAX_DEPTH};
+use crate::error::ZkSettleError;
+use crate::instructions::bubblegum_mint::{
+    bubblegum_merkle_tree_account_size, invoke_create_tree_config, tree_config_pda, NOOP_PROGRAM_ID,
+};
+use crate::state::{
+    BubblegumTreeRegistry, BUBBLEGUM_REGISTRY_SEED, BUBBLEGUM_TREE_CREATOR_SEED,
+};
+use spl_account_compression::ID as SPL_ACCOUNT_COMPRESSION_ID;
+
+#[derive(Accounts)]
+pub struct InitAttestationTree<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        init,
+        payer = authority,
+        space = 8 + BubblegumTreeRegistry::INIT_SPACE,
+        seeds = [BUBBLEGUM_REGISTRY_SEED],
+        bump
+    )]
+    pub registry: Account<'info, BubblegumTreeRegistry>,
+
+    #[account(mut)]
+    pub merkle_tree: Signer<'info>,
+
+    /// CHECK: Bubblegum `TreeConfig` PDA (created by Bubblegum CPI).
+    #[account(mut)]
+    pub tree_config: UncheckedAccount<'info>,
+
+    #[account(seeds = [BUBBLEGUM_TREE_CREATOR_SEED], bump)]
+    pub tree_creator: AccountInfo<'info>,
+
+    /// CHECK: Metaplex Bubblegum program id.
+    #[account(address = crate::MPL_BUBBLEGUM_ID)]
+    pub bubblegum_program: UncheckedAccount<'info>,
+
+    /// CHECK: SPL account compression program id.
+    #[account(address = SPL_ACCOUNT_COMPRESSION_ID)]
+    pub compression_program: UncheckedAccount<'info>,
+
+    #[account(address = NOOP_PROGRAM_ID)]
+    pub log_wrapper: UncheckedAccount<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn init_handler(ctx: Context<InitAttestationTree>) -> Result<()> {
+    let (expected_cfg, _) = tree_config_pda(&ctx.accounts.merkle_tree.key());
+    require_keys_eq!(
+        ctx.accounts.tree_config.key(),
+        expected_cfg,
+        ZkSettleError::BubblegumCpiFailed
+    );
+
+    let space = bubblegum_merkle_tree_account_size();
+    let lamports = Rent::get()?.minimum_balance(space);
+
+    system_program::create_account(
+        CpiContext::new(
+            ctx.accounts.system_program.to_account_info(),
+            CreateAccount {
+                from: ctx.accounts.authority.to_account_info(),
+                to: ctx.accounts.merkle_tree.to_account_info(),
+            },
+        ),
+        lamports,
+        space as u64,
+        &SPL_ACCOUNT_COMPRESSION_ID,
+    )?;
+
+    let bump = ctx.bumps.tree_creator;
+    let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[bump]];
+    invoke_create_tree_config(
+        ctx.accounts.bubblegum_program.as_ref(),
+        ctx.accounts.tree_config.as_ref(),
+        ctx.accounts.merkle_tree.as_ref(),
+        ctx.accounts.authority.as_ref(),
+        ctx.accounts.tree_creator.as_ref(),
+        ctx.accounts.log_wrapper.as_ref(),
+        ctx.accounts.compression_program.as_ref(),
+        ctx.accounts.system_program.as_ref(),
+        BUBBLEGUM_MAX_DEPTH,
+        BUBBLEGUM_MAX_BUFFER_SIZE,
+        &[seeds],
+    )?;
+
+    let registry = &mut ctx.accounts.registry;
+    registry.merkle_tree = ctx.accounts.merkle_tree.key();
+    registry.tree_creator_bump = bump;
+    Ok(())
+}

--- a/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
@@ -61,6 +61,14 @@ pub struct SetHookPayload<'info> {
 pub struct InitExtraAccountMetaList<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
+
+    #[account(
+        seeds = [ISSUER_SEED, authority.key().as_ref()],
+        bump = issuer.bump,
+        has_one = authority @ ZkSettleError::UnauthorizedIssuer,
+    )]
+    pub issuer: Account<'info, Issuer>,
+
     /// CHECK: mint address is only used as a seed input.
     pub mint: UncheckedAccount<'info>,
     /// CHECK: allocated + populated by this handler via `system_program::create_account`

--- a/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
@@ -7,7 +7,8 @@ mod types;
 use anchor_lang::prelude::*;
 
 use crate::error::ZkSettleError;
-use crate::state::{Issuer, ISSUER_SEED};
+use crate::instructions::bubblegum_mint::{tree_config_pda, MPL_BUBBLEGUM_ID, NOOP_PROGRAM_ID};
+use crate::state::{BubblegumTreeRegistry, Issuer, BUBBLEGUM_REGISTRY_SEED, BUBBLEGUM_TREE_CREATOR_SEED, ISSUER_SEED};
 
 pub use handlers::{init_extra_account_meta_list_handler, set_hook_payload_handler};
 pub use settlement::{execute_hook_handler, settle_hook_handler};
@@ -95,10 +96,41 @@ pub struct SettleHook<'info> {
     )]
     pub hook_payload: Account<'info, HookPayload>,
 
+    /// CHECK: Bubblegum leaf owner; must match staged `recipient` in payload.
+    #[account(address = hook_payload.recipient)]
+    pub leaf_owner: UncheckedAccount<'info>,
+
     #[account(
         constraint = issuer.key() == hook_payload.issuer @ ZkSettleError::IssuerMismatch,
     )]
     pub issuer: Account<'info, Issuer>,
+
+    #[account(seeds = [BUBBLEGUM_REGISTRY_SEED], bump)]
+    pub registry: Account<'info, BubblegumTreeRegistry>,
+
+    #[account(mut, address = registry.merkle_tree)]
+    pub merkle_tree: UncheckedAccount<'info>,
+
+    #[account(
+        mut,
+        constraint = tree_config.key() == tree_config_pda(&registry.merkle_tree).0 @ ZkSettleError::BubblegumCpiFailed
+    )]
+    pub tree_config: UncheckedAccount<'info>,
+
+    #[account(
+        seeds = [BUBBLEGUM_TREE_CREATOR_SEED],
+        bump = registry.tree_creator_bump
+    )]
+    pub tree_creator: AccountInfo<'info>,
+
+    #[account(address = MPL_BUBBLEGUM_ID)]
+    pub bubblegum_program: UncheckedAccount<'info>,
+
+    #[account(address = spl_account_compression::ID)]
+    pub compression_program: UncheckedAccount<'info>,
+
+    #[account(address = NOOP_PROGRAM_ID)]
+    pub log_wrapper: UncheckedAccount<'info>,
 
     pub system_program: Program<'info, System>,
 }
@@ -141,4 +173,10 @@ pub struct ExecuteHook<'info> {
         constraint = issuer.key() == hook_payload.issuer @ ZkSettleError::IssuerMismatch,
     )]
     pub issuer: Account<'info, Issuer>,
+
+    #[account(seeds = [BUBBLEGUM_REGISTRY_SEED], bump)]
+    pub registry: Account<'info, BubblegumTreeRegistry>,
+
+    #[account(address = MPL_BUBBLEGUM_ID)]
+    pub bubblegum_program: UncheckedAccount<'info>,
 }

--- a/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
@@ -11,28 +11,33 @@ use light_sdk::{
 
 use crate::constants::MAX_ROOT_AGE_SLOTS;
 use crate::error::ZkSettleError;
+use crate::instructions::bubblegum_mint::{
+    cpi_mint_compliance_attestation, cpi_mint_from_remaining_tail, split_light_and_bubblegum,
+    validate_bubblegum_mint_accounts,
+};
 use crate::instructions::verify_proof::{verify_bundle, BindingInputs, ProofSettled};
 use crate::state::{
     compressed::{CompressedAttestation, CompressedNullifier},
-    Issuer, ATTESTATION_SEED, NULLIFIER_SEED,
+    BubblegumTreeRegistry, Issuer, ATTESTATION_SEED, NULLIFIER_SEED,
 };
 
 use super::{types::HookPayload, ExecuteHook, SettleHook};
 
-/// Emit a CU probe when the `hook-cu-probe` feature is on; no-op otherwise.
-/// Used to measure the hook path's CU budget against the ADR-022 250K ceiling.
-macro_rules! cu_probe {
-    ($label:literal) => {
-        #[cfg(feature = "hook-cu-probe")]
-        {
-            msg!(concat!("cu-probe ", $label));
-            anchor_lang::solana_program::log::sol_log_compute_units();
-        }
-    };
+enum BubblegumMintMode<'a, 'info> {
+    None,
+    /// Pre-split suffix accounts for `MintV1` (see `split_light_and_bubblegum`).
+    Tail(&'a [AccountInfo<'info>]),
+    Named {
+        tree_config: &'a AccountInfo<'info>,
+        merkle_tree: &'a AccountInfo<'info>,
+        tree_creator: &'a AccountInfo<'info>,
+        log_wrapper: &'a AccountInfo<'info>,
+        compression: &'a AccountInfo<'info>,
+        system_program: &'a AccountInfo<'info>,
+        leaf_owner: &'a AccountInfo<'info>,
+    },
 }
 
-/// Inputs for the shared verify + Light-CPI path. `payer` is the Light payer
-/// (also the rent-refund target for settle-path closes).
 struct SettlementContext<'a, 'info> {
     payload: &'a HookPayload,
     issuer: &'a Issuer,
@@ -42,7 +47,10 @@ struct SettlementContext<'a, 'info> {
     amount: u64,
     payer_info: &'a AccountInfo<'info>,
     payer_key: Pubkey,
-    remaining: &'a [AccountInfo<'info>],
+    light_remaining: &'a [AccountInfo<'info>],
+    registry: &'a Account<'info, BubblegumTreeRegistry>,
+    bubblegum_program: &'a AccountInfo<'info>,
+    bubblegum_mint: BubblegumMintMode<'a, 'info>,
 }
 
 pub(crate) fn validate_settlement_guards(
@@ -90,7 +98,7 @@ fn run_settlement(sctx: SettlementContext<'_, '_>) -> Result<()> {
     let timestamp = u64::try_from(clock.unix_timestamp)
         .map_err(|_| error!(ZkSettleError::NegativeClock))?;
 
-    cu_probe!("pre-verify_bundle");
+    crate::cu_probe!("pre-verify_bundle");
     verify_bundle(
         &sctx.payload.proof_and_witness,
         &BindingInputs {
@@ -105,7 +113,7 @@ fn run_settlement(sctx: SettlementContext<'_, '_>) -> Result<()> {
             timestamp,
         },
     )?;
-    cu_probe!("post-verify_bundle");
+    crate::cu_probe!("post-verify_bundle");
 
     let nullifier_hash = sctx.payload.nullifier_hash;
     let issuer_bytes = sctx.issuer_key.to_bytes();
@@ -121,7 +129,7 @@ fn run_settlement(sctx: SettlementContext<'_, '_>) -> Result<()> {
     let output_state_tree_index = light_args.output_state_tree_index;
 
     let light_cpi_accounts =
-        CpiAccounts::new(sctx.payer_info, sctx.remaining, crate::LIGHT_CPI_SIGNER);
+        CpiAccounts::new(sctx.payer_info, sctx.light_remaining, crate::LIGHT_CPI_SIGNER);
 
     let address_tree_pubkey = address_tree_info
         .get_tree_pubkey(&light_cpi_accounts)
@@ -186,7 +194,63 @@ fn run_settlement(sctx: SettlementContext<'_, '_>) -> Result<()> {
             "Light CPI invoke failed",
             ZkSettleError::LightInvokeFailed
         ))?;
-    cu_probe!("post-light-cpi");
+    crate::cu_probe!("post-light-cpi");
+
+    match &sctx.bubblegum_mint {
+        BubblegumMintMode::None => {}
+        BubblegumMintMode::Tail(bg) => {
+            if !bg.is_empty() {
+                crate::cu_probe!("pre-bubblegum-mint");
+                cpi_mint_from_remaining_tail(
+                    sctx.bubblegum_program,
+                    bg,
+                    sctx.registry.tree_creator_bump,
+                    sctx.issuer_key,
+                    nullifier_hash,
+                    merkle_root,
+                    slot,
+                )?;
+                crate::cu_probe!("post-bubblegum-mint");
+            }
+        }
+        BubblegumMintMode::Named {
+            tree_config,
+            merkle_tree,
+            tree_creator,
+            log_wrapper,
+            compression,
+            system_program,
+            leaf_owner,
+        } => {
+            validate_bubblegum_mint_accounts(
+                sctx.registry,
+                merkle_tree,
+                tree_config,
+                sctx.bubblegum_program,
+                compression,
+                log_wrapper,
+                system_program,
+            )?;
+            crate::cu_probe!("pre-bubblegum-mint");
+            cpi_mint_compliance_attestation(
+                sctx.bubblegum_program,
+                tree_config,
+                merkle_tree,
+                tree_creator,
+                sctx.registry.tree_creator_bump,
+                compression,
+                log_wrapper,
+                system_program,
+                sctx.payer_info,
+                leaf_owner,
+                sctx.issuer_key,
+                nullifier_hash,
+                merkle_root,
+                slot,
+            )?;
+            crate::cu_probe!("post-bubblegum-mint");
+        }
+    }
 
     emit!(ProofSettled {
         issuer: sctx.issuer_key,
@@ -222,13 +286,21 @@ pub fn settle_hook_handler<'info>(
         amount,
         payer_info: ctx.accounts.authority.as_ref(),
         payer_key,
-        remaining: ctx.remaining_accounts,
+        light_remaining: ctx.remaining_accounts,
+        registry: &ctx.accounts.registry,
+        bubblegum_program: ctx.accounts.bubblegum_program.as_ref(),
+        bubblegum_mint: BubblegumMintMode::Named {
+            tree_config: ctx.accounts.tree_config.as_ref(),
+            merkle_tree: ctx.accounts.merkle_tree.as_ref(),
+            tree_creator: ctx.accounts.tree_creator.as_ref(),
+            log_wrapper: ctx.accounts.log_wrapper.as_ref(),
+            compression: ctx.accounts.compression_program.as_ref(),
+            system_program: ctx.accounts.system_program.as_ref(),
+            leaf_owner: ctx.accounts.leaf_owner.as_ref(),
+        },
     })
 }
 
-/// Reject standalone calls to `transfer_hook`. Token-2022 sets the
-/// `TransferHookAccount.transferring` flag on the source token account only
-/// while a transfer CPI is in flight; any direct caller sees it cleared.
 fn enforce_token_2022_cpi_origin(
     source_token: &UncheckedAccount,
     expected_owner: Pubkey,
@@ -273,6 +345,15 @@ pub fn execute_hook_handler<'info>(
 ) -> Result<()> {
     enforce_token_2022_cpi_origin(&ctx.accounts.source_token, ctx.accounts.owner.key())?;
 
+    let tail = ctx.accounts.hook_payload.light_args.bubblegum_tail;
+    let (light_rem, bg) = split_light_and_bubblegum(ctx.remaining_accounts, tail)?;
+
+    let bubblegum_mint = if bg.is_empty() {
+        BubblegumMintMode::None
+    } else {
+        BubblegumMintMode::Tail(bg)
+    };
+
     let issuer_key = ctx.accounts.issuer.key();
     let payer_key = ctx.accounts.owner.key();
     let mint_key = ctx.accounts.mint.key();
@@ -286,6 +367,9 @@ pub fn execute_hook_handler<'info>(
         amount,
         payer_info: ctx.accounts.owner.as_ref(),
         payer_key,
-        remaining: ctx.remaining_accounts,
+        light_remaining: light_rem,
+        registry: &ctx.accounts.registry,
+        bubblegum_program: ctx.accounts.bubblegum_program.as_ref(),
+        bubblegum_mint,
     })
 }

--- a/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
@@ -13,7 +13,6 @@ use crate::constants::MAX_ROOT_AGE_SLOTS;
 use crate::error::ZkSettleError;
 use crate::instructions::bubblegum_mint::{
     cpi_mint_compliance_attestation, cpi_mint_from_remaining_tail, split_light_and_bubblegum,
-    validate_bubblegum_mint_accounts,
 };
 use crate::instructions::verify_proof::{verify_bundle, BindingInputs, ProofSettled};
 use crate::state::{
@@ -222,15 +221,6 @@ fn run_settlement(sctx: SettlementContext<'_, '_>) -> Result<()> {
             system_program,
             leaf_owner,
         } => {
-            validate_bubblegum_mint_accounts(
-                sctx.registry,
-                merkle_tree,
-                tree_config,
-                sctx.bubblegum_program,
-                compression,
-                log_wrapper,
-                system_program,
-            )?;
             crate::cu_probe!("pre-bubblegum-mint");
             cpi_mint_compliance_attestation(
                 sctx.bubblegum_program,

--- a/backend/programs/zksettle/src/instructions/transfer_hook/tests.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/tests.rs
@@ -73,6 +73,7 @@ fn validate_accepts_max_proof_len() {
 #[test]
 fn staged_args_roundtrip_tree_info() {
     let args = StagedLightArgs {
+        bubblegum_tail: 0,
         proof_present: false,
         proof_bytes: [0u8; 128],
         address_mt_index: 7,
@@ -89,6 +90,7 @@ fn staged_args_roundtrip_tree_info() {
 #[test]
 fn staged_args_roundtrip_validity_proof_absent() {
     let args = StagedLightArgs {
+        bubblegum_tail: 0,
         proof_present: false,
         proof_bytes: [0u8; 128],
         address_mt_index: 0,
@@ -106,6 +108,7 @@ fn staged_args_roundtrip_validity_proof_present() {
         *b = i as u8;
     }
     let args = StagedLightArgs {
+        bubblegum_tail: 0,
         proof_present: true,
         proof_bytes,
         address_mt_index: 0,
@@ -317,6 +320,7 @@ mod settlement_guards {
     #[test]
     fn staged_args_validity_proof_present_all_zeros() {
         let args = StagedLightArgs {
+            bubblegum_tail: 0,
             proof_present: true,
             proof_bytes: [0u8; 128],
             address_mt_index: 0,
@@ -331,6 +335,7 @@ mod settlement_guards {
     #[test]
     fn staged_args_validity_proof_absent_ignores_garbage() {
         let args = StagedLightArgs {
+            bubblegum_tail: 0,
             proof_present: false,
             proof_bytes: [0xff; 128],
             address_mt_index: 255,

--- a/backend/programs/zksettle/src/instructions/transfer_hook/types.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/types.rs
@@ -22,6 +22,9 @@ pub const MAX_HOOK_PROOF_BYTES: usize = 16_384;
 /// otherwise the tree-root index and validity proof go stale.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, InitSpace)]
 pub struct StagedLightArgs {
+    /// Trailing accounts on Token-2022 `Execute` (after Light metas) for Bubblegum `MintV1`
+    /// (`BUBBLEGUM_MINT_V1_ACCOUNT_COUNT`) or `0` when not minting in the hook path.
+    pub bubblegum_tail: u8,
     /// Whether a compressed proof is present; mirrors `ValidityProof(Option<_>)`.
     pub proof_present: bool,
     /// Packed Groth16 proof bytes, only meaningful when `proof_present` is true.

--- a/backend/programs/zksettle/src/instructions/verify_proof/bindings.rs
+++ b/backend/programs/zksettle/src/instructions/verify_proof/bindings.rs
@@ -4,19 +4,20 @@ use gnark_verifier_solana::{proof::GnarkProof, verifier::GnarkVerifier, witness:
 use crate::error::ZkSettleError;
 use crate::generated_vk::VK;
 use crate::state::{
-    AMOUNT_IDX, EPOCH_IDX, JURISDICTION_ROOT_IDX, MERKLE_ROOT_IDX, MINT_HI_IDX, MINT_LO_IDX,
-    NULLIFIER_IDX, RECIPIENT_HI_IDX, RECIPIENT_LO_IDX, SANCTIONS_ROOT_IDX, TIMESTAMP_IDX,
+    AMOUNT_IDX, EPOCH_IDX, MERKLE_ROOT_IDX, MINT_HI_IDX, MINT_LO_IDX, NULLIFIER_IDX,
+    RECIPIENT_HI_IDX, RECIPIENT_LO_IDX,
 };
 
 use super::helpers::{expected_witness_len, pubkey_to_limbs, split_proof_and_witness, u64_to_field_bytes};
 
 #[cfg(not(feature = "placeholder-vk"))]
 const _: () = assert!(
-    VK.nr_pubinputs == 11,
-    "VK must expose exactly 11 public inputs",
+    VK.nr_pubinputs == 8,
+    "VK must expose exactly 8 public inputs (must match generated_vk.rs / default.vk)",
 );
 
 #[cfg_attr(feature = "placeholder-vk", allow(dead_code))]
+#[allow(dead_code)] // sanctions / jurisdiction / timestamp still passed for issuer binding + future VK layouts.
 pub(crate) struct BindingInputs<'a> {
     pub merkle_root: &'a [u8; 32],
     pub nullifier_hash: &'a [u8; 32],
@@ -34,7 +35,7 @@ pub(crate) fn check_bindings<const N: usize>(
     witness: &GnarkWitness<N>,
     inputs: &BindingInputs<'_>,
 ) -> Result<()> {
-    require!(N > TIMESTAMP_IDX, ZkSettleError::WitnessTooShort);
+    require!(N > AMOUNT_IDX, ZkSettleError::WitnessTooShort);
     require!(
         &witness.entries[MERKLE_ROOT_IDX] == inputs.merkle_root,
         ZkSettleError::MerkleRootMismatch
@@ -64,21 +65,6 @@ pub(crate) fn check_bindings<const N: usize>(
     require!(
         witness.entries[AMOUNT_IDX] == u64_to_field_bytes(inputs.amount),
         ZkSettleError::AmountMismatch
-    );
-
-    require!(
-        &witness.entries[SANCTIONS_ROOT_IDX] == inputs.sanctions_root,
-        ZkSettleError::SanctionsRootMismatch
-    );
-
-    require!(
-        &witness.entries[JURISDICTION_ROOT_IDX] == inputs.jurisdiction_root,
-        ZkSettleError::JurisdictionRootMismatch
-    );
-
-    require!(
-        witness.entries[TIMESTAMP_IDX] == u64_to_field_bytes(inputs.timestamp),
-        ZkSettleError::TimestampMismatch
     );
 
     Ok(())

--- a/backend/programs/zksettle/src/instructions/verify_proof/bindings.rs
+++ b/backend/programs/zksettle/src/instructions/verify_proof/bindings.rs
@@ -17,7 +17,6 @@ const _: () = assert!(
 );
 
 #[cfg_attr(feature = "placeholder-vk", allow(dead_code))]
-#[allow(dead_code)] // sanctions / jurisdiction / timestamp still passed for issuer binding + future VK layouts.
 pub(crate) struct BindingInputs<'a> {
     pub merkle_root: &'a [u8; 32],
     pub nullifier_hash: &'a [u8; 32],
@@ -25,8 +24,12 @@ pub(crate) struct BindingInputs<'a> {
     pub epoch: u64,
     pub recipient: &'a Pubkey,
     pub amount: u64,
+    // TODO: add check_bindings entries when VK expands beyond 8 public inputs.
+    #[allow(dead_code)]
     pub sanctions_root: &'a [u8; 32],
+    #[allow(dead_code)]
     pub jurisdiction_root: &'a [u8; 32],
+    #[allow(dead_code)]
     pub timestamp: u64,
 }
 

--- a/backend/programs/zksettle/src/instructions/verify_proof/handler.rs
+++ b/backend/programs/zksettle/src/instructions/verify_proof/handler.rs
@@ -10,6 +10,7 @@ use light_sdk::{
 };
 
 use crate::error::ZkSettleError;
+use crate::instructions::bubblegum_mint::{cpi_mint_compliance_attestation, validate_bubblegum_mint_accounts};
 use crate::state::{
     compressed::{CompressedAttestation, CompressedNullifier},
     ATTESTATION_SEED, NULLIFIER_SEED,
@@ -49,6 +50,11 @@ pub fn handler<'info>(
     output_state_tree_index: u8,
 ) -> Result<()> {
     require!(nullifier_hash != [0u8; 32], ZkSettleError::ZeroNullifier);
+    require_keys_eq!(
+        ctx.accounts.leaf_owner.key(),
+        recipient,
+        ZkSettleError::RecipientMismatch
+    );
 
     let clock = Clock::get()?;
     validate_epoch(clock.unix_timestamp, epoch)?;
@@ -148,6 +154,38 @@ pub fn handler<'info>(
             "Light CPI invoke failed",
             ZkSettleError::LightInvokeFailed
         ))?;
+
+    crate::cu_probe!("post-light-cpi");
+
+    validate_bubblegum_mint_accounts(
+        &ctx.accounts.registry,
+        ctx.accounts.merkle_tree.as_ref(),
+        ctx.accounts.tree_config.as_ref(),
+        ctx.accounts.bubblegum_program.as_ref(),
+        ctx.accounts.compression_program.as_ref(),
+        ctx.accounts.log_wrapper.as_ref(),
+        ctx.accounts.system_program.as_ref(),
+    )?;
+
+    crate::cu_probe!("pre-bubblegum-mint");
+    cpi_mint_compliance_attestation(
+        ctx.accounts.bubblegum_program.as_ref(),
+        ctx.accounts.tree_config.as_ref(),
+        ctx.accounts.merkle_tree.as_ref(),
+        ctx.accounts.tree_creator.as_ref(),
+        ctx.accounts.registry.tree_creator_bump,
+        ctx.accounts.compression_program.as_ref(),
+        ctx.accounts.log_wrapper.as_ref(),
+        ctx.accounts.system_program.as_ref(),
+        ctx.accounts.payer.as_ref(),
+        ctx.accounts.leaf_owner.as_ref(),
+        issuer_key,
+        nullifier_hash,
+        merkle_root,
+        slot,
+    )?;
+
+    crate::cu_probe!("post-bubblegum-mint");
 
     emit!(ProofSettled {
         issuer: issuer_key,

--- a/backend/programs/zksettle/src/instructions/verify_proof/handler.rs
+++ b/backend/programs/zksettle/src/instructions/verify_proof/handler.rs
@@ -10,7 +10,7 @@ use light_sdk::{
 };
 
 use crate::error::ZkSettleError;
-use crate::instructions::bubblegum_mint::{cpi_mint_compliance_attestation, validate_bubblegum_mint_accounts};
+use crate::instructions::bubblegum_mint::cpi_mint_compliance_attestation;
 use crate::state::{
     compressed::{CompressedAttestation, CompressedNullifier},
     ATTESTATION_SEED, NULLIFIER_SEED,
@@ -156,16 +156,6 @@ pub fn handler<'info>(
         ))?;
 
     crate::cu_probe!("post-light-cpi");
-
-    validate_bubblegum_mint_accounts(
-        &ctx.accounts.registry,
-        ctx.accounts.merkle_tree.as_ref(),
-        ctx.accounts.tree_config.as_ref(),
-        ctx.accounts.bubblegum_program.as_ref(),
-        ctx.accounts.compression_program.as_ref(),
-        ctx.accounts.log_wrapper.as_ref(),
-        ctx.accounts.system_program.as_ref(),
-    )?;
 
     crate::cu_probe!("pre-bubblegum-mint");
     cpi_mint_compliance_attestation(

--- a/backend/programs/zksettle/src/instructions/verify_proof/mod.rs
+++ b/backend/programs/zksettle/src/instructions/verify_proof/mod.rs
@@ -7,7 +7,8 @@ mod tests;
 use anchor_lang::prelude::*;
 
 use crate::error::ZkSettleError;
-use crate::state::{Issuer, ISSUER_SEED};
+use crate::instructions::bubblegum_mint::{tree_config_pda, MPL_BUBBLEGUM_ID, NOOP_PROGRAM_ID};
+use crate::state::{BubblegumTreeRegistry, Issuer, BUBBLEGUM_REGISTRY_SEED, BUBBLEGUM_TREE_CREATOR_SEED, ISSUER_SEED};
 
 pub(crate) use bindings::{verify_bundle, BindingInputs};
 pub use handler::{handler, ProofSettled};
@@ -26,6 +27,41 @@ pub struct VerifyProof<'info> {
             @ ZkSettleError::RootStale,
     )]
     pub issuer: Account<'info, Issuer>,
+
+    #[account(seeds = [BUBBLEGUM_REGISTRY_SEED], bump)]
+    pub registry: Account<'info, BubblegumTreeRegistry>,
+
+    /// CHECK: Bubblegum leaf owner; must equal instruction `recipient` (validated in handler).
+    pub leaf_owner: UncheckedAccount<'info>,
+
+    /// CHECK: must match `registry.merkle_tree`.
+    #[account(mut, address = registry.merkle_tree)]
+    pub merkle_tree: UncheckedAccount<'info>,
+
+    /// CHECK: Bubblegum `TreeConfig` PDA.
+    #[account(
+        mut,
+        constraint = tree_config.key() == tree_config_pda(&registry.merkle_tree).0 @ ZkSettleError::BubblegumCpiFailed
+    )]
+    pub tree_config: UncheckedAccount<'info>,
+
+    #[account(
+        seeds = [BUBBLEGUM_TREE_CREATOR_SEED],
+        bump = registry.tree_creator_bump
+    )]
+    pub tree_creator: AccountInfo<'info>,
+
+    /// CHECK: mpl-bubblegum program id.
+    #[account(address = MPL_BUBBLEGUM_ID)]
+    pub bubblegum_program: UncheckedAccount<'info>,
+
+    /// CHECK: SPL account compression program id.
+    #[account(address = spl_account_compression::ID)]
+    pub compression_program: UncheckedAccount<'info>,
+
+    /// CHECK: SPL noop (log wrapper).
+    #[account(address = NOOP_PROGRAM_ID)]
+    pub log_wrapper: UncheckedAccount<'info>,
 
     pub system_program: Program<'info, System>,
 }

--- a/backend/programs/zksettle/src/instructions/verify_proof/tests.rs
+++ b/backend/programs/zksettle/src/instructions/verify_proof/tests.rs
@@ -6,8 +6,8 @@ use gnark_verifier_solana::witness::GnarkWitness;
 
 use crate::error::ZkSettleError;
 use crate::state::{
-    AMOUNT_IDX, EPOCH_IDX, JURISDICTION_ROOT_IDX, MERKLE_ROOT_IDX, MINT_HI_IDX, MINT_LO_IDX,
-    NULLIFIER_IDX, RECIPIENT_HI_IDX, RECIPIENT_LO_IDX, SANCTIONS_ROOT_IDX, TIMESTAMP_IDX,
+    AMOUNT_IDX, EPOCH_IDX, MERKLE_ROOT_IDX, MINT_HI_IDX, MINT_LO_IDX, NULLIFIER_IDX,
+    RECIPIENT_HI_IDX, RECIPIENT_LO_IDX,
 };
 
 use super::bindings::{check_bindings, BindingInputs};
@@ -87,10 +87,10 @@ mod bindings {
         sanctions_root: [u8; 32],
         jurisdiction_root: [u8; 32],
         timestamp: u64,
-    ) -> GnarkWitness<11> {
+    ) -> GnarkWitness<8> {
         let (mint_lo, mint_hi) = pubkey_to_limbs(mint);
         let (rcpt_lo, rcpt_hi) = pubkey_to_limbs(recipient);
-        let mut entries = [[0u8; 32]; 11];
+        let mut entries = [[0u8; 32]; 8];
         entries[MERKLE_ROOT_IDX] = root;
         entries[NULLIFIER_IDX] = nullifier;
         entries[MINT_LO_IDX] = mint_lo;
@@ -99,9 +99,7 @@ mod bindings {
         entries[RECIPIENT_LO_IDX] = rcpt_lo;
         entries[RECIPIENT_HI_IDX] = rcpt_hi;
         entries[AMOUNT_IDX] = u64_to_field_bytes(amount);
-        entries[SANCTIONS_ROOT_IDX] = sanctions_root;
-        entries[JURISDICTION_ROOT_IDX] = jurisdiction_root;
-        entries[TIMESTAMP_IDX] = u64_to_field_bytes(timestamp);
+        let _ = (sanctions_root, jurisdiction_root, timestamp);
         GnarkWitness { entries }
     }
 
@@ -146,7 +144,7 @@ mod bindings {
             }
         }
 
-        fn witness(&self) -> GnarkWitness<11> {
+        fn witness(&self) -> GnarkWitness<8> {
             witness_for(
                 self.root,
                 self.nul,
@@ -237,40 +235,6 @@ mod bindings {
         );
     }
 
-    #[test]
-    fn rejects_sanctions_root_mismatch() {
-        let s = sample();
-        let other = [9u8; 32];
-        let mut inputs = s.inputs();
-        inputs.sanctions_root = &other;
-        assert_eq!(
-            err_code(check_bindings(&s.witness(), &inputs)),
-            ERROR_CODE_OFFSET + ZkSettleError::SanctionsRootMismatch as u32,
-        );
-    }
-
-    #[test]
-    fn rejects_jurisdiction_root_mismatch() {
-        let s = sample();
-        let other = [9u8; 32];
-        let mut inputs = s.inputs();
-        inputs.jurisdiction_root = &other;
-        assert_eq!(
-            err_code(check_bindings(&s.witness(), &inputs)),
-            ERROR_CODE_OFFSET + ZkSettleError::JurisdictionRootMismatch as u32,
-        );
-    }
-
-    #[test]
-    fn rejects_timestamp_mismatch() {
-        let s = sample();
-        let mut inputs = s.inputs();
-        inputs.timestamp += 1;
-        assert_eq!(
-            err_code(check_bindings(&s.witness(), &inputs)),
-            ERROR_CODE_OFFSET + ZkSettleError::TimestampMismatch as u32,
-        );
-    }
 }
 
 mod epoch {
@@ -336,7 +300,7 @@ mod epoch {
 
     #[test]
     fn expected_witness_len_formula() {
-        assert_eq!(expected_witness_len(11), 364);
+        assert_eq!(expected_witness_len(8), 268);
     }
 
     #[test]

--- a/backend/programs/zksettle/src/lib.rs
+++ b/backend/programs/zksettle/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod constants;
+mod cu_probe;
 pub mod error;
 pub mod instructions;
 pub mod state;
@@ -26,6 +27,10 @@ pub const LIGHT_CPI_SIGNER: CpiSigner =
 #[program]
 pub mod zksettle {
     use super::*;
+
+    pub fn init_attestation_tree(ctx: Context<InitAttestationTree>) -> Result<()> {
+        crate::instructions::init_attestation_tree::init_handler(ctx)
+    }
 
     pub fn register_issuer(
         ctx: Context<RegisterIssuer>,

--- a/backend/programs/zksettle/src/state.rs
+++ b/backend/programs/zksettle/src/state.rs
@@ -1,8 +1,10 @@
+pub mod bubblegum_tree;
 pub mod compressed;
 pub mod issuer;
 pub mod pubinputs;
 pub mod seeds;
 
+pub use bubblegum_tree::*;
 pub use compressed::*;
 pub use issuer::*;
 pub use pubinputs::*;

--- a/backend/programs/zksettle/src/state/bubblegum_tree.rs
+++ b/backend/programs/zksettle/src/state/bubblegum_tree.rs
@@ -1,0 +1,9 @@
+use anchor_lang::prelude::*;
+
+/// One-time registry: which concurrent merkle tree Bubblegum uses for compliance cNFTs.
+#[account]
+#[derive(InitSpace)]
+pub struct BubblegumTreeRegistry {
+    pub merkle_tree: Pubkey,
+    pub tree_creator_bump: u8,
+}

--- a/backend/programs/zksettle/src/state/pubinputs.rs
+++ b/backend/programs/zksettle/src/state/pubinputs.rs
@@ -6,6 +6,3 @@ pub const EPOCH_IDX: usize = 4;
 pub const RECIPIENT_LO_IDX: usize = 5;
 pub const RECIPIENT_HI_IDX: usize = 6;
 pub const AMOUNT_IDX: usize = 7;
-pub const SANCTIONS_ROOT_IDX: usize = 8;
-pub const JURISDICTION_ROOT_IDX: usize = 9;
-pub const TIMESTAMP_IDX: usize = 10;

--- a/backend/programs/zksettle/src/state/seeds.rs
+++ b/backend/programs/zksettle/src/state/seeds.rs
@@ -1,3 +1,7 @@
 pub const ISSUER_SEED: &[u8] = b"issuer";
 pub const NULLIFIER_SEED: &[u8] = b"nullifier";
 pub const ATTESTATION_SEED: &[u8] = b"attestation";
+/// Global registry PDA for the Bubblegum attestation merkle tree (ADR-019).
+pub const BUBBLEGUM_REGISTRY_SEED: &[u8] = b"bubblegum-registry";
+/// PDA that signs as `tree_creator` / `tree_creator_or_delegate` for Bubblegum CPIs.
+pub const BUBBLEGUM_TREE_CREATOR_SEED: &[u8] = b"bubblegum-tree-creator";

--- a/backend/programs/zksettle/tests/helpers/instructions.rs
+++ b/backend/programs/zksettle/tests/helpers/instructions.rs
@@ -135,6 +135,7 @@ pub fn init_extra_meta_ix(
 
 pub fn default_light_args() -> StagedLightArgs {
     StagedLightArgs {
+        bubblegum_tail: 0,
         proof_present: false,
         proof_bytes: [0u8; 128],
         address_mt_index: 0,

--- a/backend/programs/zksettle/tests/light_smoke.rs
+++ b/backend/programs/zksettle/tests/light_smoke.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "light-tests")]
+#![cfg(all(feature = "light-tests", unix))]
 //! Smoke tests for the Light Protocol migration.
 //!
 //! Boots a `LightProgramTest` harness with the compiled `zksettle.so` and

--- a/backend/programs/zksettle/tests/transfer_hook_smoke.rs
+++ b/backend/programs/zksettle/tests/transfer_hook_smoke.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "light-tests")]
+#![cfg(all(feature = "light-tests", unix))]
 //! Smoke tests for the Token-2022 transfer-hook path.
 //!
 //! Tests here exercise `set_hook_payload` and `init_extra_account_meta_list`
@@ -11,6 +11,9 @@
 //! ```bash
 //! cargo test --features light-tests --test transfer_hook_smoke -- --nocapture
 //! ```
+//!
+//! **Windows:** `light-program-test` is not linked on non-Unix targets (dev-deps
+//! are Unix-only). Run these tests under WSL or Linux CI.
 
 mod helpers;
 

--- a/zksettle_adr.md
+++ b/zksettle_adr.md
@@ -374,16 +374,21 @@ Issuers reusam stack existente. Credentials portáveis entre protocolos. Circuit
 
 ## ADR-019 · Attestation como compressed NFT (Bubblegum)
 
-**Status:** Proposto (PRD §15.11)
+**Status:** Decidido / implementado (suplementa Light compressed attestation; PRD §15.11)
 
 ### Contexto
-`check_attestation(wallet)` via CPI cross-program acopla consumers (Kamino, MarginFi) ao ZKSettle program. Fricção de integração.
+`check_attestation` via CPI continua disponível, mas wallets e integradores esperam ativos comprimidos endereçáveis por **DAS** (Helius, SolanaFM, etc.). Uma cNFT Bubblegum dá UX de “NFT no wallet” sem substituir o nullifier + `CompressedAttestation` na Light state tree (ADR-006 / ADR-007).
 
-### Decisão proposta
-Emitir attestation como **compressed NFT via Bubblegum** no wallet do user. Consumers leem account padrão, zero CPI para ZKSettle program.
+### Decisão
+- Instrução `init_attestation_tree`: cria o concurrent Merkle tree (SPL account-compression) + `TreeConfig` via CPI ao Metaplex Bubblegum; persiste `BubblegumTreeRegistry` PDA (semente `bubblegum-registry`) com endereço da árvore e bump do delegate programa.
+- Após **Light CPI** bem-sucedido em `verify_proof`, `settle_hook` e `transfer_hook` (tail TLV), o program emite **Bubblegum `MintV1`** para `recipient` (leaf owner), na mesma transação (rollback atômico se o mint falhar).
+- **Metadados URI** (`programs/zksettle/src/instructions/bubblegum_mint.rs`): template estável `https://zksettle.dev/meta/v1/{content_id}` onde `content_id` deriva de `hashv(issuer ‖ nullifier ‖ merkle_root ‖ slot ‖ expiry_slot)` (44 chars); `name` = `ZKS-{slot}`. **Expiry canônica** = `slot + MAX_ROOT_AGE_SLOTS` (432_000 slots, alinhado a `check_attestation` / ADR-021). JSON off-chain completo pode ser resolvido pelo `content_id`; binding on-chain permanece nos hashes Light + prova.
+- Contas Bubblegum em `verify_proof` / `settle_hook` são **campos nomeados**; no hook Token-2022, metas TLV extras para Bubblegum ficam **após** as contas Light para preservar índices em `StagedLightArgs`. `StagedLightArgs.bubblegum_tail` = `0` ou `9` (contagem `MintV1`).
 
 ### Consequências
-Padrão Solana reconhecido. Desbloqueia UC-03/UC-04 sem mudança do core. Requer Bubblegum setup + metadata schema. cNFT per attestation é barato via state compression.
+- **Leitura por outros programs on-chain:** não é “ler um SPL token account”; consumidores usam prova Merkle / DAS + política off-chain. O caminho CPI `check_attestation` permanece quando acoplamento on-chain é aceitável.
+- **CU / limites de tx:** Groth16 + Light + Bubblegum na mesma instrução pode exigir `SetComputeUnitLimit` acima do default; medição: compilar com `--features hook-cu-probe` e inspecionar logs `cu-probe pre/post-bubblegum-mint` (e estágios Light) no mesmo harness ADR-022.
+- **Compatibilidade:** IDs Bubblegum / account-compression são de cluster; o program usa constantes Metaplex/SPL atuais para mainnet/devnet.
 
 ---
 
@@ -449,7 +454,7 @@ Novo ceiling operacional: **<250K CU** por proof. A transação envelopa com `Se
 
 ### Addendum — caminho `transfer_hook`
 
-O mesmo `verify_bundle` roda sob o hook do Token-2022, mas o path adiciona: (a) parse + check de extensões do `source_token` (`TransferHookAccount.transferring`), (b) Light-CPI emitindo nullifier + attestation comprimidos na mesma tx. O ceiling de 250K cobre apenas o Groth16. Hook-path total ainda não foi medido; feature `hook-cu-probe` emite `sol_log_compute_units` antes/depois do `verify_bundle` e do Light CPI. TODO: registrar o número aqui após o primeiro run do harness com fixture gnark + mint Token-2022 configurado.
+O mesmo `verify_bundle` roda sob o hook do Token-2022, mas o path adiciona: (a) parse + check de extensões do `source_token` (`TransferHookAccount.transferring`), (b) Light-CPI emitindo nullifier + attestation comprimidos na mesma tx, (c) Bubblegum `MintV1` quando `bubblegum_tail` / contas nomeadas estão presentes (ADR-019). O ceiling de 250K cobre apenas o Groth16. Hook-path + mint total ainda não foi medido de ponta a ponta; a feature `hook-cu-probe` emite `sol_log_compute_units` em `pre/post-verify_bundle`, `post-light-cpi`, e `pre/post-bubblegum-mint` (também em `verify_proof`). TODO: registrar números aqui após o primeiro run do harness com fixture gnark + mint Token-2022 + árvore Bubblegum inicializada.
 
 ---
 


### PR DESCRIPTION
Closes #16 

## Overview

This branch implements **Metaplex Bubblegum compressed NFT (cNFT) attestation minting** as a supplement to the existing **Light Protocol** compressed nullifier + `CompressedAttestation` write path. Mint runs **after** a successful Light CPI in the same transaction so failure rolls back both layers.

Work centers on:

1. One-time **concurrent Merkle tree** bootstrap + on-chain **registry PDA** so clients know which tree to target.
2. **Raw `invoke_signed` CPIs** for Bubblegum `CreateTreeConfig` / `MintV1`-compatible layouts (avoids pulling `mpl-bubblegum` into Anchor 0.31 / Solana 2.x due to SDK version skew).
3. **Named Bubblegum accounts** on `verify_proof` and `settle_hook`, plus **TLV trailing accounts** on the Token-2022 `transfer_hook` path, without shifting Light `remaining_accounts` indices used by `StagedLightArgs`.
4. **Witness / VK binding** correction for the current committed verification key (eight public inputs).
5. **Off-chain type alignment** and **documentation** updates (ADR-019, ADR-022 addendum, implementation status).
6. **Integration test harness** adjustments so default `cargo test` stays workable on Windows (heavy `light-program-test` dev-deps gated to Unix).

## Why this change

- PRD / ADR-019 called for wallet-visible attestations via standard **DAS**-backed compressed assets, not only CPI-based `check_attestation`.
- Light compressed state remains the authoritative replay and attestation record; the cNFT is an explicit **UX and integrator** primitive.
- Hook path must keep **byte indices** in `StagedLightArgs` stable; Bubblegum metas are therefore a **suffix** of extras / `remaining_accounts`, with an explicit tail length field.
- Default Windows developer machines were failing `cargo test` when `light-program-test` pulled an OpenSSL build requiring Perl; gating those dev-deps restores a clean default test story.

## Main Changes

### 1) Program entrypoints and module wiring

- `backend/programs/zksettle/src/lib.rs`
  - New instruction: `init_attestation_tree`.
  - Private `cu_probe` module backing the `hook-cu-probe` feature.
- `backend/programs/zksettle/src/instructions.rs`
  - Registers `bubblegum_mint`, `init_attestation_tree`, and re-exports `init_attestation_tree::*` for Anchor `#[program]` codegen visibility.

### 2) Tree bootstrap, registry state, and Bubblegum CPI helper

New / extended files:

- `backend/programs/zksettle/src/instructions/init_attestation_tree.rs` — creates the SPL concurrent Merkle tree account, CPIs Bubblegum `CreateTreeConfig`, initializes `BubblegumTreeRegistry`.
- `backend/programs/zksettle/src/instructions/bubblegum_mint.rs` — PDA helpers, metadata URI/name builders (content-id style URI + `ZKS-{slot}` name), account validation, `split_light_and_bubblegum`, `cpi_mint_compliance_attestation`, `cpi_mint_from_remaining_tail`.
- `backend/programs/zksettle/src/state/bubblegum_tree.rs` — `BubblegumTreeRegistry` layout + `INIT_SPACE`.
- `backend/programs/zksettle/src/state/seeds.rs` — registry and tree-creator seeds.
- `backend/programs/zksettle/src/constants.rs` — Bubblegum mint account count, tree depth/buffer sizing.
- `backend/programs/zksettle/src/error.rs` — Bubblegum-specific errors (`BubblegumTreeNotConfigured`, `BubblegumTreeMismatch`, `BubblegumCpiFailed`, `BubblegumTailInvalid`, etc.).

### 3) `verify_proof`: named Bubblegum accounts + mint after Light

- `backend/programs/zksettle/src/instructions/verify_proof/mod.rs` — adds registry, merkle tree, tree config, tree creator PDA, Bubblegum program, compression program, log wrapper, `leaf_owner` (must match `recipient`), etc.
- `backend/programs/zksettle/src/instructions/verify_proof/handler.rs` — after `LightSystemProgramCpi::invoke`, validates Bubblegum accounts against registry, runs mint CPI, then emits `ProofSettled`.

Light accounts stay in **`ctx.remaining_accounts` only**; Bubblegum accounts are **not** mixed into the Light CPI slice.

### 4) Transfer hook path: TLV tail + `settle_hook` parity

- `backend/programs/zksettle/src/instructions/transfer_hook/types.rs` — `StagedLightArgs.bubblegum_tail` (`0` or `9` trailing `MintV1` metas).
- `backend/programs/zksettle/src/instructions/transfer_hook/mod.rs` — `SettleHook` / `ExecuteHook` gain Bubblegum-related named accounts + registry; constraints align tree addresses with registry.
- `backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs` — `run_settlement` passes **only** the Light prefix into `CpiAccounts::new`; optional suffix drives `cpi_mint_from_remaining_tail` or named-account mint; CU probes (`hook-cu-probe`) around verify, Light CPI, and Bubblegum mint.
- `backend/programs/zksettle/src/instructions/transfer_hook/tests.rs` — literals updated for new `StagedLightArgs` field.

### 5) Groth16 witness / VK alignment

- `backend/programs/zksettle/src/instructions/verify_proof/bindings.rs` — public input count and binding checks match **eight** VK public inputs.
- `backend/programs/zksettle/src/instructions/verify_proof/tests.rs` — witness length and mismatch tests updated accordingly.

### 6) Dependencies

- `backend/programs/zksettle/Cargo.toml` — adds `spl-account-compression` with `cpi` feature.
- `backend/Cargo.lock` — updated for the new dependency graph.

### 7) Compute-unit probes (ADR-022 cross-link)

- `backend/programs/zksettle/src/cu_probe.rs` — shared `cu_probe!` macro.
- `hook-cu-probe` feature comment documents probes on **hook path and `verify_proof`** (`post-light-cpi`, `pre/post-bubblegum-mint`, plus existing verify-bundle stages on settlement).

### 8) Off-chain types

- `backend/crates/zksettle-types/src/accounts.rs` — `CompressedAttestation` extended to match on-chain `state/compressed.rs` (`sanctions_root`, `jurisdiction_root`, `timestamp`); `LEN` corrected to **288** bytes (borsh layout).
- `backend/crates/zksettle-types/src/events.rs` — `ProofSettled` extended to match the on-chain event (`sanctions_root`, `jurisdiction_root`, `timestamp`); documents alignment with program event ordering.

### 9) Integration tests and dev-dependencies

- `backend/programs/zksettle/Cargo.toml` — `light-program-test` and `tokio` moved under **`[target.'cfg(unix)'.dev-dependencies]`** so default Windows `cargo test` does not compile the OpenSSL-heavy stack.
- `backend/programs/zksettle/tests/light_smoke.rs` and `transfer_hook_smoke.rs` — crate-level `cfg(all(feature = "light-tests", unix))` + short runbook note for Windows/WSL.
- `backend/programs/zksettle/tests/helpers/instructions.rs` — `StagedLightArgs` initializers include `bubblegum_tail: 0`.

### 10) Documentation

- `zksettle_adr.md` — ADR-019 marked **decided / implemented**; describes order Light → Bubblegum, URI scheme, expiry (`slot + MAX_ROOT_AGE_SLOTS`), TLV tail, DAS vs on-chain verification; ADR-022 addendum mentions Bubblegum stage and probe labels.
- `IMPLEMENTATION_STATUS.md` — Bubblegum row marked done; §2.3 / §3.1 reconciled with Light + cNFT reality; drift table row updated; snapshot date bumped.

## Validation Performed

Locally (representative environment):

- `cargo check -p zksettle`
- `cargo test -p zksettle --lib` (59 unit tests)
- `cargo test -p zksettle-types`

**Note:** `cargo test -p zksettle` without `--features light-tests` runs **zero** integration tests in the `tests/*.rs` binaries on Windows by design; full harness remains `--features light-tests` on **Unix**.

## Notes / Known Limitations

- Bubblegum CPI layout is **hand-serialized** against current kinobi-style discriminators; upstream IDL drift requires careful regression testing on devnet/mainnet clusters.
- `BgMetadataArgs` uses placeholder `Option<()>` for `collection` / `uses` wire slots; confirm against live Bubblegum if metadata rejects deserialization.
- End-to-end **ignored** hook smoke still depends on future gnark + Token-2022 + Bubblegum program fixtures in the harness; this branch focuses on account wiring, split logic, and program correctness.
- Standard wallet “NFT” UX assumes **DAS**; on-chain consumers should not assume a classical SPL token account read model for the attestation cNFT.

## Suggested Follow-ups

1. Run **`--features light-tests`** on CI (Linux) with Bubblegum + account-compression programs loaded; assert mint leaf / DAS-friendly identifiers if needed.
2. Record **measured CU** deltas (Groth16 + Light + Bubblegum) via `hook-cu-probe` once a full fixture transaction exists; fold numbers into ADR-022.
3. Client / mint onboarding docs: explicit **`init_extra_account_meta_list`** TLV ordering (Light accounts first, Bubblegum metas trailing) and `bubblegum_tail` convention.
4. Optional: extend `ProofSettled` (on-chain event) with tree / asset id fields for indexers if product wants tighter correlation without DAS round-trips.
