### PR TITLE
Persist NullifierStore across restarts with RocksDB

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -917,6 +917,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cargo_toml"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1199,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1216,6 +1253,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2156,6 +2204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gnark-verifier-solana"
 version = "1.0.0"
 source = "git+https://github.com/reilabs/sunspot.git?rev=ce4765ccdf050507874bbb544be992a11dc48ffc#ce4765ccdf050507874bbb544be992a11dc48ffc"
@@ -2686,9 +2740,11 @@ dependencies = [
  "hex",
  "moka",
  "reqwest 0.12.28",
+ "rocksdb",
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -2931,6 +2987,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
 name = "libsecp256k1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2976,6 +3057,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3771,6 +3863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3844,6 +3946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +4004,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -4819,6 +4937,16 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]

--- a/backend/crates/indexer/Cargo.toml
+++ b/backend/crates/indexer/Cargo.toml
@@ -27,8 +27,10 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 moka = { version = "0.12", features = ["sync"] }
+rocksdb = "0.24"
 sha2 = "0.10"
 
 [dev-dependencies]
 axum-test = "16"
+tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/backend/crates/indexer/src/config.rs
+++ b/backend/crates/indexer/src/config.rs
@@ -8,6 +8,7 @@ pub struct Config {
     pub irys_wallet_key: Option<String>,
     pub program_id: String,
     pub log_level: String,
+    pub dedup_path: String,
     pub dedup_capacity: u64,
     pub dedup_ttl_secs: u64,
 }
@@ -21,6 +22,7 @@ impl std::fmt::Debug for Config {
             .field("irys_wallet_key", &self.irys_wallet_key.as_ref().map(|_| "[REDACTED]"))
             .field("program_id", &self.program_id)
             .field("log_level", &self.log_level)
+            .field("dedup_path", &self.dedup_path)
             .field("dedup_capacity", &self.dedup_capacity)
             .field("dedup_ttl_secs", &self.dedup_ttl_secs)
             .finish()
@@ -40,6 +42,8 @@ impl Config {
             irys_wallet_key: read_var("INDEXER_IRYS_WALLET_KEY").ok(),
             program_id: read_var("INDEXER_PROGRAM_ID")?,
             log_level: read_var("INDEXER_LOG_LEVEL").unwrap_or_else(|_| "info".into()),
+            dedup_path: read_var("INDEXER_DEDUP_PATH")
+                .unwrap_or_else(|_| "./data/dedup".into()),
             dedup_capacity: read_var("INDEXER_DEDUP_CAPACITY")
                 .unwrap_or_else(|_| "1000000".into())
                 .parse()
@@ -83,6 +87,7 @@ mod tests {
             irys_wallet_key: None,
             program_id: "test".into(),
             log_level: "info".into(),
+            dedup_path: "./data/dedup".into(),
             dedup_capacity: 1_000_000,
             dedup_ttl_secs: 86400,
         };
@@ -98,6 +103,7 @@ mod tests {
             irys_wallet_key: Some("key".into()),
             program_id: "test".into(),
             log_level: "info".into(),
+            dedup_path: "./data/dedup".into(),
             dedup_capacity: 1_000_000,
             dedup_ttl_secs: 86400,
         };

--- a/backend/crates/indexer/src/dedup.rs
+++ b/backend/crates/indexer/src/dedup.rs
@@ -1,27 +1,87 @@
+use std::path::Path;
 use std::time::Duration;
 
 use moka::sync::Cache;
+use rocksdb::{Options, DB};
+
+use crate::error::IndexerError;
 
 pub struct NullifierStore {
-    seen: Cache<[u8; 32], ()>,
+    cache: Cache<[u8; 32], ()>,
+    db: DB,
 }
 
 impl NullifierStore {
-    pub fn new(capacity: u64, ttl: Duration) -> Self {
-        Self {
-            seen: Cache::builder()
-                .max_capacity(capacity)
-                .time_to_live(ttl)
-                .build(),
+    pub fn open(path: &Path, capacity: u64, ttl: Duration) -> Result<Self, IndexerError> {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
+
+        let db = DB::open(&opts, path).map_err(|e| {
+            IndexerError::Config(format!("failed to open dedup database at {}: {e}", path.display()))
+        })?;
+
+        let cache: Cache<[u8; 32], ()> = Cache::builder()
+            .max_capacity(capacity)
+            .time_to_live(ttl)
+            .build();
+
+        let start = std::time::Instant::now();
+        let iter = db.iterator(rocksdb::IteratorMode::Start);
+        let mut warmed = 0u64;
+        let mut skipped = 0u64;
+        for item in iter {
+            let (key, _) = item.map_err(|e| {
+                IndexerError::Config(format!("failed reading dedup db during warmup: {e}"))
+            })?;
+            if key.len() == 32 {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&key);
+                cache.insert(arr, ());
+                warmed += 1;
+                if warmed >= capacity {
+                    break;
+                }
+            } else {
+                skipped += 1;
+                tracing::warn!(key_len = key.len(), "unexpected key size in dedup db, skipping");
+            }
         }
+
+        tracing::info!(warmed, skipped, elapsed_ms = start.elapsed().as_millis() as u64, "dedup store opened");
+
+        Ok(Self { cache, db })
     }
 
-    pub fn mark_uploaded(&self, nullifier: &[u8; 32]) {
-        self.seen.insert(*nullifier, ());
+    pub fn mark_uploaded(&self, nullifier: &[u8; 32]) -> Result<(), IndexerError> {
+        self.db.put(nullifier, b"").map_err(|e| {
+            IndexerError::DedupWrite(format!("failed to persist nullifier: {e}"))
+        })?;
+        self.cache.insert(*nullifier, ());
+        Ok(())
     }
 
     pub fn contains(&self, nullifier: &[u8; 32]) -> bool {
-        self.seen.contains_key(nullifier)
+        if self.cache.contains_key(nullifier) {
+            return true;
+        }
+        match self.db.get_pinned(nullifier) {
+            Ok(Some(_)) => {
+                self.cache.insert(*nullifier, ());
+                true
+            }
+            Ok(None) => false,
+            Err(e) => {
+                tracing::warn!(error = %e, "dedup db read failed, treating as not-found");
+                false
+            }
+        }
+    }
+
+    pub fn flush(&self) -> Result<(), IndexerError> {
+        self.db.flush().map_err(|e| {
+            IndexerError::DedupWrite(format!("failed to flush dedup db: {e}"))
+        })
     }
 }
 
@@ -29,24 +89,60 @@ impl NullifierStore {
 mod tests {
     use super::*;
 
-    fn test_store() -> NullifierStore {
-        NullifierStore::new(1_000, Duration::from_secs(3600))
+    fn test_store(dir: &Path) -> NullifierStore {
+        NullifierStore::open(dir, 1_000, Duration::from_secs(3600)).unwrap()
     }
 
     #[test]
     fn mark_uploaded_then_contains() {
-        let store = test_store();
+        let tmp = tempfile::tempdir().unwrap();
+        let store = test_store(tmp.path());
         let n = [1u8; 32];
         assert!(!store.contains(&n));
-        store.mark_uploaded(&n);
+        store.mark_uploaded(&n).unwrap();
         assert!(store.contains(&n));
     }
 
     #[test]
     fn duplicate_mark_is_idempotent() {
-        let store = test_store();
-        store.mark_uploaded(&[2u8; 32]);
-        store.mark_uploaded(&[2u8; 32]);
+        let tmp = tempfile::tempdir().unwrap();
+        let store = test_store(tmp.path());
+        store.mark_uploaded(&[2u8; 32]).unwrap();
+        store.mark_uploaded(&[2u8; 32]).unwrap();
         assert!(store.contains(&[2u8; 32]));
+    }
+
+    #[test]
+    fn persists_across_reopen() {
+        let tmp = tempfile::tempdir().unwrap();
+        let n = [3u8; 32];
+
+        {
+            let store = test_store(tmp.path());
+            store.mark_uploaded(&n).unwrap();
+            assert!(store.contains(&n));
+        }
+
+        let store = test_store(tmp.path());
+        assert!(store.contains(&n), "nullifier should survive reopen");
+    }
+
+    #[test]
+    fn cache_miss_falls_back_to_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let n = [4u8; 32];
+
+        // Write with capacity=1 so cache evicts fast
+        let store = NullifierStore::open(tmp.path(), 1, Duration::from_secs(1)).unwrap();
+        store.mark_uploaded(&n).unwrap();
+
+        // Evict from cache by inserting another key and invalidating
+        store.cache.invalidate_all();
+        store.cache.run_pending_tasks();
+        assert!(!store.cache.contains_key(&n), "cache should be empty after invalidation");
+
+        // contains should hit disk and re-warm cache
+        assert!(store.contains(&n), "should find nullifier on disk after cache miss");
+        assert!(store.cache.contains_key(&n), "cache should be warm after disk hit");
     }
 }

--- a/backend/crates/indexer/src/error.rs
+++ b/backend/crates/indexer/src/error.rs
@@ -26,6 +26,9 @@ pub enum IndexerError {
     #[error("irys upload failed: {0}")]
     IrysUpload(String),
 
+    #[error("dedup write failed: {0}")]
+    DedupWrite(String),
+
     #[error("configuration error: {0}")]
     Config(String),
 
@@ -37,7 +40,7 @@ impl IntoResponse for IndexerError {
     fn into_response(self) -> Response {
         let status = match &self {
             Self::Unauthorized => StatusCode::UNAUTHORIZED,
-            Self::Config(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Config(_) | Self::DedupWrite(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::IrysUpload(_) => StatusCode::BAD_GATEWAY,
             Self::Base64Decode(_)
             | Self::BorshDeserialize(_)

--- a/backend/crates/indexer/src/lib.rs
+++ b/backend/crates/indexer/src/lib.rs
@@ -30,7 +30,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
 }
 
 #[cfg(test)]
-pub fn test_app() -> Router {
+pub fn test_app() -> (Router, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("failed to create tempdir for test dedup store");
     let config = Config {
         port: 3000,
         helius_auth_token: "test-token".into(),
@@ -38,15 +39,18 @@ pub fn test_app() -> Router {
         irys_wallet_key: None,
         program_id: "11111111111111111111111111111111".into(),
         log_level: "error".into(),
+        dedup_path: tmp.path().to_string_lossy().into_owned(),
         dedup_capacity: 1_000_000,
         dedup_ttl_secs: 86400,
     };
     let http = reqwest::Client::new();
     let irys = IrysClient::new(config.irys_node_url.clone(), None, http);
+    let dedup = NullifierStore::open(tmp.path(), 1_000_000, std::time::Duration::from_secs(86400))
+        .expect("failed to open test dedup store");
     let state = Arc::new(AppState {
         config,
         irys,
-        dedup: NullifierStore::new(1_000_000, std::time::Duration::from_secs(86400)),
+        dedup,
     });
-    build_router(state)
+    (build_router(state), tmp)
 }

--- a/backend/crates/indexer/src/main.rs
+++ b/backend/crates/indexer/src/main.rs
@@ -33,19 +33,36 @@ async fn main() -> anyhow::Result<()> {
         http,
     );
 
+    let dedup_path = std::path::Path::new(&config.dedup_path);
+    std::fs::create_dir_all(dedup_path).context("creating dedup directory")?;
+    let dedup = NullifierStore::open(
+        dedup_path,
+        config.dedup_capacity,
+        std::time::Duration::from_secs(config.dedup_ttl_secs),
+    )
+    .context("opening dedup store")?;
+
     let state = Arc::new(AppState {
         config: config.clone(),
         irys,
-        dedup: NullifierStore::new(
-            config.dedup_capacity,
-            std::time::Duration::from_secs(config.dedup_ttl_secs),
-        ),
+        dedup,
     });
 
     let addr = format!("0.0.0.0:{}", config.port);
     let listener = TcpListener::bind(&addr).await?;
     info!(%addr, dry_run = config.is_dry_run(), "indexer starting");
 
-    axum::serve(listener, build_router(state)).await?;
+    let server = axum::serve(listener, build_router(state.clone()));
+
+    tokio::select! {
+        result = server => { result?; }
+        _ = tokio::signal::ctrl_c() => {
+            info!("shutdown signal received, flushing dedup store");
+            if let Err(e) = state.dedup.flush() {
+                tracing::error!(error = %e, "failed to flush dedup store on shutdown");
+            }
+        }
+    }
+
     Ok(())
 }

--- a/backend/crates/indexer/src/routes/webhook.rs
+++ b/backend/crates/indexer/src/routes/webhook.rs
@@ -42,7 +42,16 @@ pub async fn handle_webhook(
 
             match state.irys.upload(event).await {
                 Ok(_) => {
-                    state.dedup.mark_uploaded(&event.nullifier_hash);
+                    // Upload succeeded but if dedup write fails, this nullifier won't
+                    // be deduplicated on restart — may cause a duplicate Irys upload.
+                    // Acceptable: Irys uploads are idempotent by content hash.
+                    if let Err(e) = state.dedup.mark_uploaded(&event.nullifier_hash) {
+                        error!(
+                            nullifier = hex::encode(event.nullifier_hash),
+                            error = %e,
+                            "failed to persist nullifier after successful upload"
+                        );
+                    }
                 }
                 Err(e) => {
                     error!(
@@ -76,7 +85,7 @@ mod tests {
 
     #[tokio::test]
     async fn missing_auth_returns_401() {
-        let app = test_app();
+        let (app, _tmp) = test_app();
         let resp = app
             .oneshot(
                 Request::builder()
@@ -93,7 +102,7 @@ mod tests {
 
     #[tokio::test]
     async fn valid_empty_batch_returns_200() {
-        let app = test_app();
+        let (app, _tmp) = test_app();
         let resp = app
             .oneshot(
                 Request::builder()
@@ -111,7 +120,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_json_returns_422() {
-        let app = test_app();
+        let (app, _tmp) = test_app();
         let resp = app
             .oneshot(
                 Request::builder()
@@ -130,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_returns_200() {
-        let app = test_app();
+        let (app, _tmp) = test_app();
         let resp = app
             .oneshot(
                 Request::builder()
@@ -146,7 +155,7 @@ mod tests {
 
     #[tokio::test]
     async fn webhook_with_no_events_returns_200() {
-        let app = test_app();
+        let (app, _tmp) = test_app();
         let payload = serde_json::json!([{
             "signature": "abc123",
             "slot": 100,
@@ -208,7 +217,7 @@ mod tests {
         }]);
         let body = serde_json::to_string(&payload).unwrap();
 
-        let app = test_app();
+        let (app, _tmp) = test_app();
 
         // First request
         let resp = app


### PR DESCRIPTION
Replace pure-moka in-memory cache with a two-layer design: RocksDB for durable persistence, moka as hot-path cache in front. On startup, the cache is warmed from persisted keys so dedup state survives restarts.

- mark_uploaded writes to both RocksDB and cache, propagates errors
- contains checks cache first, falls back to disk on miss
- Graceful shutdown flushes RocksDB via ctrl_c handler
- Add DedupWrite error variant, INDEXER_DEDUP_PATH config field

Closes #44