### PR TITLE
Scaffold api-gateway crate with auth, rate limiting, and proxy

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -374,6 +374,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "api-gateway"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.9",
+ "dashmap",
+ "governor",
+ "hex",
+ "http-body-util",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "zksettle-types",
+]
+
+[[package]]
 name = "ark-bn254"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1654,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,6 +2152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,6 +2272,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "groth16-solana"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2297,6 +2364,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -4007,6 +4080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,6 +4094,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -4530,6 +4615,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,6 +4810,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -8011,6 +8120,15 @@ dependencies = [
  "subtle",
  "thiserror 2.0.18",
  "zeroize",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/backend/crates/api-gateway/Cargo.toml
+++ b/backend/crates/api-gateway/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "api-gateway"
+version = "0.1.0"
+edition = "2021"
+description = "API gateway: auth, rate limiting, metering, and proxy to issuer-service"
+license = "Apache-2.0 OR MIT"
+
+[[bin]]
+name = "api-gateway"
+path = "src/main.rs"
+
+[dependencies]
+zksettle-types = { path = "../zksettle-types" }
+axum = { version = "0.8", features = ["macros"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["trace"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+thiserror = "2"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+hex = "0.4"
+governor = "0.8"
+dashmap = "6"
+rand = "0.9"
+sha2 = "0.10"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/backend/crates/api-gateway/src/auth.rs
+++ b/backend/crates/api-gateway/src/auth.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use zksettle_types::gateway::ApiKeyRecord;
+
+use crate::error::GatewayError;
+use crate::key_store::hash_key;
+use crate::AppState;
+
+pub struct AuthenticatedKey(pub ApiKeyRecord);
+
+impl FromRequestParts<Arc<AppState>> for AuthenticatedKey {
+    type Rejection = GatewayError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let header = parts
+            .headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .ok_or(GatewayError::Unauthorized)?;
+
+        let token = header
+            .strip_prefix("Bearer ")
+            .ok_or(GatewayError::Unauthorized)?;
+
+        if token.is_empty() {
+            return Err(GatewayError::Unauthorized);
+        }
+
+        let hash = hash_key(token);
+        let record = state
+            .keys
+            .lookup_by_hash(&hash)
+            .ok_or(GatewayError::KeyNotFound)?;
+
+        Ok(AuthenticatedKey(record))
+    }
+}

--- a/backend/crates/api-gateway/src/config.rs
+++ b/backend/crates/api-gateway/src/config.rs
@@ -1,0 +1,58 @@
+use crate::error::GatewayError;
+
+#[derive(Clone)]
+pub struct Config {
+    pub port: u16,
+    pub upstream_url: String,
+    pub log_level: String,
+    pub admin_key: Option<String>,
+    pub allow_open_keys: bool,
+}
+
+impl std::fmt::Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Config")
+            .field("port", &self.port)
+            .field("upstream_url", &self.upstream_url)
+            .field("log_level", &self.log_level)
+            .field("admin_key", &self.admin_key.as_ref().map(|_| "[REDACTED]"))
+            .field("allow_open_keys", &self.allow_open_keys)
+            .finish()
+    }
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, GatewayError> {
+        Ok(Self {
+            port: read_var("GATEWAY_PORT")
+                .unwrap_or_else(|_| "4000".into())
+                .parse()
+                .map_err(|_| GatewayError::Config("GATEWAY_PORT must be a valid u16".into()))?,
+            upstream_url: read_var("GATEWAY_UPSTREAM_URL")?,
+            log_level: read_var("GATEWAY_LOG_LEVEL").unwrap_or_else(|_| "info".into()),
+            admin_key: read_var("GATEWAY_ADMIN_KEY").ok(),
+            allow_open_keys: read_var("GATEWAY_ALLOW_OPEN_KEYS")
+                .map(|v| v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false),
+        })
+    }
+}
+
+fn read_var(name: &str) -> Result<String, GatewayError> {
+    std::env::var(name)
+        .map_err(|_| GatewayError::Config(format!("missing required env var: {name}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_var_missing_reports_name() {
+        let err = read_var("GATEWAY_DOES_NOT_EXIST_TEST").unwrap_err();
+        assert!(
+            err.to_string().contains("GATEWAY_DOES_NOT_EXIST_TEST"),
+            "error should name the var"
+        );
+    }
+}

--- a/backend/crates/api-gateway/src/error.rs
+++ b/backend/crates/api-gateway/src/error.rs
@@ -1,0 +1,50 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum GatewayError {
+    #[error("missing or invalid Authorization header")]
+    Unauthorized,
+
+    #[error("api key not found")]
+    KeyNotFound,
+
+    #[error("rate limit exceeded")]
+    RateLimited,
+
+    #[error("monthly quota exhausted")]
+    QuotaExhausted,
+
+    #[error("upstream request failed: {0}")]
+    Upstream(String),
+
+    #[error("forbidden")]
+    Forbidden,
+
+    #[error("configuration error: {0}")]
+    Config(String),
+}
+
+#[derive(Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+impl IntoResponse for GatewayError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            Self::Unauthorized | Self::KeyNotFound => StatusCode::UNAUTHORIZED,
+            Self::RateLimited | Self::QuotaExhausted => StatusCode::TOO_MANY_REQUESTS,
+            Self::Forbidden => StatusCode::FORBIDDEN,
+            Self::Upstream(_) => StatusCode::BAD_GATEWAY,
+            Self::Config(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let body = ErrorBody {
+            error: self.to_string(),
+        };
+        (status, axum::Json(body)).into_response()
+    }
+}

--- a/backend/crates/api-gateway/src/key_store.rs
+++ b/backend/crates/api-gateway/src/key_store.rs
@@ -1,0 +1,94 @@
+use dashmap::DashMap;
+use sha2::{Digest, Sha256};
+use zksettle_types::gateway::{ApiKeyRecord, Tier};
+
+#[derive(Default)]
+pub struct KeyStore {
+    keys: DashMap<String, ApiKeyRecord>,
+}
+
+impl KeyStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&self, raw_key: &str, owner: String, tier: Tier, created_at: u64) {
+        let hash = hash_key(raw_key);
+        self.keys.insert(
+            hash.clone(),
+            ApiKeyRecord {
+                key_hash: hash,
+                tier,
+                owner,
+                created_at,
+            },
+        );
+    }
+
+    pub fn lookup(&self, raw_key: &str) -> Option<ApiKeyRecord> {
+        let hash = hash_key(raw_key);
+        self.keys.get(&hash).map(|r| r.clone())
+    }
+
+    pub fn lookup_by_hash(&self, key_hash: &str) -> Option<ApiKeyRecord> {
+        self.keys.get(key_hash).map(|r| r.clone())
+    }
+
+    pub fn remove(&self, raw_key: &str) -> bool {
+        let hash = hash_key(raw_key);
+        self.keys.remove(&hash).is_some()
+    }
+}
+
+pub fn hash_key(raw: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(raw.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+pub fn generate_key() -> String {
+    use rand::Rng;
+    let bytes: [u8; 32] = rand::rng().random();
+    format!("zks_{}", hex::encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_lookup() {
+        let store = KeyStore::new();
+        store.insert("test-key", "alice".into(), Tier::Developer, 1000);
+        let record = store.lookup("test-key").unwrap();
+        assert_eq!(record.owner, "alice");
+        assert_eq!(record.tier, Tier::Developer);
+    }
+
+    #[test]
+    fn lookup_missing_returns_none() {
+        let store = KeyStore::new();
+        assert!(store.lookup("nonexistent").is_none());
+    }
+
+    #[test]
+    fn remove_key() {
+        let store = KeyStore::new();
+        store.insert("key", "bob".into(), Tier::Startup, 2000);
+        assert!(store.remove("key"));
+        assert!(store.lookup("key").is_none());
+    }
+
+    #[test]
+    fn generated_key_has_prefix() {
+        let key = generate_key();
+        assert!(key.starts_with("zks_"));
+        assert_eq!(key.len(), 4 + 64); // "zks_" + 32 bytes hex
+    }
+
+    #[test]
+    fn hash_is_deterministic() {
+        assert_eq!(hash_key("abc"), hash_key("abc"));
+        assert_ne!(hash_key("abc"), hash_key("def"));
+    }
+}

--- a/backend/crates/api-gateway/src/lib.rs
+++ b/backend/crates/api-gateway/src/lib.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+
+use axum::routing::{any, get, post};
+use axum::Router;
+use tower_http::trace::TraceLayer;
+
+pub mod auth;
+pub mod config;
+pub mod error;
+pub mod key_store;
+pub mod metering;
+pub mod proxy;
+pub mod rate_limit;
+pub mod routes;
+
+use config::Config;
+use key_store::KeyStore;
+use metering::Metering;
+use rate_limit::RateLimitStore;
+
+pub struct AppState {
+    pub config: Config,
+    pub keys: KeyStore,
+    pub metering: Metering,
+    pub rate_limiter: RateLimitStore,
+    pub http: reqwest::Client,
+}
+
+pub fn build_router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/health", get(routes::health::health))
+        .route("/api-keys", post(routes::keys::create_key))
+        .route("/usage", get(routes::usage::get_usage))
+        .route("/v1/{*path}", any(proxy::proxy_to_upstream))
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}
+
+#[cfg(test)]
+pub fn test_state() -> Arc<AppState> {
+    let config = Config {
+        port: 4000,
+        upstream_url: "http://localhost:0".into(),
+        log_level: "error".into(),
+        admin_key: None,
+        allow_open_keys: true,
+    };
+    Arc::new(AppState {
+        config,
+        keys: KeyStore::new(),
+        metering: Metering::new(),
+        rate_limiter: RateLimitStore::new(),
+        http: reqwest::Client::new(),
+    })
+}
+
+#[cfg(test)]
+pub fn test_app() -> Router {
+    build_router(test_state())
+}

--- a/backend/crates/api-gateway/src/main.rs
+++ b/backend/crates/api-gateway/src/main.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use anyhow::Context;
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+use api_gateway::config::Config;
+use api_gateway::key_store::KeyStore;
+use api_gateway::metering::Metering;
+use api_gateway::rate_limit::RateLimitStore;
+use api_gateway::{build_router, AppState};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = Config::from_env().context("loading config")?;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new(&config.log_level)),
+        )
+        .json()
+        .init();
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .build()
+        .context("building http client")?;
+
+    let state = Arc::new(AppState {
+        config: config.clone(),
+        keys: KeyStore::new(),
+        metering: Metering::new(),
+        rate_limiter: RateLimitStore::new(),
+        http,
+    });
+
+    if config.admin_key.is_none() {
+        if config.allow_open_keys {
+            warn!("GATEWAY_ADMIN_KEY not set and GATEWAY_ALLOW_OPEN_KEYS=true: key provisioning is open to anyone");
+        } else {
+            info!("GATEWAY_ADMIN_KEY not set: key provisioning disabled (set GATEWAY_ALLOW_OPEN_KEYS=true to allow open access)");
+        }
+    }
+
+    let addr = format!("0.0.0.0:{}", config.port);
+    let listener = TcpListener::bind(&addr).await?;
+    info!(%addr, "api-gateway starting");
+
+    axum::serve(listener, build_router(state)).await?;
+
+    Ok(())
+}

--- a/backend/crates/api-gateway/src/metering.rs
+++ b/backend/crates/api-gateway/src/metering.rs
@@ -1,0 +1,89 @@
+use dashmap::DashMap;
+use zksettle_types::gateway::UsageRecord;
+
+const PERIOD_SECS: u64 = 30 * 24 * 60 * 60; // 30 days
+
+#[derive(Default)]
+pub struct Metering {
+    usage: DashMap<String, UsageRecord>,
+}
+
+impl Metering {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn increment(&self, key_hash: &str, now: u64) {
+        self.usage
+            .entry(key_hash.to_owned())
+            .and_modify(|u| {
+                if now - u.period_start >= PERIOD_SECS {
+                    u.request_count = 1;
+                    u.period_start = now;
+                } else {
+                    u.request_count += 1;
+                }
+                u.last_request = now;
+            })
+            .or_insert_with(|| {
+                let mut r = UsageRecord::new(now);
+                r.request_count = 1;
+                r
+            });
+    }
+
+    pub fn get(&self, key_hash: &str, now: u64) -> UsageRecord {
+        match self.usage.get(key_hash) {
+            Some(u) => {
+                let u = u.clone();
+                if now - u.period_start >= PERIOD_SECS {
+                    UsageRecord::new(now)
+                } else {
+                    u
+                }
+            }
+            None => UsageRecord::new(now),
+        }
+    }
+
+    pub fn current_count(&self, key_hash: &str, now: u64) -> u64 {
+        self.get(key_hash, now).request_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn increment_from_zero() {
+        let m = Metering::new();
+        m.increment("k1", 1000);
+        assert_eq!(m.current_count("k1", 1000), 1);
+    }
+
+    #[test]
+    fn increment_accumulates() {
+        let m = Metering::new();
+        m.increment("k1", 1000);
+        m.increment("k1", 1001);
+        m.increment("k1", 1002);
+        assert_eq!(m.current_count("k1", 1002), 3);
+    }
+
+    #[test]
+    fn period_rollover_resets_count() {
+        let m = Metering::new();
+        m.increment("k1", 1000);
+        m.increment("k1", 1001);
+        let after_period = 1000 + PERIOD_SECS + 1;
+        m.increment("k1", after_period);
+        assert_eq!(m.current_count("k1", after_period), 1);
+    }
+
+    #[test]
+    fn get_unknown_key_returns_zero() {
+        let m = Metering::new();
+        assert_eq!(m.current_count("unknown", 5000), 0);
+    }
+}

--- a/backend/crates/api-gateway/src/proxy.rs
+++ b/backend/crates/api-gateway/src/proxy.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::body::Body;
+use axum::extract::{Request, State};
+use axum::http::{HeaderMap, HeaderName, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::auth::AuthenticatedKey;
+use crate::error::GatewayError;
+use crate::AppState;
+
+const HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+    "authorization",
+];
+
+fn is_hop_by_hop(name: &str) -> bool {
+    HOP_BY_HOP.iter().any(|h| h.eq_ignore_ascii_case(name))
+}
+
+pub async fn proxy_to_upstream(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedKey(record): AuthenticatedKey,
+    req: Request,
+) -> Result<Response, GatewayError> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let current = state.metering.current_count(&record.key_hash, now);
+    if current >= record.tier.monthly_limit() {
+        return Err(GatewayError::QuotaExhausted);
+    }
+
+    if !state.rate_limiter.check(&record.key_hash, record.tier) {
+        return Err(GatewayError::RateLimited);
+    }
+
+    let method = req.method().clone();
+    let req_headers = req.headers().clone();
+    let path = req
+        .uri()
+        .path()
+        .strip_prefix("/v1")
+        .unwrap_or(req.uri().path());
+    let query = req
+        .uri()
+        .query()
+        .map(|q| format!("?{q}"))
+        .unwrap_or_default();
+    let url = format!("{}{path}{query}", state.config.upstream_url);
+
+    let body_bytes = axum::body::to_bytes(req.into_body(), 1024 * 1024)
+        .await
+        .map_err(|e| GatewayError::Upstream(e.to_string()))?;
+
+    let mut upstream_req = state.http.request(method, &url);
+    for (name, value) in &req_headers {
+        if !is_hop_by_hop(name.as_str()) {
+            upstream_req = upstream_req.header(name.as_str(), value);
+        }
+    }
+
+    let upstream_resp = upstream_req
+        .body(body_bytes)
+        .send()
+        .await
+        .map_err(|e| GatewayError::Upstream(e.to_string()))?;
+
+    let status = StatusCode::from_u16(upstream_resp.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+    if status.is_success() || status.is_redirection() {
+        state.metering.increment(&record.key_hash, now);
+    }
+
+    let mut resp_headers = HeaderMap::new();
+    for (name, value) in upstream_resp.headers() {
+        if !is_hop_by_hop(name.as_str()) {
+            if let Ok(header_name) = HeaderName::from_bytes(name.as_str().as_bytes()) {
+                resp_headers.append(header_name, value.clone());
+            }
+        }
+    }
+
+    let resp_bytes = upstream_resp
+        .bytes()
+        .await
+        .map_err(|e| GatewayError::Upstream(e.to_string()))?;
+
+    Ok((status, resp_headers, Body::from(resp_bytes)).into_response())
+}

--- a/backend/crates/api-gateway/src/rate_limit.rs
+++ b/backend/crates/api-gateway/src/rate_limit.rs
@@ -1,0 +1,71 @@
+use std::num::NonZeroU32;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use governor::clock::DefaultClock;
+use governor::state::{InMemoryState, NotKeyed};
+use governor::{Quota, RateLimiter};
+use zksettle_types::gateway::Tier;
+
+type Limiter = RateLimiter<NotKeyed, InMemoryState, DefaultClock>;
+
+#[derive(Default)]
+pub struct RateLimitStore {
+    limiters: DashMap<String, Arc<Limiter>>,
+}
+
+impl RateLimitStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn check(&self, key_hash: &str, tier: Tier) -> bool {
+        let compound_key = format!("{key_hash}:{tier}");
+        let limiter = self
+            .limiters
+            .entry(compound_key)
+            .or_insert_with(|| Arc::new(build_limiter(tier)))
+            .clone();
+        limiter.check().is_ok()
+    }
+}
+
+fn build_limiter(tier: Tier) -> Limiter {
+    let per_second = match tier {
+        Tier::Developer => 1,
+        Tier::Startup => 10,
+        Tier::Growth => 50,
+        Tier::Enterprise => 200,
+    };
+    let quota = Quota::per_second(NonZeroU32::new(per_second).unwrap());
+    RateLimiter::direct(quota)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_within_limit() {
+        let store = RateLimitStore::new();
+        assert!(store.check("k1", Tier::Developer));
+    }
+
+    #[test]
+    fn blocks_after_burst() {
+        let store = RateLimitStore::new();
+        // Developer tier: 1/sec, burst of 1
+        let first = store.check("k1", Tier::Developer);
+        assert!(first);
+        // Rapid second call should be blocked
+        let second = store.check("k1", Tier::Developer);
+        assert!(!second);
+    }
+
+    #[test]
+    fn separate_keys_independent() {
+        let store = RateLimitStore::new();
+        assert!(store.check("k1", Tier::Developer));
+        assert!(store.check("k2", Tier::Developer));
+    }
+}

--- a/backend/crates/api-gateway/src/routes/health.rs
+++ b/backend/crates/api-gateway/src/routes/health.rs
@@ -1,0 +1,15 @@
+use axum::Json;
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct HealthResponse {
+    status: &'static str,
+    version: &'static str,
+}
+
+pub async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}

--- a/backend/crates/api-gateway/src/routes/keys.rs
+++ b/backend/crates/api-gateway/src/routes/keys.rs
@@ -1,0 +1,185 @@
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use zksettle_types::gateway::Tier;
+
+use crate::error::GatewayError;
+use crate::key_store::generate_key;
+use crate::AppState;
+
+#[derive(Deserialize)]
+pub struct CreateKeyRequest {
+    pub owner: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CreateKeyResponse {
+    pub api_key: String,
+    pub tier: Tier,
+    pub owner: String,
+}
+
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    let a_hash = Sha256::digest(a.as_bytes());
+    let b_hash = Sha256::digest(b.as_bytes());
+    a_hash == b_hash
+}
+
+pub async fn create_key(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<CreateKeyRequest>,
+) -> Result<Json<CreateKeyResponse>, GatewayError> {
+    if let Some(ref admin_key) = state.config.admin_key {
+        let provided = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .ok_or(GatewayError::Forbidden)?;
+
+        if !constant_time_eq(provided, admin_key) {
+            return Err(GatewayError::Forbidden);
+        }
+    } else if !state.config.allow_open_keys {
+        return Err(GatewayError::Config(
+            "key provisioning disabled: set GATEWAY_ADMIN_KEY or GATEWAY_ALLOW_OPEN_KEYS=true"
+                .into(),
+        ));
+    }
+
+    let raw_key = generate_key();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    state
+        .keys
+        .insert(&raw_key, body.owner.clone(), Tier::Developer, now);
+
+    Ok(Json(CreateKeyResponse {
+        api_key: raw_key,
+        tier: Tier::Developer,
+        owner: body.owner,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use crate::config::Config;
+    use crate::key_store::KeyStore;
+    use crate::metering::Metering;
+    use crate::rate_limit::RateLimitStore;
+    use crate::{build_router, test_app, AppState};
+
+    #[tokio::test]
+    async fn create_key_no_admin_key_configured_allows_open() {
+        let app = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api-keys")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"owner":"alice"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let body: CreateKeyResponse = serde_json::from_slice(&bytes).unwrap();
+        assert!(body.api_key.starts_with("zks_"));
+        assert_eq!(body.tier, Tier::Developer);
+        assert_eq!(body.owner, "alice");
+    }
+
+    fn app_with_admin_key() -> axum::Router {
+        let config = Config {
+            port: 4000,
+            upstream_url: "http://localhost:0".into(),
+            log_level: "error".into(),
+            admin_key: Some("secret-admin".into()),
+            allow_open_keys: false,
+        };
+        let state = Arc::new(AppState {
+            config,
+            keys: KeyStore::new(),
+            metering: Metering::new(),
+            rate_limiter: RateLimitStore::new(),
+            http: reqwest::Client::new(),
+        });
+        build_router(state)
+    }
+
+    #[tokio::test]
+    async fn create_key_rejects_without_admin_auth() {
+        let app = app_with_admin_key();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api-keys")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"owner":"alice"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 403);
+    }
+
+    #[tokio::test]
+    async fn create_key_rejects_wrong_admin_key() {
+        let app = app_with_admin_key();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api-keys")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer wrong-key")
+                    .body(Body::from(r#"{"owner":"alice"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 403);
+    }
+
+    #[tokio::test]
+    async fn create_key_accepts_correct_admin_key() {
+        let app = app_with_admin_key();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api-keys")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer secret-admin")
+                    .body(Body::from(r#"{"owner":"alice"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let body: CreateKeyResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body.owner, "alice");
+    }
+}

--- a/backend/crates/api-gateway/src/routes/mod.rs
+++ b/backend/crates/api-gateway/src/routes/mod.rs
@@ -1,0 +1,3 @@
+pub mod health;
+pub mod keys;
+pub mod usage;

--- a/backend/crates/api-gateway/src/routes/usage.rs
+++ b/backend/crates/api-gateway/src/routes/usage.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use zksettle_types::gateway::{Tier, UsageRecord};
+
+use crate::auth::AuthenticatedKey;
+use crate::AppState;
+
+#[derive(Serialize, Deserialize)]
+pub struct UsageResponse {
+    pub tier: Tier,
+    pub monthly_limit: u64,
+    pub usage: UsageRecord,
+}
+
+pub async fn get_usage(
+    State(state): State<Arc<AppState>>,
+    AuthenticatedKey(record): AuthenticatedKey,
+) -> Json<UsageResponse> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let usage = state.metering.get(&record.key_hash, now);
+
+    Json(UsageResponse {
+        tier: record.tier,
+        monthly_limit: record.tier.monthly_limit(),
+        usage,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use crate::{build_router, test_state};
+
+    #[tokio::test]
+    async fn usage_requires_auth() {
+        let state = test_state();
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/usage")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 401);
+    }
+
+    #[tokio::test]
+    async fn usage_returns_zero_for_new_key() {
+        let state = test_state();
+
+        // Insert key directly via state
+        let raw_key = "test-key-for-usage";
+        state
+            .keys
+            .insert(raw_key, "bob".into(), Tier::Developer, 1000);
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/usage")
+                    .header("authorization", format!("Bearer {raw_key}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let body: UsageResponse = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body.usage.request_count, 0);
+        assert_eq!(body.tier, Tier::Developer);
+    }
+}

--- a/backend/crates/zksettle-types/src/gateway.rs
+++ b/backend/crates/zksettle-types/src/gateway.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Tier {
+    Developer,
+    Startup,
+    Growth,
+    Enterprise,
+}
+
+impl Tier {
+    pub fn monthly_limit(self) -> u64 {
+        match self {
+            Self::Developer => 1_000,
+            Self::Startup => 10_000,
+            Self::Growth => 100_000,
+            Self::Enterprise => 1_000_000,
+        }
+    }
+
+    pub fn price_cents(self) -> u64 {
+        match self {
+            Self::Developer => 0,
+            Self::Startup => 4_900,
+            Self::Growth => 19_900,
+            Self::Enterprise => 49_900,
+        }
+    }
+}
+
+impl std::fmt::Display for Tier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Developer => write!(f, "developer"),
+            Self::Startup => write!(f, "startup"),
+            Self::Growth => write!(f, "growth"),
+            Self::Enterprise => write!(f, "enterprise"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyRecord {
+    pub key_hash: String,
+    pub tier: Tier,
+    pub owner: String,
+    pub created_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageRecord {
+    pub request_count: u64,
+    pub period_start: u64,
+    pub last_request: u64,
+}
+
+impl UsageRecord {
+    pub fn new(now: u64) -> Self {
+        Self {
+            request_count: 0,
+            period_start: now,
+            last_request: now,
+        }
+    }
+}

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -2,12 +2,14 @@ pub mod accounts;
 pub mod credential;
 pub mod error;
 pub mod events;
+pub mod gateway;
 pub mod policy;
 
 pub use accounts::{CompressedAttestation, CompressedNullifier, Issuer};
 pub use credential::{Credential, CredentialCommitment};
 pub use error::ZksettleError;
 pub use events::{AttestationChecked, ProofSettled};
+pub use gateway::{ApiKeyRecord, Tier, UsageRecord};
 pub use policy::Policy;
 
 pub type Pubkey = [u8; 32];


### PR DESCRIPTION
Problem

ADR-008 specifies pay-per-proof pricing with volume tiers, but we have no code enforcing any of it. The issuer-service is completely open right now. Anyone can send unlimited requests,
there's no auth, no usage tracking, no rate limiting. This crate is how the protocol starts charging money.

What this PR does

New api-gateway crate that reverse-proxies to the issuer-service, adding auth, metering, and rate limiting along the way.

Shared types added to zksettle-types:
- Tier enum (Developer / Startup / Growth / Enterprise) with monthly_limit() and price_cents()
- ApiKeyRecord and UsageRecord structs

New crate at backend/crates/api-gateway/:
- auth.rs -- AuthenticatedKey axum extractor, resolves Bearer tokens against key store
- config.rs -- GATEWAY_* env vars, explicit open-keys opt-in
- key_store.rs -- DashMap CRUD, SHA-256 hashing, zks_-prefixed key generation
- metering.rs -- per-key usage counting, 30-day period rollover
- rate_limit.rs -- per-key token bucket via governor (1/10/50/200 rps by tier)
- proxy.rs -- /v1/* reverse proxy, strips prefix, forwards headers both directions (filtering hop-by-hop), meters only 2xx/3xx responses
- routes/ -- GET /health, POST /api-keys (admin-gated), GET /usage (authenticated)

Security fixes from review:
- Admin key comparison uses SHA-256 digest comparison instead of != (timing attack vector)
- Key provisioning locked behind GATEWAY_ADMIN_KEY by default; requires GATEWAY_ALLOW_OPEN_KEYS=true for open access
- Logs a warning on startup when keys endpoint is open
- Response headers use append() not insert(), so multi-value headers like Set-Cookie survive
- Rate limiter keys on {hash}:{tier} so tier upgrades get a fresh bucket
- Moved to rand 0.9 to deduplicate with governor's dep

Design decisions

Auth is an axum extractor (FromRequestParts), same pattern as the indexer but composable across routes.

The /v1/* proxy is a single any() fallback. Adding new issuer-service endpoints doesn't require gateway changes.

Stores are in-memory (DashMap). Good enough for MVP. The handler signatures don't depend on the backing store, so swapping in persistence later won't touch route code.

Key provisioning is locked by default. If you deploy without setting GATEWAY_ADMIN_KEY and forget GATEWAY_ALLOW_OPEN_KEYS=true, the endpoint returns 500 instead of silently minting keys for
 anyone.

Verification

- cargo build -p api-gateway -- clean
- cargo test -p api-gateway -- 19 tests pass
- cargo clippy -p api-gateway -- -D warnings -- no warnings
- cargo test -p zksettle-types -- existing 8 tests still pass

Test plan

- Unit tests for key store, metering, rate limiter
- Integration tests for key creation, usage endpoint, admin auth
- Admin key rejection (no key, wrong key, correct key)
- Open-keys mode requires explicit opt-in
- Smoke test: start gateway, create key, GET /usage, proxy a request, check metering incremented

Branch: feat/api-gateway → dev
Closes #23