### PR TITLE
Scaffold sanctions-updater and fix Bubblegum tail validation

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1525,6 +1525,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,6 +5255,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sanctions-updater"
+version = "0.1.0"
+dependencies = [
+ "ark-bn254 0.5.0",
+ "ark-ff 0.5.0",
+ "borsh 1.6.1",
+ "csv",
+ "hex",
+ "reqwest 0.12.28",
+ "serde_json",
+ "sha2 0.10.9",
+ "solana-rpc-client",
+ "solana-sdk",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "zksettle-crypto",
 ]
 
 [[package]]

--- a/backend/crates/sanctions-updater/Cargo.toml
+++ b/backend/crates/sanctions-updater/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "sanctions-updater"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "sanctions-updater"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+solana-sdk = "2.3"
+solana-rpc-client = "2.3"
+ark-bn254 = "0.5"
+ark-ff = "0.5"
+zksettle-crypto = { path = "../zksettle-crypto" }
+reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
+csv = "1"
+hex = "0.4"
+thiserror = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+borsh = "1"
+sha2 = "0.10"
+serde_json = "1"

--- a/backend/crates/sanctions-updater/src/build.rs
+++ b/backend/crates/sanctions-updater/src/build.rs
@@ -1,0 +1,43 @@
+use zksettle_crypto::smt::SparseMerkleTree;
+
+use crate::convert::{fr_to_bytes_be, wallet_to_fr};
+use crate::error::UpdaterError;
+
+pub fn build_sanctions_tree(
+    wallets: &[String],
+) -> Result<(SparseMerkleTree, [u8; 32]), UpdaterError> {
+    let mut tree = SparseMerkleTree::new();
+    for w in wallets {
+        let fr = wallet_to_fr(w)?;
+        tree.insert(fr);
+    }
+    let root_bytes = fr_to_bytes_be(&tree.root());
+    tracing::info!(wallets = wallets.len(), root = hex::encode(root_bytes), "built sanctions tree");
+    Ok((tree, root_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_tree_from_mock_wallets() {
+        let wallets: Vec<String> = vec![
+            "0x000000000000000000000000000000000000000000000000000000000000dead",
+            "0x00000000000000000000000000000000000000000000000000000000cafebabe",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let (_, root) = build_sanctions_tree(&wallets).unwrap();
+        assert_ne!(root, [0u8; 32]);
+    }
+
+    #[test]
+    fn empty_tree_has_deterministic_root() {
+        let (_, root1) = build_sanctions_tree(&[]).unwrap();
+        let (_, root2) = build_sanctions_tree(&[]).unwrap();
+        assert_eq!(root1, root2);
+    }
+}

--- a/backend/crates/sanctions-updater/src/chain.rs
+++ b/backend/crates/sanctions-updater/src/chain.rs
@@ -1,0 +1,185 @@
+use borsh::BorshSerialize;
+use solana_rpc_client::rpc_client::RpcClient;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::instruction::{AccountMeta, Instruction};
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer;
+use solana_sdk::transaction::Transaction;
+
+use crate::error::UpdaterError;
+
+type Roots = ([u8; 32], [u8; 32], [u8; 32]);
+
+const ISSUER_SEED: &[u8] = b"issuer";
+
+fn issuer_pda(authority: &Pubkey, program_id: &Pubkey) -> (Pubkey, u8) {
+    Pubkey::find_program_address(&[ISSUER_SEED, authority.as_ref()], program_id)
+}
+
+#[derive(BorshSerialize)]
+struct RootArgs {
+    merkle_root: [u8; 32],
+    sanctions_root: [u8; 32],
+    jurisdiction_root: [u8; 32],
+}
+
+fn discriminator(name: &str) -> [u8; 8] {
+    use std::io::Write;
+    let input = format!("global:{name}");
+    let hash = <sha2::Sha256 as sha2::Digest>::digest(input.as_bytes());
+    let mut disc = [0u8; 8];
+    (&mut disc[..]).write_all(&hash[..8]).unwrap();
+    disc
+}
+
+fn build_register_ix(
+    authority: &Pubkey,
+    program_id: &Pubkey,
+    roots: &RootArgs,
+) -> Instruction {
+    let (pda, _) = issuer_pda(authority, program_id);
+    let disc = discriminator("register_issuer");
+    let mut data = disc.to_vec();
+    roots.serialize(&mut data).unwrap();
+
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new(*authority, true),
+            AccountMeta::new(pda, false),
+            #[allow(deprecated)]
+            AccountMeta::new_readonly(solana_sdk::system_program::ID, false),
+        ],
+        data,
+    }
+}
+
+fn build_update_ix(
+    authority: &Pubkey,
+    program_id: &Pubkey,
+    roots: &RootArgs,
+) -> Instruction {
+    let (pda, _) = issuer_pda(authority, program_id);
+    let disc = discriminator("update_issuer_root");
+    let mut data = disc.to_vec();
+    roots.serialize(&mut data).unwrap();
+
+    Instruction {
+        program_id: *program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(*authority, true),
+            AccountMeta::new(pda, false),
+        ],
+        data,
+    }
+}
+
+fn send_tx(
+    rpc: &RpcClient,
+    keypair: &Keypair,
+    ix: Instruction,
+) -> Result<u64, UpdaterError> {
+    let recent = rpc
+        .get_latest_blockhash()
+        .map_err(|e| UpdaterError::Chain(e.to_string()))?;
+    let tx = Transaction::new_signed_with_payer(&[ix], Some(&keypair.pubkey()), &[keypair], recent);
+    let sig = rpc
+        .send_and_confirm_transaction(&tx)
+        .map_err(|e| UpdaterError::Chain(e.to_string()))?;
+    tracing::info!(%sig, "tx confirmed");
+    let statuses = rpc
+        .get_signature_statuses(&[sig])
+        .map_err(|e| UpdaterError::Chain(format!("get_signature_statuses: {e}")))?;
+    let slot = statuses.value[0]
+        .as_ref()
+        .ok_or_else(|| UpdaterError::Chain("tx confirmed but status not found".into()))?
+        .slot;
+    Ok(slot)
+}
+
+pub struct PublishResult {
+    pub slot: u64,
+    pub did_register: bool,
+}
+
+pub fn is_issuer_registered(
+    rpc_url: &str,
+    authority: &Pubkey,
+    program_id: &Pubkey,
+) -> Result<bool, UpdaterError> {
+    let rpc = RpcClient::new(rpc_url.to_string());
+    let (pda, _) = issuer_pda(authority, program_id);
+    let resp = rpc
+        .get_account_with_commitment(&pda, CommitmentConfig::confirmed())
+        .map_err(|e| UpdaterError::Chain(format!("RPC probe for issuer PDA failed: {e}")))?;
+    Ok(resp.value.is_some())
+}
+
+// PDA layout: 8 disc + 32 authority + 32 merkle + 32 sanctions + 32 jurisdiction + 8 slot + 1 bump
+pub fn read_current_roots(
+    rpc_url: &str,
+    authority: &Pubkey,
+    program_id: &Pubkey,
+) -> Result<Roots, UpdaterError> {
+    let rpc = RpcClient::new(rpc_url.to_string());
+    let (pda, _) = issuer_pda(authority, program_id);
+    let account = rpc
+        .get_account_with_commitment(&pda, CommitmentConfig::confirmed())
+        .map_err(|e| UpdaterError::Chain(e.to_string()))?
+        .value
+        .ok_or_else(|| UpdaterError::Chain("issuer PDA not found".into()))?;
+
+    let data = &account.data;
+    if data.len() < 8 + 32 + 32 * 3 {
+        return Err(UpdaterError::Chain(format!(
+            "PDA data too short: {} bytes",
+            data.len()
+        )));
+    }
+
+    let mut merkle = [0u8; 32];
+    let mut sanctions = [0u8; 32];
+    let mut jurisdiction = [0u8; 32];
+    merkle.copy_from_slice(&data[40..72]);
+    sanctions.copy_from_slice(&data[72..104]);
+    jurisdiction.copy_from_slice(&data[104..136]);
+
+    Ok((merkle, sanctions, jurisdiction))
+}
+
+pub fn publish_sanctions_root(
+    rpc_url: &str,
+    keypair_bytes: &[u8],
+    program_id: &Pubkey,
+    new_sanctions_root: [u8; 32],
+    currently_registered: bool,
+) -> Result<PublishResult, UpdaterError> {
+    let keypair = Keypair::try_from(keypair_bytes)
+        .map_err(|e| UpdaterError::Chain(e.to_string()))?;
+
+    let (merkle_root, _old_sanctions, jurisdiction_root) = if currently_registered {
+        read_current_roots(rpc_url, &keypair.pubkey(), program_id)?
+    } else {
+        ([0u8; 32], [0u8; 32], [0u8; 32])
+    };
+
+    let rpc = RpcClient::new(rpc_url.to_string());
+    let roots = RootArgs {
+        merkle_root,
+        sanctions_root: new_sanctions_root,
+        jurisdiction_root,
+    };
+
+    let ix = if !currently_registered {
+        build_register_ix(&keypair.pubkey(), program_id, &roots)
+    } else {
+        build_update_ix(&keypair.pubkey(), program_id, &roots)
+    };
+
+    let slot = send_tx(&rpc, &keypair, ix)?;
+    Ok(PublishResult {
+        slot,
+        did_register: !currently_registered,
+    })
+}

--- a/backend/crates/sanctions-updater/src/config.rs
+++ b/backend/crates/sanctions-updater/src/config.rs
@@ -1,0 +1,43 @@
+pub struct Config {
+    pub rpc_url: String,
+    pub keypair_path: String,
+    pub program_id: String,
+    pub update_interval_secs: u64,
+    pub mock_sanctions: bool,
+    pub ofac_sdn_url: String,
+    pub log_level: String,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self {
+            rpc_url: env_or("RPC_URL", "http://127.0.0.1:8899"),
+            keypair_path: expand_tilde(&env_or("KEYPAIR_PATH", "~/.config/solana/id.json")),
+            program_id: env_or("PROGRAM_ID", "zkSet11ezkSet11ezkSet11ezkSet11ezkSet11ezkS"),
+            update_interval_secs: env_or("UPDATE_INTERVAL_SECS", "86400")
+                .parse()
+                .expect("UPDATE_INTERVAL_SECS must be u64"),
+            mock_sanctions: env_or("MOCK_SANCTIONS", "true")
+                .parse()
+                .expect("MOCK_SANCTIONS must be bool"),
+            ofac_sdn_url: env_or(
+                "OFAC_SDN_URL",
+                "https://www.treasury.gov/ofac/downloads/sdn.csv",
+            ),
+            log_level: env_or("LOG_LEVEL", "info"),
+        }
+    }
+}
+
+fn env_or(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return format!("{home}/{rest}");
+        }
+    }
+    path.to_string()
+}

--- a/backend/crates/sanctions-updater/src/convert.rs
+++ b/backend/crates/sanctions-updater/src/convert.rs
@@ -1,0 +1,69 @@
+use ark_bn254::Fr;
+use ark_ff::{BigInteger, PrimeField};
+
+use crate::error::UpdaterError;
+
+pub fn fr_to_bytes_be(f: &Fr) -> [u8; 32] {
+    let repr = f.into_bigint();
+    let le = repr.to_bytes_le();
+    let mut be = [0u8; 32];
+    for (i, b) in le.iter().enumerate() {
+        be[31 - i] = *b;
+    }
+    be
+}
+
+pub fn bytes_be_to_fr(bytes: &[u8; 32]) -> Fr {
+    let mut le = [0u8; 32];
+    for (i, b) in bytes.iter().enumerate() {
+        le[31 - i] = *b;
+    }
+    Fr::from_le_bytes_mod_order(&le)
+}
+
+pub fn wallet_to_fr(hex_str: &str) -> Result<Fr, UpdaterError> {
+    let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = hex::decode(hex_str).map_err(|e| UpdaterError::InvalidHex(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(UpdaterError::InvalidHex(format!(
+            "expected 32 bytes, got {}",
+            bytes.len()
+        )));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(bytes_be_to_fr(&arr))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_ff::AdditiveGroup;
+
+    #[test]
+    fn roundtrip_fr_bytes() {
+        let original = Fr::from(42u64);
+        let bytes = fr_to_bytes_be(&original);
+        let recovered = bytes_be_to_fr(&bytes);
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn zero_roundtrip() {
+        let bytes = fr_to_bytes_be(&Fr::ZERO);
+        assert_eq!(bytes_be_to_fr(&bytes), Fr::ZERO);
+    }
+
+    #[test]
+    fn wallet_to_fr_with_prefix() {
+        let hex = format!("0x{}", hex::encode([1u8; 32]));
+        let fr = wallet_to_fr(&hex).unwrap();
+        let back = fr_to_bytes_be(&fr);
+        assert_eq!(back, [1u8; 32]);
+    }
+
+    #[test]
+    fn wallet_to_fr_rejects_short() {
+        assert!(wallet_to_fr("0xabcd").is_err());
+    }
+}

--- a/backend/crates/sanctions-updater/src/error.rs
+++ b/backend/crates/sanctions-updater/src/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum UpdaterError {
+    #[error("fetch error: {0}")]
+    Fetch(String),
+
+    #[error("parse error: {0}")]
+    Parse(String),
+
+    #[error("chain error: {0}")]
+    Chain(String),
+
+    #[error("crypto error: {0}")]
+    Crypto(#[from] zksettle_crypto::error::CryptoError),
+
+    #[error("invalid hex: {0}")]
+    InvalidHex(String),
+}

--- a/backend/crates/sanctions-updater/src/fetch.rs
+++ b/backend/crates/sanctions-updater/src/fetch.rs
@@ -1,0 +1,65 @@
+use crate::config::Config;
+use crate::error::UpdaterError;
+
+pub async fn fetch_sanctioned_wallets(config: &Config) -> Result<Vec<String>, UpdaterError> {
+    if config.mock_sanctions {
+        return Ok(mock_wallets());
+    }
+    fetch_ofac_wallets(&config.ofac_sdn_url).await
+}
+
+fn mock_wallets() -> Vec<String> {
+    vec![
+        "0x000000000000000000000000000000000000000000000000000000000000dead",
+        "0x00000000000000000000000000000000000000000000000000000000cafebabe",
+        "0x00000000000000000000000000000000000000000000000000000000deadbeef",
+        "0x00000000000000000000000000000000000000000000000000000000bad00bad",
+        "0x0000000000000000000000000000000000000000000000000000000000facade",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect()
+}
+
+async fn fetch_ofac_wallets(url: &str) -> Result<Vec<String>, UpdaterError> {
+    let body = reqwest::get(url)
+        .await
+        .map_err(|e| UpdaterError::Fetch(e.to_string()))?
+        .text()
+        .await
+        .map_err(|e| UpdaterError::Fetch(e.to_string()))?;
+
+    let mut wallets = Vec::new();
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .from_reader(body.as_bytes());
+
+    for result in rdr.records() {
+        let record = result.map_err(|e| UpdaterError::Parse(e.to_string()))?;
+        // SDN CSV: look for "Digital Currency Address" entries
+        for field in record.iter() {
+            let trimmed = field.trim();
+            if trimmed.starts_with("0x") && trimmed.len() == 66 {
+                wallets.push(trimmed.to_string());
+            }
+        }
+    }
+
+    tracing::info!(count = wallets.len(), "fetched OFAC wallet addresses");
+    Ok(wallets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_returns_wallets() {
+        let wallets = mock_wallets();
+        assert_eq!(wallets.len(), 5);
+        for w in &wallets {
+            assert!(w.starts_with("0x"));
+        }
+    }
+}

--- a/backend/crates/sanctions-updater/src/main.rs
+++ b/backend/crates/sanctions-updater/src/main.rs
@@ -1,0 +1,106 @@
+mod build;
+mod chain;
+mod config;
+mod convert;
+mod error;
+mod fetch;
+
+use std::time::Duration;
+
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Keypair;
+use solana_sdk::signer::Signer;
+
+use config::Config;
+
+#[tokio::main]
+async fn main() {
+    let cfg = Config::from_env();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| format!("sanctions_updater={}", cfg.log_level).into()),
+        )
+        .init();
+
+    let keypair_bytes = std::fs::read(&cfg.keypair_path)
+        .unwrap_or_else(|e| panic!("failed to read keypair at {}: {e}", cfg.keypair_path));
+    let keypair_json: Vec<u8> = serde_json::from_slice(&keypair_bytes)
+        .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"));
+    let keypair = Keypair::try_from(keypair_json.as_slice())
+        .unwrap_or_else(|e| panic!("invalid keypair bytes: {e}"));
+    let program_id: Pubkey = cfg
+        .program_id
+        .parse()
+        .unwrap_or_else(|e| panic!("invalid program ID '{}': {e}", cfg.program_id));
+
+    tracing::info!(
+        authority = %keypair.pubkey(),
+        %program_id,
+        rpc = %cfg.rpc_url,
+        interval_secs = cfg.update_interval_secs,
+        mock = cfg.mock_sanctions,
+        "starting sanctions updater"
+    );
+
+    let mut registered = match chain::is_issuer_registered(&cfg.rpc_url, &keypair.pubkey(), &program_id) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(%e, "could not probe issuer PDA, assuming not registered");
+            false
+        }
+    };
+
+    let interval = Duration::from_secs(cfg.update_interval_secs);
+    let keypair_bytes = keypair_json;
+
+    loop {
+        match run_tick(&cfg, &keypair_bytes, &program_id, registered).await {
+            Ok(result) => {
+                if result.did_register {
+                    registered = true;
+                    tracing::info!(slot = result.slot, "issuer registered on-chain");
+                } else {
+                    tracing::info!(slot = result.slot, "sanctions root updated on-chain");
+                }
+            }
+            Err(e) => {
+                tracing::error!(%e, "sanctions update tick failed");
+            }
+        }
+
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = tokio::signal::ctrl_c() => {
+                tracing::info!("shutdown signal received");
+                return;
+            }
+        }
+    }
+}
+
+async fn run_tick(
+    cfg: &Config,
+    keypair_bytes: &[u8],
+    program_id: &Pubkey,
+    registered: bool,
+) -> Result<chain::PublishResult, error::UpdaterError> {
+    let wallets = fetch::fetch_sanctioned_wallets(cfg).await?;
+    tracing::info!(count = wallets.len(), "fetched sanctioned wallets");
+
+    let (_tree, root_bytes) = build::build_sanctions_tree(&wallets)?;
+
+    let result = {
+        let url = cfg.rpc_url.clone();
+        let kb = keypair_bytes.to_vec();
+        let pid = *program_id;
+        tokio::task::spawn_blocking(move || {
+            chain::publish_sanctions_root(&url, &kb, &pid, root_bytes, registered)
+        })
+        .await
+        .map_err(|e| error::UpdaterError::Chain(format!("task panicked: {e}")))?
+    }?;
+
+    Ok(result)
+}

--- a/backend/programs/zksettle/src/error.rs
+++ b/backend/programs/zksettle/src/error.rs
@@ -75,6 +75,8 @@ pub enum ZkSettleError {
     BubblegumCpiFailed,
     #[msg("Trailing Bubblegum account count is invalid for remaining_accounts split")]
     BubblegumTailInvalid,
+    #[msg("Bubblegum leaf owner does not match settlement recipient")]
+    BubblegumLeafOwnerMismatch,
 }
 
 /// Map an external Result's Err into a `ZkSettleError`, logging the source via
@@ -150,6 +152,7 @@ mod tests {
             ZkSettleError::BubblegumTreeMismatch as u32,
             ZkSettleError::BubblegumCpiFailed as u32,
             ZkSettleError::BubblegumTailInvalid as u32,
+            ZkSettleError::BubblegumLeafOwnerMismatch as u32,
         ];
         let mut seen = std::collections::HashSet::new();
         for code in &codes {

--- a/backend/programs/zksettle/src/instructions/bubblegum_mint.rs
+++ b/backend/programs/zksettle/src/instructions/bubblegum_mint.rs
@@ -176,13 +176,19 @@ pub fn invoke_create_tree_config<'info>(
     max_buffer_size: u32,
     signer_seeds: &[&[&[u8]]],
 ) -> Result<()> {
-    let mut data = CreateTreeConfigDisc::new().try_to_vec().unwrap();
+    let mut data = CreateTreeConfigDisc::new()
+        .try_to_vec()
+        .map_err(|_| error!(ZkSettleError::BubblegumCpiFailed))?;
     let args = CreateTreeConfigArgs {
         max_depth,
         max_buffer_size,
         public: Some(false),
     };
-    data.extend_from_slice(&args.try_to_vec().unwrap());
+    data.extend_from_slice(
+        &args
+            .try_to_vec()
+            .map_err(|_| error!(ZkSettleError::BubblegumCpiFailed))?,
+    );
 
     let ix = Instruction {
         program_id: MPL_BUBBLEGUM_ID,
@@ -229,9 +235,15 @@ pub fn invoke_mint_v1<'info>(
     metadata: BgMetadataArgs,
     signer_seeds: &[&[&[u8]]],
 ) -> Result<()> {
-    let mut data = MintV1Disc::new().try_to_vec().unwrap();
+    let mut data = MintV1Disc::new()
+        .try_to_vec()
+        .map_err(|_| error!(ZkSettleError::BubblegumCpiFailed))?;
     let args = MintV1Args { metadata };
-    data.extend_from_slice(&args.try_to_vec().unwrap());
+    data.extend_from_slice(
+        &args
+            .try_to_vec()
+            .map_err(|_| error!(ZkSettleError::BubblegumCpiFailed))?,
+    );
 
     let ix = Instruction {
         program_id: MPL_BUBBLEGUM_ID,
@@ -337,6 +349,8 @@ pub fn cpi_mint_from_remaining_tail<'info>(
     bubblegum_program: &AccountInfo<'info>,
     tail: &[AccountInfo<'info>],
     tree_creator_bump: u8,
+    registry_merkle_tree: &Pubkey,
+    expected_leaf_owner: &Pubkey,
     issuer: Pubkey,
     nullifier_hash: [u8; 32],
     merkle_root: [u8; 32],
@@ -346,21 +360,45 @@ pub fn cpi_mint_from_remaining_tail<'info>(
         tail.len() == BUBBLEGUM_MINT_V1_ACCOUNT_COUNT,
         ZkSettleError::BubblegumTailInvalid
     );
-    let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[tree_creator_bump]];
-    let metadata = build_attestation_metadata(issuer, slot, &nullifier_hash, &merkle_root);
 
     // tail layout: [0] tree_config, [1] leaf_owner, [2] merkle_tree, [3] payer,
     // [4] tree_creator, [5] log_wrapper, [6] compression, [7] system_program
+
+    require_keys_eq!(
+        tail[2].key(),
+        *registry_merkle_tree,
+        ZkSettleError::BubblegumTreeMismatch
+    );
+    require_keys_eq!(
+        *tail[2].owner,
+        SPL_ACCOUNT_COMPRESSION_ID,
+        ZkSettleError::BubblegumCpiFailed
+    );
+    let (expected_cfg, _) = tree_config_pda(registry_merkle_tree);
+    require_keys_eq!(
+        tail[0].key(),
+        expected_cfg,
+        ZkSettleError::BubblegumCpiFailed
+    );
+    require_keys_eq!(
+        tail[1].key(),
+        *expected_leaf_owner,
+        ZkSettleError::BubblegumLeafOwnerMismatch
+    );
+
+    let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[tree_creator_bump]];
+    let metadata = build_attestation_metadata(issuer, slot, &nullifier_hash, &merkle_root);
+
     invoke_mint_v1(
         bubblegum_program,
-        &tail[0],  // tree_config
-        &tail[1],  // leaf_owner (used as both owner + delegate)
-        &tail[2],  // merkle_tree
-        &tail[3],  // payer
-        &tail[4],  // tree_creator_or_delegate
-        &tail[5],  // log_wrapper
-        &tail[6],  // compression_program
-        &tail[7],  // system_program
+        &tail[0],
+        &tail[1],
+        &tail[2],
+        &tail[3],
+        &tail[4],
+        &tail[5],
+        &tail[6],
+        &tail[7],
         metadata,
         &[seeds],
     )

--- a/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
@@ -133,19 +133,19 @@ fn run_settlement(sctx: SettlementContext<'_, '_>) -> Result<()> {
     match &sctx.bubblegum_mint {
         BubblegumMintMode::None => {}
         BubblegumMintMode::Tail(bg) => {
-            if !bg.is_empty() {
-                crate::cu_probe!("pre-bubblegum-mint");
-                cpi_mint_from_remaining_tail(
-                    sctx.bubblegum_program,
-                    bg,
-                    sctx.registry.tree_creator_bump,
-                    sctx.issuer_key,
-                    nullifier_hash,
-                    merkle_root,
-                    slot,
-                )?;
-                crate::cu_probe!("post-bubblegum-mint");
-            }
+            crate::cu_probe!("pre-bubblegum-mint");
+            cpi_mint_from_remaining_tail(
+                sctx.bubblegum_program,
+                bg,
+                sctx.registry.tree_creator_bump,
+                &sctx.registry.merkle_tree,
+                &sctx.payload.recipient,
+                sctx.issuer_key,
+                nullifier_hash,
+                merkle_root,
+                slot,
+            )?;
+            crate::cu_probe!("post-bubblegum-mint");
         }
         BubblegumMintMode::Named {
             tree_config,


### PR DESCRIPTION
## Summary

- **Scaffold `sanctions-updater` crate** (closes #24): standalone cron service that fetches OFAC sanctions data, builds a sparse Merkle tree, and publishes the updated `sanctions_root` on-chain via read-before-write (preserves existing `merkle_root` and `jurisdiction_root`)
- **Fix critical security vulnerabilities** in the `execute_hook` Bubblegum mint path where caller-supplied `remaining_accounts` bypassed all validation

## Security Fixes

### Critical: Unvalidated tail accounts in `cpi_mint_from_remaining_tail`

The `settle_hook` (Named) path enforced Anchor constraints on `tree_config`, `merkle_tree`, `leaf_owner`, and `compression_program`. The `execute_hook` (Tail) path passed raw `remaining_accounts` with zero validation — an attacker could:

1. Pass a fake merkle tree owned by a program they control and mint arbitrary cNFTs under the `tree_creator` PDA signer
2. Set `tail[1]` (leaf_owner) to any wallet, minting the compliance attestation cNFT to an unrelated address

**Fix:** Added four `require_keys_eq!` guards to `cpi_mint_from_remaining_tail`:
- `tail[2].key() == registry.merkle_tree` — tree matches registry
- `tail[2].owner == SPL_ACCOUNT_COMPRESSION_ID` — tree owned by compression program
- `tail[0].key() == tree_config_pda(registry.merkle_tree)` — config PDA derived correctly
- `tail[1].key() == hook_payload.recipient` — leaf owner matches staged recipient

New error variant: `BubblegumLeafOwnerMismatch`.

### Warnings fixed
- Removed dead `if !bg.is_empty()` branch (`Tail` variant always has 8 accounts by construction)
- Replaced 4 `unwrap()` calls on serialization with `map_err(|_| error!(ZkSettleError::BubblegumCpiFailed))?`

## Sanctions Updater

New crate at `backend/crates/sanctions-updater/` with:
- `fetch.rs` — mock mode (5 hardcoded wallets) + real OFAC SDN CSV parser via reqwest
- `build.rs` — constructs SMT from wallet list, returns tree + root bytes
- `chain.rs` — adapted from issuer-service; adds `read_current_roots()` to read existing PDA state before writing only the sanctions root
- `config.rs` — env-based config (`MOCK_SANCTIONS=true` default for hackathon)
- `main.rs` — tokio cron loop with graceful shutdown

## Test plan

- [x] `cargo check -p sanctions-updater` — compiles clean
- [x] `cargo test -p sanctions-updater` — 7 tests pass (convert roundtrip, build tree, mock fetch)
- [x] `cargo clippy -p sanctions-updater` — no warnings
- [x] `cargo check -p zksettle` — compiles clean
- [x] `cargo test -p zksettle` — 63 tests pass
- [x] `cargo clippy -p zksettle` — no new warnings
- [ ] Manual: run sanctions-updater with `MOCK_SANCTIONS=true` against local validator, verify PDA updated

## Files changed

| File | Change |
|------|--------|
| `crates/sanctions-updater/**` | New crate (7 source files) |
| `programs/zksettle/src/instructions/bubblegum_mint.rs` | Add tail validation guards, replace unwrap |
| `programs/zksettle/src/instructions/transfer_hook/settlement.rs` | Pass registry + recipient to tail mint, remove dead branch |
| `programs/zksettle/src/error.rs` | Add `BubblegumLeafOwnerMismatch` variant |

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a sanctions updater service that automatically fetches sanctioned wallet addresses and publishes them on-chain at a configurable interval, supporting both real OFAC data feeds and mock sanctions lists for testing purposes.

* **Bug Fixes**
  * Improved error handling in minting operations by replacing unsafe unwrap calls with proper error variants, and added validation for leaf ownership verification before minting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->