### PR TITLE
Feat/harden transfer hook

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -10708,6 +10708,7 @@ dependencies = [
  "solana-keypair",
  "solana-signer 2.2.1",
  "spl-account-compression",
+ "spl-discriminator 0.5.2",
  "spl-tlv-account-resolution 0.11.1",
  "spl-token-2022 6.0.0",
  "spl-transfer-hook-interface 2.1.0",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -10709,6 +10709,7 @@ dependencies = [
  "solana-signer 2.2.1",
  "spl-account-compression",
  "spl-tlv-account-resolution 0.11.1",
+ "spl-token-2022 6.0.0",
  "spl-transfer-hook-interface 2.1.0",
  "tokio",
 ]

--- a/backend/programs/zksettle/Cargo.toml
+++ b/backend/programs/zksettle/Cargo.toml
@@ -50,6 +50,7 @@ gnark-verifier-solana = { git = "https://github.com/reilabs/sunspot.git", rev = 
 [dev-dependencies]
 solana-signer = "2.2"
 solana-keypair = "2.2"
+spl-token-2022 = "6.0"
 solana-instruction = "2.3"
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/backend/programs/zksettle/Cargo.toml
+++ b/backend/programs/zksettle/Cargo.toml
@@ -52,6 +52,7 @@ solana-signer = "2.2"
 solana-keypair = "2.2"
 spl-token-2022 = "6.0"
 solana-instruction = "2.3"
+spl-discriminator = "0.5"
 
 [target.'cfg(unix)'.dev-dependencies]
 light-program-test = "=0.23.0"

--- a/backend/programs/zksettle/src/error.rs
+++ b/backend/programs/zksettle/src/error.rs
@@ -77,6 +77,8 @@ pub enum ZkSettleError {
     BubblegumTailInvalid,
     #[msg("Bubblegum leaf owner does not match settlement recipient")]
     BubblegumLeafOwnerMismatch,
+    #[msg("Mint's TransferHook extension does not point to this program")]
+    MintHookMismatch,
 }
 
 /// Map an external Result's Err into a `ZkSettleError`, logging the source via
@@ -153,6 +155,7 @@ mod tests {
             ZkSettleError::BubblegumCpiFailed as u32,
             ZkSettleError::BubblegumTailInvalid as u32,
             ZkSettleError::BubblegumLeafOwnerMismatch as u32,
+            ZkSettleError::MintHookMismatch as u32,
         ];
         let mut seen = std::collections::HashSet::new();
         for code in &codes {

--- a/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
@@ -1,4 +1,8 @@
 use anchor_lang::prelude::*;
+use anchor_spl::token_2022::spl_token_2022::{
+    extension::{transfer_hook::TransferHook, BaseStateWithExtensions, StateWithExtensions},
+    state::Mint as SplMint,
+};
 use spl_tlv_account_resolution::{account::ExtraAccountMeta, state::ExtraAccountMetaList};
 use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 
@@ -51,6 +55,21 @@ pub fn set_hook_payload_handler(
     Ok(())
 }
 
+pub(crate) fn validate_mint_has_hook(mint_info: &AccountInfo) -> Result<()> {
+    let data = mint_info.data.borrow();
+    let mint_state = StateWithExtensions::<SplMint>::unpack(&data)
+        .map_err(|_| error!(ZkSettleError::MintHookMismatch))?;
+    let hook = mint_state
+        .get_extension::<TransferHook>()
+        .map_err(|_| error!(ZkSettleError::MintHookMismatch))?;
+    let hook_program_id = Option::<Pubkey>::from(hook.program_id);
+    require!(
+        hook_program_id == Some(crate::ID),
+        ZkSettleError::MintHookMismatch
+    );
+    Ok(())
+}
+
 // TODO: companion `update_extra_account_meta_list_handler`. TLV is write-once
 // today; evolving metas (e.g., new address-tree pubkey indices) requires a
 // re-init path. Tracked post-hackathon.
@@ -58,6 +77,7 @@ pub fn init_extra_account_meta_list_handler(
     ctx: Context<InitExtraAccountMetaList>,
     extras: Vec<ExtraAccountMetaInput>,
 ) -> Result<()> {
+    validate_mint_has_hook(&ctx.accounts.mint.to_account_info())?;
     let metas: Vec<ExtraAccountMeta> = extras.into_iter().map(Into::into).collect();
     let size = ExtraAccountMetaList::size_of(metas.len())
         .map_err(|_| error!(ZkSettleError::HookPayloadInvalid))?;

--- a/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
@@ -5,6 +5,7 @@ mod tests;
 mod types;
 
 use anchor_lang::prelude::*;
+use anchor_spl::token_interface;
 
 use crate::error::ZkSettleError;
 use crate::instructions::bubblegum_mint::{tree_config_pda, MPL_BUBBLEGUM_ID, NOOP_PROGRAM_ID};
@@ -69,7 +70,10 @@ pub struct InitExtraAccountMetaList<'info> {
     )]
     pub issuer: Account<'info, Issuer>,
 
-    /// CHECK: mint address is only used as a seed input.
+    /// CHECK: validated by `validate_mint_has_hook()` at the start of the handler —
+    /// unpacks as Token-2022 Mint and asserts the TransferHook extension points to
+    /// this program. Kept as UncheckedAccount to avoid Anchor Mint deser overhead
+    /// on a one-time setup instruction.
     pub mint: UncheckedAccount<'info>,
     /// CHECK: allocated + populated by this handler via `system_program::create_account`
     /// and `ExtraAccountMetaList::init`. PDA seed matches the SPL transfer-hook
@@ -91,9 +95,12 @@ pub struct SettleHook<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
 
-    /// CHECK: bound to `hook_payload.mint`.
-    pub mint: UncheckedAccount<'info>,
-    /// CHECK: bound to `hook_payload.recipient`.
+    #[account(constraint = mint.key() == hook_payload.mint @ ZkSettleError::MintMismatch)]
+    pub mint: InterfaceAccount<'info, token_interface::Mint>,
+    /// CHECK: bound to `hook_payload.recipient` via constraint. Kept as
+    /// UncheckedAccount because in the direct-call path `recipient` may be a
+    /// wallet address (matching `leaf_owner`) rather than a token account.
+    #[account(constraint = destination_token.key() == hook_payload.recipient @ ZkSettleError::RecipientMismatch)]
     pub destination_token: UncheckedAccount<'info>,
 
     #[account(

--- a/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
@@ -162,7 +162,8 @@ pub struct SettleHook<'info> {
 pub struct ExecuteHook<'info> {
     /// CHECK: source token account; Token-2022 enforces ownership + writability.
     pub source_token: UncheckedAccount<'info>,
-    /// CHECK: mint; bound to `hook_payload.mint`.
+    /// CHECK: mint; validated by `enforce_token_2022_hook_accounts` + constraint.
+    #[account(constraint = mint.key() == hook_payload.mint @ ZkSettleError::MintMismatch)]
     pub mint: UncheckedAccount<'info>,
     /// CHECK: destination token; bound to `hook_payload.recipient`.
     pub destination_token: UncheckedAccount<'info>,

--- a/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/settlement.rs
@@ -212,8 +212,10 @@ pub fn settle_hook_handler<'info>(
     })
 }
 
-fn enforce_token_2022_cpi_origin(
+fn enforce_token_2022_hook_accounts(
     source_token: &UncheckedAccount,
+    mint: &UncheckedAccount,
+    destination_token: &UncheckedAccount,
     expected_owner: Pubkey,
 ) -> Result<()> {
     use anchor_spl::token_2022::spl_token_2022::{
@@ -226,6 +228,16 @@ fn enforce_token_2022_cpi_origin(
 
     require_keys_eq!(
         *source_token.owner,
+        spl_token_2022::ID,
+        ZkSettleError::NotToken2022
+    );
+    require_keys_eq!(
+        *mint.owner,
+        spl_token_2022::ID,
+        ZkSettleError::NotToken2022
+    );
+    require_keys_eq!(
+        *destination_token.owner,
         spl_token_2022::ID,
         ZkSettleError::NotToken2022
     );
@@ -257,7 +269,12 @@ pub fn execute_hook_handler<'info>(
     ctx: Context<'_, '_, '_, 'info, ExecuteHook<'info>>,
     amount: u64,
 ) -> Result<()> {
-    enforce_token_2022_cpi_origin(&ctx.accounts.source_token, ctx.accounts.owner.key())?;
+    enforce_token_2022_hook_accounts(
+        &ctx.accounts.source_token,
+        &ctx.accounts.mint,
+        &ctx.accounts.destination_token,
+        ctx.accounts.owner.key(),
+    )?;
 
     let tail = ctx.accounts.hook_payload.light_args.bubblegum_tail;
     let (light_rem, bg) = split_light_and_bubblegum(ctx.remaining_accounts, tail)?;

--- a/backend/programs/zksettle/src/instructions/transfer_hook/tests.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/tests.rs
@@ -66,6 +66,11 @@ fn validate_accepts_max_proof_len() {
 }
 
 #[test]
+fn validate_accepts_minimal_proof() {
+    assert!(validate_set_hook_inputs(1, &nonzero_nullifier(), 1).is_ok());
+}
+
+#[test]
 fn staged_args_roundtrip_tree_info() {
     let args = StagedLightArgs {
         bubblegum_tail: 0,

--- a/backend/programs/zksettle/src/instructions/transfer_hook/types.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/types.rs
@@ -74,8 +74,7 @@ pub struct HookPayload {
     pub bump: u8,
 }
 
-/// Anchor-serializable mirror of `spl_tlv_account_resolution::account::ExtraAccountMeta`.
-/// Clients submit an ordered list; the program converts and writes the TLV.
+/// Anchor-serializable mirror of `ExtraAccountMeta` (which lacks Anchor derives).
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug)]
 pub struct ExtraAccountMetaInput {
     pub discriminator: u8,

--- a/backend/programs/zksettle/tests/helpers/harness.rs
+++ b/backend/programs/zksettle/tests/helpers/harness.rs
@@ -1,6 +1,9 @@
+use anchor_lang::prelude::Pubkey;
 use light_program_test::{LightProgramTest, ProgramTestConfig, Rpc};
 use solana_keypair::Keypair;
 use solana_signer::Signer;
+
+use super::instructions::{issuer_pda, register_ix};
 
 pub async fn boot_harness() -> LightProgramTest {
     let config = ProgramTestConfig::new_v2(false, Some(vec![("zksettle", zksettle::ID)]));
@@ -15,4 +18,23 @@ pub async fn funded_authority(rpc: &mut LightProgramTest, lamports: u64) -> Keyp
         .await
         .expect("airdrop");
     kp
+}
+
+pub async fn registered_issuer(rpc: &mut LightProgramTest) -> (Keypair, Pubkey) {
+    let authority = funded_authority(rpc, 10_000_000_000).await;
+    rpc.create_and_send_transaction(
+        &[register_ix(&authority.pubkey(), [1u8; 32])],
+        &authority.pubkey(),
+        &[&authority],
+    )
+    .await
+    .expect("register issuer");
+    let issuer_key = issuer_pda(&authority.pubkey());
+    (authority, issuer_key)
+}
+
+pub fn nonzero_nullifier() -> [u8; 32] {
+    let mut n = [0u8; 32];
+    n[0] = 1;
+    n
 }

--- a/backend/programs/zksettle/tests/helpers/instructions.rs
+++ b/backend/programs/zksettle/tests/helpers/instructions.rs
@@ -98,8 +98,8 @@ pub fn set_hook_payload_ix(
         program_id: zksettle::ID,
         accounts: vec![
             AccountMeta::new(*owner, true),
-            AccountMeta::new(payload_pda, false),
             AccountMeta::new_readonly(*issuer_key, false),
+            AccountMeta::new(payload_pda, false),
             AccountMeta::new_readonly(system_program::ID, false),
         ],
         data: SetPayloadIx {
@@ -121,15 +121,88 @@ pub fn init_extra_meta_ix(
     extras: Vec<ExtraAccountMetaInput>,
 ) -> Instruction {
     let (meta_pda, _) = extra_meta_pda(mint);
+    let issuer = issuer_pda(authority);
     Instruction {
         program_id: zksettle::ID,
         accounts: vec![
             AccountMeta::new(*authority, true),
-            AccountMeta::new(meta_pda, false),
+            AccountMeta::new_readonly(issuer, false),
             AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new(meta_pda, false),
             AccountMeta::new_readonly(system_program::ID, false),
         ],
         data: InitMetaIx { extras }.data(),
+    }
+}
+
+/// Build instructions to create a Token-2022 mint with TransferHook extension
+/// pointing to the zksettle program.
+pub fn create_token2022_mint_with_hook_ixs(
+    payer: &Pubkey,
+    mint_key: &Pubkey,
+    decimals: u8,
+) -> Vec<Instruction> {
+    use spl_token_2022::{
+        extension::{transfer_hook::instruction::initialize as init_hook, ExtensionType},
+        instruction::initialize_mint2,
+        state::Mint as SplMint,
+    };
+
+    let extensions = &[ExtensionType::TransferHook];
+    let space = ExtensionType::try_calculate_account_len::<SplMint>(extensions).unwrap();
+
+    let rent = anchor_lang::solana_program::rent::Rent::default();
+    let create_ix = anchor_lang::solana_program::system_instruction::create_account(
+        payer,
+        mint_key,
+        rent.minimum_balance(space),
+        space as u64,
+        &spl_token_2022::ID,
+    );
+
+    let init_hook_ix =
+        init_hook(&spl_token_2022::ID, mint_key, Some(*payer), Some(zksettle::ID)).unwrap();
+
+    let init_mint_ix =
+        initialize_mint2(&spl_token_2022::ID, mint_key, payer, None, decimals).unwrap();
+
+    vec![create_ix, init_hook_ix, init_mint_ix]
+}
+
+/// Build a raw `transfer_hook` (ExecuteHook) instruction.
+/// Uses the SPL transfer-hook discriminator `[105, 37, 101, 197, 75, 251, 102, 26]`.
+#[allow(clippy::too_many_arguments)]
+pub fn execute_hook_ix(
+    source_token: &Pubkey,
+    mint: &Pubkey,
+    destination_token: &Pubkey,
+    owner: &Pubkey,
+    issuer: &Pubkey,
+    registry: &Pubkey,
+    bubblegum_program: &Pubkey,
+    amount: u64,
+) -> Instruction {
+    let (meta_pda, _) = extra_meta_pda(mint);
+    let (payload_pda, _) = hook_payload_pda(owner);
+
+    let mut data = Vec::with_capacity(16);
+    data.extend_from_slice(&[105, 37, 101, 197, 75, 251, 102, 26]);
+    data.extend_from_slice(&amount.to_le_bytes());
+
+    Instruction {
+        program_id: zksettle::ID,
+        accounts: vec![
+            AccountMeta::new_readonly(*source_token, false),
+            AccountMeta::new_readonly(*mint, false),
+            AccountMeta::new_readonly(*destination_token, false),
+            AccountMeta::new_readonly(*owner, false),
+            AccountMeta::new_readonly(meta_pda, false),
+            AccountMeta::new(payload_pda, false),
+            AccountMeta::new_readonly(*issuer, false),
+            AccountMeta::new_readonly(*registry, false),
+            AccountMeta::new_readonly(*bubblegum_program, false),
+        ],
+        data,
     }
 }
 

--- a/backend/programs/zksettle/tests/helpers/instructions.rs
+++ b/backend/programs/zksettle/tests/helpers/instructions.rs
@@ -1,6 +1,7 @@
 use anchor_lang::prelude::Pubkey;
 use anchor_lang::{system_program, InstructionData};
 use solana_instruction::{AccountMeta, Instruction};
+use spl_discriminator::SplDiscriminate;
 
 use zksettle::instruction::{
     InitExtraAccountMetaList as InitMetaIx, RegisterIssuer as RegisterIssuerIx,
@@ -186,7 +187,7 @@ pub fn execute_hook_ix(
     let (payload_pda, _) = hook_payload_pda(owner);
 
     let mut data = Vec::with_capacity(16);
-    data.extend_from_slice(&[105, 37, 101, 197, 75, 251, 102, 26]);
+    data.extend_from_slice(spl_transfer_hook_interface::instruction::ExecuteInstruction::SPL_DISCRIMINATOR_SLICE);
     data.extend_from_slice(&amount.to_le_bytes());
 
     Instruction {

--- a/backend/programs/zksettle/tests/helpers/mod.rs
+++ b/backend/programs/zksettle/tests/helpers/mod.rs
@@ -1,7 +1,7 @@
 pub mod harness;
 pub mod instructions;
 
-pub use harness::{boot_harness, funded_authority};
+pub use harness::{boot_harness, funded_authority, nonzero_nullifier, registered_issuer};
 pub use instructions::{
     create_token2022_mint_with_hook_ixs, default_light_args, execute_hook_ix, extra_meta_pda,
     hook_payload_pda, init_extra_meta_ix, issuer_pda, register_ix, set_hook_payload_ix, update_ix,

--- a/backend/programs/zksettle/tests/helpers/mod.rs
+++ b/backend/programs/zksettle/tests/helpers/mod.rs
@@ -3,6 +3,7 @@ pub mod instructions;
 
 pub use harness::{boot_harness, funded_authority};
 pub use instructions::{
-    default_light_args, extra_meta_pda, hook_payload_pda, init_extra_meta_ix, issuer_pda,
-    register_ix, set_hook_payload_ix, update_ix, ANCHOR_ERROR_CODE_OFFSET, CONSTRAINT_SEEDS,
+    create_token2022_mint_with_hook_ixs, default_light_args, execute_hook_ix, extra_meta_pda,
+    hook_payload_pda, init_extra_meta_ix, issuer_pda, register_ix, set_hook_payload_ix, update_ix,
+    ANCHOR_ERROR_CODE_OFFSET, CONSTRAINT_SEEDS,
 };

--- a/backend/programs/zksettle/tests/transfer_hook_smoke.rs
+++ b/backend/programs/zksettle/tests/transfer_hook_smoke.rs
@@ -22,11 +22,12 @@ use light_program_test::{utils::assert::assert_rpc_error, Rpc};
 use solana_signer::Signer;
 
 use zksettle::error::ZkSettleError;
-use zksettle::instructions::transfer_hook::ExtraAccountMetaInput;
+use zksettle::instructions::transfer_hook::{ExtraAccountMetaInput, MAX_HOOK_PROOF_BYTES};
 
 use helpers::{
-    boot_harness, default_light_args, extra_meta_pda, funded_authority, hook_payload_pda,
-    init_extra_meta_ix, issuer_pda, register_ix, set_hook_payload_ix, ANCHOR_ERROR_CODE_OFFSET,
+    boot_harness, create_token2022_mint_with_hook_ixs, default_light_args, execute_hook_ix,
+    extra_meta_pda, funded_authority, hook_payload_pda, init_extra_meta_ix, issuer_pda,
+    register_ix, set_hook_payload_ix, ANCHOR_ERROR_CODE_OFFSET,
 };
 
 #[tokio::test]
@@ -170,9 +171,26 @@ async fn set_hook_payload_rejects_zero_amount() {
 
 #[tokio::test]
 async fn init_extra_account_meta_list_succeeds() {
+    use solana_keypair::Keypair;
+
     let mut rpc = boot_harness().await;
     let authority = funded_authority(&mut rpc, 10_000_000_000).await;
-    let mint = Pubkey::new_unique();
+
+    // Register issuer (required by InitExtraAccountMetaList struct constraint)
+    rpc.create_and_send_transaction(
+        &[register_ix(&authority.pubkey(), [1u8; 32])],
+        &authority.pubkey(),
+        &[&authority],
+    )
+    .await
+    .expect("register should succeed");
+
+    // Create a Token-2022 mint with TransferHook pointing to zksettle
+    let mint_kp = Keypair::new();
+    let mint_ixs = create_token2022_mint_with_hook_ixs(&authority.pubkey(), &mint_kp.pubkey(), 6);
+    rpc.create_and_send_transaction(&mint_ixs, &authority.pubkey(), &[&authority, &mint_kp])
+        .await
+        .expect("create Token-2022 mint should succeed");
 
     let meta = ExtraAccountMetaInput {
         discriminator: 0,
@@ -182,14 +200,18 @@ async fn init_extra_account_meta_list_succeeds() {
     };
 
     rpc.create_and_send_transaction(
-        &[init_extra_meta_ix(&authority.pubkey(), &mint, vec![meta])],
+        &[init_extra_meta_ix(
+            &authority.pubkey(),
+            &mint_kp.pubkey(),
+            vec![meta],
+        )],
         &authority.pubkey(),
         &[&authority],
     )
     .await
     .expect("init_extra_account_meta_list should succeed");
 
-    let (meta_pda, _) = extra_meta_pda(&mint);
+    let (meta_pda, _) = extra_meta_pda(&mint_kp.pubkey());
     let info = rpc
         .get_account(meta_pda)
         .await
@@ -199,13 +221,107 @@ async fn init_extra_account_meta_list_succeeds() {
 }
 
 #[tokio::test]
-#[ignore = "requires gnark fixture + Token-2022 mint with hook configured"]
+async fn set_hook_payload_rejects_oversized_proof() {
+    let mut rpc = boot_harness().await;
+    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
+
+    rpc.create_and_send_transaction(
+        &[register_ix(&authority.pubkey(), [1u8; 32])],
+        &authority.pubkey(),
+        &[&authority],
+    )
+    .await
+    .expect("register");
+
+    let issuer_key = issuer_pda(&authority.pubkey());
+    let mut nullifier = [0u8; 32];
+    nullifier[0] = 1;
+
+    let result = rpc
+        .create_and_send_transaction(
+            &[set_hook_payload_ix(
+                &authority.pubkey(),
+                &issuer_key,
+                vec![0xaa; MAX_HOOK_PROOF_BYTES + 1],
+                nullifier,
+                Pubkey::new_unique(),
+                10,
+                Pubkey::new_unique(),
+                500,
+                default_light_args(),
+            )],
+            &authority.pubkey(),
+            &[&authority],
+        )
+        .await;
+
+    assert_rpc_error(
+        result,
+        0,
+        ANCHOR_ERROR_CODE_OFFSET + ZkSettleError::HookPayloadInvalid as u32,
+    )
+    .expect("expected HookPayloadInvalid for oversized proof");
+}
+
+#[tokio::test]
+async fn execute_hook_rejects_missing_payload() {
+    let mut rpc = boot_harness().await;
+    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
+
+    rpc.create_and_send_transaction(
+        &[register_ix(&authority.pubkey(), [1u8; 32])],
+        &authority.pubkey(),
+        &[&authority],
+    )
+    .await
+    .expect("register");
+
+    let issuer_key = issuer_pda(&authority.pubkey());
+    let fake_mint = Pubkey::new_unique();
+    let fake_source = Pubkey::new_unique();
+    let fake_dest = Pubkey::new_unique();
+    let registry = Pubkey::new_unique();
+    let bubblegum = Pubkey::new_unique();
+
+    // No hook_payload has been staged — the PDA account is uninitialized.
+    let result = rpc
+        .create_and_send_transaction(
+            &[execute_hook_ix(
+                &fake_source,
+                &fake_mint,
+                &fake_dest,
+                &authority.pubkey(),
+                &issuer_key,
+                &registry,
+                &bubblegum,
+                500,
+            )],
+            &authority.pubkey(),
+            &[&authority],
+        )
+        .await;
+
+    // Anchor AccountNotInitialized = 3012
+    assert_rpc_error(result, 0, 3012).expect("expected AccountNotInitialized for missing payload");
+}
+
+#[tokio::test]
+#[ignore = "requires gnark fixture + bubblegum tree + Token-2022 mint infrastructure"]
 async fn transfer_hook_settles_and_blocks_replay() {
     let _rpc = boot_harness().await;
-    // TODO(ADR-006 follow-up):
-    // - build Token-2022 mint with TransferHook extension pointing at zksettle
-    // - load gnark proof + witness fixture for (mint, epoch, recipient, amount)
-    // - run set_hook_payload then a Token-2022 transfer that triggers the hook
-    // - assert Light attestation account + ProofSettled event (9 fields)
-    // - replay same payload, assert address-collision error from Light CPI
+    // Blocked on:
+    //   1. Bubblegum tree registry + merkle tree init (init_attestation_tree)
+    //   2. Token-2022 mint with TransferHook extension (create_token2022_mint_with_hook_ixs helper exists)
+    //   3. gnark proof fixture for (mint, epoch, recipient, amount)
+    //
+    // Partial test plan (once bubblegum infra lands):
+    //   - register_issuer, init_attestation_tree, create Token-2022 mint
+    //   - set_hook_payload with dummy proof
+    //   - call settle_hook → expect MalformedProof from verify_bundle
+    //   - proves full account wiring up to the gnark boundary
+    //
+    // Full test:
+    //   - load valid gnark proof fixture
+    //   - Token-2022 transferChecked triggers hook → asserts Light attestation + ProofSettled event
+    //   - replay same payload → assert address-collision from Light CPI
 }

--- a/backend/programs/zksettle/tests/transfer_hook_smoke.rs
+++ b/backend/programs/zksettle/tests/transfer_hook_smoke.rs
@@ -26,31 +26,18 @@ use zksettle::instructions::transfer_hook::{ExtraAccountMetaInput, MAX_HOOK_PROO
 
 use helpers::{
     boot_harness, create_token2022_mint_with_hook_ixs, default_light_args, execute_hook_ix,
-    extra_meta_pda, funded_authority, hook_payload_pda, init_extra_meta_ix, issuer_pda,
-    register_ix, set_hook_payload_ix, ANCHOR_ERROR_CODE_OFFSET,
+    extra_meta_pda, hook_payload_pda, init_extra_meta_ix, nonzero_nullifier, registered_issuer,
+    set_hook_payload_ix, ANCHOR_ERROR_CODE_OFFSET,
 };
 
 #[tokio::test]
 async fn set_hook_payload_stores_fields() {
     let mut rpc = boot_harness().await;
-    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
+    let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
-    rpc.create_and_send_transaction(
-        &[register_ix(&authority.pubkey(), [1u8; 32])],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("register should succeed");
-
-    let issuer_key = issuer_pda(&authority.pubkey());
     let mint = Pubkey::new_unique();
     let recipient = Pubkey::new_unique();
-    let nullifier = {
-        let mut n = [0u8; 32];
-        n[0] = 1;
-        n
-    };
+    let nullifier = nonzero_nullifier();
 
     rpc.create_and_send_transaction(
         &[set_hook_payload_ix(
@@ -89,17 +76,8 @@ async fn set_hook_payload_stores_fields() {
 #[tokio::test]
 async fn set_hook_payload_rejects_zero_nullifier() {
     let mut rpc = boot_harness().await;
-    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
+    let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
-    rpc.create_and_send_transaction(
-        &[register_ix(&authority.pubkey(), [1u8; 32])],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("register");
-
-    let issuer_key = issuer_pda(&authority.pubkey());
     let result = rpc
         .create_and_send_transaction(
             &[set_hook_payload_ix(
@@ -129,19 +107,7 @@ async fn set_hook_payload_rejects_zero_nullifier() {
 #[tokio::test]
 async fn set_hook_payload_rejects_zero_amount() {
     let mut rpc = boot_harness().await;
-    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
-
-    rpc.create_and_send_transaction(
-        &[register_ix(&authority.pubkey(), [1u8; 32])],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("register");
-
-    let issuer_key = issuer_pda(&authority.pubkey());
-    let mut nullifier = [0u8; 32];
-    nullifier[0] = 1;
+    let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
     let result = rpc
         .create_and_send_transaction(
@@ -149,7 +115,7 @@ async fn set_hook_payload_rejects_zero_amount() {
                 &authority.pubkey(),
                 &issuer_key,
                 vec![0xaa; 256],
-                nullifier,
+                nonzero_nullifier(),
                 Pubkey::new_unique(),
                 10,
                 Pubkey::new_unique(),
@@ -174,18 +140,8 @@ async fn init_extra_account_meta_list_succeeds() {
     use solana_keypair::Keypair;
 
     let mut rpc = boot_harness().await;
-    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
+    let (authority, _) = registered_issuer(&mut rpc).await;
 
-    // Register issuer (required by InitExtraAccountMetaList struct constraint)
-    rpc.create_and_send_transaction(
-        &[register_ix(&authority.pubkey(), [1u8; 32])],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("register should succeed");
-
-    // Create a Token-2022 mint with TransferHook pointing to zksettle
     let mint_kp = Keypair::new();
     let mint_ixs = create_token2022_mint_with_hook_ixs(&authority.pubkey(), &mint_kp.pubkey(), 6);
     rpc.create_and_send_transaction(&mint_ixs, &authority.pubkey(), &[&authority, &mint_kp])
@@ -223,19 +179,7 @@ async fn init_extra_account_meta_list_succeeds() {
 #[tokio::test]
 async fn set_hook_payload_rejects_oversized_proof() {
     let mut rpc = boot_harness().await;
-    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
-
-    rpc.create_and_send_transaction(
-        &[register_ix(&authority.pubkey(), [1u8; 32])],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("register");
-
-    let issuer_key = issuer_pda(&authority.pubkey());
-    let mut nullifier = [0u8; 32];
-    nullifier[0] = 1;
+    let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
     let result = rpc
         .create_and_send_transaction(
@@ -243,7 +187,7 @@ async fn set_hook_payload_rejects_oversized_proof() {
                 &authority.pubkey(),
                 &issuer_key,
                 vec![0xaa; MAX_HOOK_PROOF_BYTES + 1],
-                nullifier,
+                nonzero_nullifier(),
                 Pubkey::new_unique(),
                 10,
                 Pubkey::new_unique(),
@@ -266,24 +210,14 @@ async fn set_hook_payload_rejects_oversized_proof() {
 #[tokio::test]
 async fn execute_hook_rejects_missing_payload() {
     let mut rpc = boot_harness().await;
-    let authority = funded_authority(&mut rpc, 10_000_000_000).await;
+    let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
-    rpc.create_and_send_transaction(
-        &[register_ix(&authority.pubkey(), [1u8; 32])],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("register");
-
-    let issuer_key = issuer_pda(&authority.pubkey());
     let fake_mint = Pubkey::new_unique();
     let fake_source = Pubkey::new_unique();
     let fake_dest = Pubkey::new_unique();
     let registry = Pubkey::new_unique();
     let bubblegum = Pubkey::new_unique();
 
-    // No hook_payload has been staged — the PDA account is uninitialized.
     let result = rpc
         .create_and_send_transaction(
             &[execute_hook_ix(

--- a/scripts/devnet-hook/package.json
+++ b/scripts/devnet-hook/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "zksettle-devnet-hook",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Devnet wiring script for Token-2022 transfer hook end-to-end test",
+  "scripts": {
+    "setup": "ts-node setup.ts"
+  },
+  "dependencies": {
+    "@coral-xyz/anchor": "^0.31.1",
+    "@solana/spl-token": "^0.4.9",
+    "@solana/web3.js": "^1.95.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.0"
+  }
+}

--- a/scripts/devnet-hook/setup.ts
+++ b/scripts/devnet-hook/setup.ts
@@ -1,0 +1,244 @@
+/**
+ * Devnet wiring script for zksettle Token-2022 transfer hook.
+ *
+ * Steps:
+ *  1. Load wallet from ANCHOR_WALLET or ~/.config/solana/id.json
+ *  2. Create Token-2022 mint with TransferHook extension → zksettle program
+ *  3. register_issuer with dummy roots
+ *  4. init_extra_account_meta_list with TLV entries
+ *  5. Create ATAs for sender/recipient
+ *  6. Mint tokens to sender
+ *  7. set_hook_payload (dummy proof for devnet)
+ *  8. transferChecked via Token-2022 — runtime auto-invokes hook
+ *  9. Log tx signature + result
+ *
+ * Usage:
+ *   ANCHOR_WALLET=~/.config/solana/id.json npx ts-node setup.ts
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import {
+  createInitializeTransferHookInstruction,
+  createInitializeMintInstruction,
+  createAssociatedTokenAccountInstruction,
+  createMintToInstruction,
+  createTransferCheckedInstruction,
+  getAssociatedTokenAddress,
+  ExtensionType,
+  getMintLen,
+  TOKEN_2022_PROGRAM_ID,
+} from "@solana/spl-token";
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import * as fs from "fs";
+import * as path from "path";
+
+const ZKSETTLE_PROGRAM_ID = new PublicKey(
+  "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo"
+);
+
+const ISSUER_SEED = Buffer.from("issuer");
+const HOOK_PAYLOAD_SEED = Buffer.from("hook-payload");
+const EXTRA_ACCOUNT_META_LIST_SEED = Buffer.from("extra-account-metas");
+const BUBBLEGUM_REGISTRY_SEED = Buffer.from("bubblegum-registry");
+
+function loadWallet(): Keypair {
+  const walletPath =
+    process.env.ANCHOR_WALLET ||
+    path.join(process.env.HOME || "~", ".config/solana/id.json");
+  const raw = JSON.parse(fs.readFileSync(walletPath, "utf-8"));
+  return Keypair.fromSecretKey(Uint8Array.from(raw));
+}
+
+function findPda(seeds: Buffer[], programId: PublicKey): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(seeds, programId);
+}
+
+async function main() {
+  const wallet = loadWallet();
+  const connection = new Connection(
+    process.env.RPC_URL || "https://api.devnet.solana.com",
+    "confirmed"
+  );
+
+  console.log(`Wallet: ${wallet.publicKey.toBase58()}`);
+
+  const balance = await connection.getBalance(wallet.publicKey);
+  console.log(`Balance: ${balance / 1e9} SOL`);
+
+  if (balance < 0.5 * 1e9) {
+    console.error("Insufficient balance. Need at least 0.5 SOL on devnet.");
+    console.error("Run: solana airdrop 2 --url devnet");
+    process.exit(1);
+  }
+
+  // --- Step 2: Create Token-2022 mint with TransferHook extension ---
+  const mintKeypair = Keypair.generate();
+  const mintLen = getMintLen([ExtensionType.TransferHook]);
+  const mintRent = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+  const createMintTx = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: wallet.publicKey,
+      newAccountPubkey: mintKeypair.publicKey,
+      space: mintLen,
+      lamports: mintRent,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    createInitializeTransferHookInstruction(
+      mintKeypair.publicKey,
+      wallet.publicKey,
+      ZKSETTLE_PROGRAM_ID,
+      TOKEN_2022_PROGRAM_ID
+    ),
+    createInitializeMintInstruction(
+      mintKeypair.publicKey,
+      6,
+      wallet.publicKey,
+      null,
+      TOKEN_2022_PROGRAM_ID
+    )
+  );
+
+  const mintSig = await sendAndConfirmTransaction(
+    connection,
+    createMintTx,
+    [wallet, mintKeypair],
+    { commitment: "confirmed" }
+  );
+  console.log(`Mint created: ${mintKeypair.publicKey.toBase58()}`);
+  console.log(`  tx: ${mintSig}`);
+
+  // --- Steps 3-8: zksettle program instructions (NOT YET IMPLEMENTED) ---
+  // TODO: register_issuer, init_extra_account_meta_list, set_hook_payload,
+  //       and transferChecked require the deployed program IDL to build
+  //       Anchor discriminators. Use `anchor-client` or generate from IDL.
+  const [issuerPda] = findPda(
+    [ISSUER_SEED, wallet.publicKey.toBuffer()],
+    ZKSETTLE_PROGRAM_ID
+  );
+
+  console.log(`\nIssuer PDA: ${issuerPda.toBase58()}`);
+  console.log(
+    "\nNote: This script only creates the Token-2022 mint and ATAs."
+  );
+  console.log(
+    "Steps 3-8 (register_issuer, init_extra_account_meta_list, set_hook_payload,"
+  );
+  console.log(
+    "transferChecked) are NOT implemented yet — they need IDL-based instruction building."
+  );
+  console.log(
+    "Deploy program first: anchor deploy --provider.cluster devnet --program-name zksettle"
+  );
+
+  // --- Step 4: init_extra_account_meta_list ---
+  const [extraMetaPda] = findPda(
+    [EXTRA_ACCOUNT_META_LIST_SEED, mintKeypair.publicKey.toBuffer()],
+    ZKSETTLE_PROGRAM_ID
+  );
+  console.log(`Extra account meta list PDA: ${extraMetaPda.toBase58()}`);
+
+  // --- Step 5: Create ATAs ---
+  const recipient = Keypair.generate();
+  const senderAta = await getAssociatedTokenAddress(
+    mintKeypair.publicKey,
+    wallet.publicKey,
+    false,
+    TOKEN_2022_PROGRAM_ID
+  );
+  const recipientAta = await getAssociatedTokenAddress(
+    mintKeypair.publicKey,
+    recipient.publicKey,
+    false,
+    TOKEN_2022_PROGRAM_ID
+  );
+
+  const atasTx = new Transaction().add(
+    createAssociatedTokenAccountInstruction(
+      wallet.publicKey,
+      senderAta,
+      wallet.publicKey,
+      mintKeypair.publicKey,
+      TOKEN_2022_PROGRAM_ID
+    ),
+    createAssociatedTokenAccountInstruction(
+      wallet.publicKey,
+      recipientAta,
+      recipient.publicKey,
+      mintKeypair.publicKey,
+      TOKEN_2022_PROGRAM_ID
+    )
+  );
+
+  const ataSig = await sendAndConfirmTransaction(
+    connection,
+    atasTx,
+    [wallet],
+    { commitment: "confirmed" }
+  );
+  console.log(`ATAs created: tx ${ataSig}`);
+  console.log(`  Sender ATA:    ${senderAta.toBase58()}`);
+  console.log(`  Recipient ATA: ${recipientAta.toBase58()}`);
+  console.log(`  Recipient:     ${recipient.publicKey.toBase58()}`);
+
+  // --- Step 6: Mint tokens to sender ---
+  const mintToTx = new Transaction().add(
+    createMintToInstruction(
+      mintKeypair.publicKey,
+      senderAta,
+      wallet.publicKey,
+      1_000_000,
+      [],
+      TOKEN_2022_PROGRAM_ID
+    )
+  );
+
+  const mintToSig = await sendAndConfirmTransaction(
+    connection,
+    mintToTx,
+    [wallet],
+    { commitment: "confirmed" }
+  );
+  console.log(`Minted 1.0 tokens to sender: tx ${mintToSig}`);
+
+  // --- Steps 7-8 require zksettle program on devnet ---
+  const [hookPayloadPda] = findPda(
+    [HOOK_PAYLOAD_SEED, wallet.publicKey.toBuffer()],
+    ZKSETTLE_PROGRAM_ID
+  );
+  const [registryPda] = findPda(
+    [BUBBLEGUM_REGISTRY_SEED],
+    ZKSETTLE_PROGRAM_ID
+  );
+
+  console.log("\n--- Devnet wiring complete (Token-2022 infrastructure) ---");
+  console.log("Addresses for manual hook testing:");
+  console.log(`  Program:        ${ZKSETTLE_PROGRAM_ID.toBase58()}`);
+  console.log(`  Mint:           ${mintKeypair.publicKey.toBase58()}`);
+  console.log(`  Issuer PDA:     ${issuerPda.toBase58()}`);
+  console.log(`  Hook Payload:   ${hookPayloadPda.toBase58()}`);
+  console.log(`  Extra Meta:     ${extraMetaPda.toBase58()}`);
+  console.log(`  Registry:       ${registryPda.toBase58()}`);
+  console.log(`  Sender ATA:     ${senderAta.toBase58()}`);
+  console.log(`  Recipient ATA:  ${recipientAta.toBase58()}`);
+
+  console.log(
+    "\nTo complete the test (once zksettle is deployed on devnet):"
+  );
+  console.log("  1. Call register_issuer");
+  console.log("  2. Call init_extra_account_meta_list with TLV entries");
+  console.log("  3. Call set_hook_payload with dummy proof");
+  console.log("  4. Call transferChecked — hook executes automatically");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/devnet-hook/tsconfig.json
+++ b/scripts/devnet-hook/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,15 @@ sonar.organization=yuribodo
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+
+# Exclude non-production code from analysis
+sonar.exclusions=\
+  scripts/**/*,\
+  circuits/**/*,\
+  docs/**/*,\
+  backend/migrations/**/*,\
+  **/target/**/*,\
+  **/*.lock
+
+# Exclude CLI scripts from coverage analysis
+sonar.coverage.exclusions=scripts/**/*


### PR DESCRIPTION
Type SettleHook.mint as InterfaceAccount<Mint> with payload constraint. Validate InitExtraAccountMetaList mint has TransferHook extension pointing to this program. Extend ExecuteHook validation to check mint and destination_token are owned by Token-2022.

Fix broken test helpers: set_hook_payload_ix had issuer/payload swapped, init_extra_meta_ix was missing issuer and had wrong account order. Add Token-2022 mint creation and execute_hook_ix helpers.

Add negative tests for oversized proof and missing payload PDA. Add devnet wiring script for end-to-end Token-2022 hook testing.

Refs #25