### PR TITLE
chore: dependency alignment for spl-token-2022

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,3 +13,7 @@ codegen-units = 1
 opt-level = 3
 incremental = false
 codegen-units = 1
+
+# Consider a workspace-level patch override once upstream compatibility allows it
+# [patch.crates-io]
+# spl-token-2022 = "=8.0.1"


### PR DESCRIPTION
#62 
## Context
Multiple versions of `spl-token-2022` currently coexist in our dependency tree:
- **6.0.0** — explicit dev-dependency in `programs/zksettle/Cargo.toml` (and used by `anchor-spl 0.31.1`)
- **7.0.0** — pulled by `light-sdk` → `light-token-interface`
- **8.0.1** — pulled by `solana-account-decoder` / `solana-transaction-status`

## Investigation & Changes
1. **Upstream Compatibility Check**: Investigated if `light-sdk` has a newer release that bumps `spl-token-2022` to `≥ 8.0`. The latest version (`0.23.0`) currently still pulls `7.0.0`. Thus, we cannot unify all dependencies to `≥ 8.0` without potentially breaking `light-sdk` or `anchor-spl`.
2. **Dev-dependency Alignment**: Confirmed that the explicit dev-dependency in `programs/zksettle/Cargo.toml` (`6.0`) already correctly matches the runtime version used by `anchor-spl` (`0.31.1`), which relies on `spl-token-2022` version `6.0.0`. This avoids any direct trait/type mismatches within our program's tests.
3. **Future Patch Consideration**: Added a commented-out workspace-level `[patch.crates-io]` block in `backend/Cargo.toml`. Once upstream projects (`light-sdk` and `anchor-spl`) provide compatibility for `spl-token-2022 ≥ 8.0`, we can uncomment and enforce the unified version across the workspace to reduce compile times and simplify the dependency tree.
