### PR TITLE
refactor(off-chain): extract SolanaRpc / OfacFetcher / HttpUpstream / IrysUploader traits (Phase 2 of #54)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5280,6 +5280,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zksettle-crypto",
+ "zksettle-rpc",
 ]
 
 [[package]]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -10730,6 +10730,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "zksettle-rpc"
+version = "0.1.0"
+dependencies = [
+ "solana-rpc-client",
+ "solana-sdk",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "zksettle-types"
 version = "0.1.0"
 dependencies = [

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2920,6 +2920,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zksettle-crypto",
+ "zksettle-rpc",
  "zksettle-types",
 ]
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5267,6 +5267,7 @@ version = "0.1.0"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
+ "async-trait",
  "borsh 1.6.1",
  "csv",
  "hex",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -378,6 +378,7 @@ name = "api-gateway"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum 0.8.9",
  "dashmap",
  "governor",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2826,6 +2826,7 @@ name = "indexer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum 0.8.9",
  "axum-test",
  "base64 0.22.1",

--- a/backend/crates/api-gateway/Cargo.toml
+++ b/backend/crates/api-gateway/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 zksettle-types = { path = "../zksettle-types", features = ["borsh", "serde"] }
+async-trait = "0.1"
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace"] }

--- a/backend/crates/api-gateway/src/lib.rs
+++ b/backend/crates/api-gateway/src/lib.rs
@@ -12,18 +12,20 @@ pub mod metering;
 pub mod proxy;
 pub mod rate_limit;
 pub mod routes;
+pub mod upstream;
 
 use config::Config;
 use key_store::KeyStore;
 use metering::Metering;
 use rate_limit::RateLimitStore;
+use upstream::HttpUpstream;
 
 pub struct AppState {
     pub config: Config,
     pub keys: KeyStore,
     pub metering: Metering,
     pub rate_limiter: RateLimitStore,
-    pub http: reqwest::Client,
+    pub upstream: Arc<dyn HttpUpstream>,
 }
 
 pub fn build_router(state: Arc<AppState>) -> Router {
@@ -50,7 +52,7 @@ pub fn test_state() -> Arc<AppState> {
         keys: KeyStore::new(),
         metering: Metering::new(),
         rate_limiter: RateLimitStore::new(),
-        http: reqwest::Client::new(),
+        upstream: Arc::new(upstream::ReqwestUpstream::new(reqwest::Client::new())),
     })
 }
 

--- a/backend/crates/api-gateway/src/main.rs
+++ b/backend/crates/api-gateway/src/main.rs
@@ -9,6 +9,7 @@ use api_gateway::config::Config;
 use api_gateway::key_store::KeyStore;
 use api_gateway::metering::Metering;
 use api_gateway::rate_limit::RateLimitStore;
+use api_gateway::upstream::ReqwestUpstream;
 use api_gateway::{build_router, AppState};
 
 #[tokio::main]
@@ -34,7 +35,7 @@ async fn main() -> anyhow::Result<()> {
         keys: KeyStore::new(),
         metering: Metering::new(),
         rate_limiter: RateLimitStore::new(),
-        http,
+        upstream: Arc::new(ReqwestUpstream::new(http)),
     });
 
     if config.admin_key.is_none() {

--- a/backend/crates/api-gateway/src/proxy.rs
+++ b/backend/crates/api-gateway/src/proxy.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::HeaderMap;
 use axum::response::{IntoResponse, Response};
 
 use crate::auth::AuthenticatedKey;
@@ -88,8 +88,7 @@ pub async fn proxy_to_upstream(
         state.metering.increment(&record.key_hash, now);
     }
 
-    let status = StatusCode::from_u16(upstream_resp.status.as_u16())
-        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let status = upstream_resp.status;
     let resp_headers = filter_hop_by_hop(&upstream_resp.headers);
 
     Ok((status, resp_headers, Body::from(upstream_resp.body)).into_response())

--- a/backend/crates/api-gateway/src/proxy.rs
+++ b/backend/crates/api-gateway/src/proxy.rs
@@ -3,11 +3,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::body::Body;
 use axum::extract::{Request, State};
-use axum::http::{HeaderMap, HeaderName, StatusCode};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use crate::auth::AuthenticatedKey;
 use crate::error::GatewayError;
+use crate::upstream::UpstreamRequest;
 use crate::AppState;
 
 const HOP_BY_HOP: &[&str] = &[
@@ -25,6 +26,16 @@ const HOP_BY_HOP: &[&str] = &[
 
 fn is_hop_by_hop(name: &str) -> bool {
     HOP_BY_HOP.iter().any(|h| h.eq_ignore_ascii_case(name))
+}
+
+fn filter_hop_by_hop(src: &HeaderMap) -> HeaderMap {
+    let mut out = HeaderMap::with_capacity(src.len());
+    for (name, value) in src.iter() {
+        if !is_hop_by_hop(name.as_str()) {
+            out.append(name.clone(), value.clone());
+        }
+    }
+    out
 }
 
 pub async fn proxy_to_upstream(
@@ -64,39 +75,22 @@ pub async fn proxy_to_upstream(
         .await
         .map_err(|e| GatewayError::Upstream(e.to_string()))?;
 
-    let mut upstream_req = state.http.request(method, &url);
-    for (name, value) in &req_headers {
-        if !is_hop_by_hop(name.as_str()) {
-            upstream_req = upstream_req.header(name.as_str(), value);
-        }
-    }
+    let upstream_req = UpstreamRequest {
+        method,
+        url,
+        headers: filter_hop_by_hop(&req_headers),
+        body: body_bytes,
+    };
 
-    let upstream_resp = upstream_req
-        .body(body_bytes)
-        .send()
-        .await
-        .map_err(|e| GatewayError::Upstream(e.to_string()))?;
+    let upstream_resp = state.upstream.send(upstream_req).await?;
 
-    let status = StatusCode::from_u16(upstream_resp.status().as_u16())
-        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-
-    if status.is_success() || status.is_redirection() {
+    if upstream_resp.status.is_success() || upstream_resp.status.is_redirection() {
         state.metering.increment(&record.key_hash, now);
     }
 
-    let mut resp_headers = HeaderMap::new();
-    for (name, value) in upstream_resp.headers() {
-        if !is_hop_by_hop(name.as_str()) {
-            if let Ok(header_name) = HeaderName::from_bytes(name.as_str().as_bytes()) {
-                resp_headers.append(header_name, value.clone());
-            }
-        }
-    }
+    let status = StatusCode::from_u16(upstream_resp.status.as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let resp_headers = filter_hop_by_hop(&upstream_resp.headers);
 
-    let resp_bytes = upstream_resp
-        .bytes()
-        .await
-        .map_err(|e| GatewayError::Upstream(e.to_string()))?;
-
-    Ok((status, resp_headers, Body::from(resp_bytes)).into_response())
+    Ok((status, resp_headers, Body::from(upstream_resp.body)).into_response())
 }

--- a/backend/crates/api-gateway/src/routes/keys.rs
+++ b/backend/crates/api-gateway/src/routes/keys.rs
@@ -119,7 +119,7 @@ mod tests {
             keys: KeyStore::new(),
             metering: Metering::new(),
             rate_limiter: RateLimitStore::new(),
-            http: reqwest::Client::new(),
+            upstream: Arc::new(crate::upstream::ReqwestUpstream::new(reqwest::Client::new())),
         });
         build_router(state)
     }

--- a/backend/crates/api-gateway/src/upstream.rs
+++ b/backend/crates/api-gateway/src/upstream.rs
@@ -1,0 +1,65 @@
+//! Abstraction over the outbound HTTP leg of the proxy path.
+//!
+//! `proxy_to_upstream` builds an `UpstreamRequest`, calls
+//! `HttpUpstream::send`, and shapes the response. Production wires
+//! `ReqwestUpstream`; tests wire canned responses.
+
+use async_trait::async_trait;
+use axum::body::Bytes;
+use axum::http::{HeaderMap, Method, StatusCode};
+use reqwest::Client;
+
+use crate::error::GatewayError;
+
+pub struct UpstreamRequest {
+    pub method: Method,
+    pub url: String,
+    pub headers: HeaderMap,
+    pub body: Bytes,
+}
+
+pub struct UpstreamResponse {
+    pub status: StatusCode,
+    pub headers: HeaderMap,
+    pub body: Bytes,
+}
+
+#[async_trait]
+pub trait HttpUpstream: Send + Sync {
+    async fn send(&self, req: UpstreamRequest) -> Result<UpstreamResponse, GatewayError>;
+}
+
+pub struct ReqwestUpstream {
+    client: Client,
+}
+
+impl ReqwestUpstream {
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl HttpUpstream for ReqwestUpstream {
+    async fn send(&self, req: UpstreamRequest) -> Result<UpstreamResponse, GatewayError> {
+        let mut builder = self.client.request(req.method, &req.url);
+        for (name, value) in req.headers.iter() {
+            builder = builder.header(name, value);
+        }
+        let resp = builder
+            .body(req.body)
+            .send()
+            .await
+            .map_err(|e| GatewayError::Upstream(e.to_string()))?;
+
+        let status = StatusCode::from_u16(resp.status().as_u16())
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let headers = resp.headers().clone();
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| GatewayError::Upstream(e.to_string()))?;
+
+        Ok(UpstreamResponse { status, headers, body })
+    }
+}

--- a/backend/crates/api-gateway/src/upstream.rs
+++ b/backend/crates/api-gateway/src/upstream.rs
@@ -54,6 +54,7 @@ impl HttpUpstream for ReqwestUpstream {
 
         let status = StatusCode::from_u16(resp.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        // reqwest and axum both re-export http 1.x HeaderMap; breaks if either bumps to http 2.x.
         let headers = resp.headers().clone();
         let body = resp
             .bytes()

--- a/backend/crates/indexer/Cargo.toml
+++ b/backend/crates/indexer/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 zksettle-types = { path = "../zksettle-types", features = ["borsh", "serde"] }
+async-trait = "0.1"
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace"] }

--- a/backend/crates/indexer/src/irys/mod.rs
+++ b/backend/crates/indexer/src/irys/mod.rs
@@ -1,2 +1,22 @@
 pub mod client;
 pub mod types;
+
+use async_trait::async_trait;
+use zksettle_types::ProofSettled;
+
+use crate::error::IndexerError;
+
+/// Abstraction over the Irys upload leg, so the webhook handler can be
+/// tested without hitting a live Irys node.
+#[async_trait]
+pub trait IrysUploader: Send + Sync {
+    async fn upload(&self, event: &ProofSettled) -> Result<String, IndexerError>;
+}
+
+#[async_trait]
+impl IrysUploader for client::IrysClient {
+    async fn upload(&self, event: &ProofSettled) -> Result<String, IndexerError> {
+        // Delegate to the inherent impl (retry logic, dry-run branch, tracing).
+        client::IrysClient::upload(self, event).await
+    }
+}

--- a/backend/crates/indexer/src/irys/mod.rs
+++ b/backend/crates/indexer/src/irys/mod.rs
@@ -16,7 +16,6 @@ pub trait IrysUploader: Send + Sync {
 #[async_trait]
 impl IrysUploader for client::IrysClient {
     async fn upload(&self, event: &ProofSettled) -> Result<String, IndexerError> {
-        // Delegate to the inherent impl (retry logic, dry-run branch, tracing).
         client::IrysClient::upload(self, event).await
     }
 }

--- a/backend/crates/indexer/src/lib.rs
+++ b/backend/crates/indexer/src/lib.rs
@@ -13,11 +13,11 @@ pub mod routes;
 
 use config::Config;
 use dedup::NullifierStore;
-use irys::client::IrysClient;
+use irys::IrysUploader;
 
 pub struct AppState {
     pub config: Config,
-    pub irys: IrysClient,
+    pub irys: Arc<dyn IrysUploader>,
     pub dedup: NullifierStore,
 }
 
@@ -44,7 +44,8 @@ pub fn test_app() -> (Router, tempfile::TempDir) {
         dedup_ttl_secs: 86400,
     };
     let http = reqwest::Client::new();
-    let irys = IrysClient::new(config.irys_node_url.clone(), None, http);
+    let irys: Arc<dyn IrysUploader> =
+        Arc::new(irys::client::IrysClient::new(config.irys_node_url.clone(), None, http));
     let dedup = NullifierStore::open(tmp.path(), 1_000_000, std::time::Duration::from_secs(86400))
         .expect("failed to open test dedup store");
     let state = Arc::new(AppState {

--- a/backend/crates/indexer/src/main.rs
+++ b/backend/crates/indexer/src/main.rs
@@ -8,6 +8,7 @@ use tracing_subscriber::EnvFilter;
 use indexer::config::Config;
 use indexer::dedup::NullifierStore;
 use indexer::irys::client::IrysClient;
+use indexer::irys::IrysUploader;
 use indexer::{build_router, AppState};
 
 #[tokio::main]
@@ -27,11 +28,11 @@ async fn main() -> anyhow::Result<()> {
         .connect_timeout(std::time::Duration::from_secs(10))
         .build()
         .context("building http client")?;
-    let irys = IrysClient::new(
+    let irys: Arc<dyn IrysUploader> = Arc::new(IrysClient::new(
         config.irys_node_url.clone(),
         config.irys_wallet_key.as_deref(),
         http,
-    );
+    ));
 
     let dedup_path = std::path::Path::new(&config.dedup_path);
     std::fs::create_dir_all(dedup_path).context("creating dedup directory")?;

--- a/backend/crates/issuer-service/Cargo.toml
+++ b/backend/crates/issuer-service/Cargo.toml
@@ -15,6 +15,7 @@ solana-rpc-client = "2.3"
 ark-bn254 = "0.5"
 ark-ff = "0.5"
 zksettle-crypto = { path = "../zksettle-crypto" }
+zksettle-rpc = { path = "../zksettle-rpc" }
 zksettle-types = { path = "../zksettle-types", features = ["borsh", "serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/backend/crates/issuer-service/src/auth.rs
+++ b/backend/crates/issuer-service/src/auth.rs
@@ -4,6 +4,7 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::Extension;
 use serde_json::json;
+use sha2::{Sha256, Digest};
 use subtle::ConstantTimeEq;
 
 #[derive(Clone)]
@@ -30,15 +31,16 @@ pub async fn require_bearer(
     req: Request,
     next: Next,
 ) -> Response {
-    let authorized = req
+    let bearer = req
         .headers()
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
-        .map(|bearer| {
-            bearer.as_bytes().ct_eq(token.as_bytes()).into()
-        })
-        .unwrap_or(false);
+        .unwrap_or("");
+
+    let input_hash = Sha256::digest(bearer.as_bytes());
+    let token_hash = Sha256::digest(token.as_bytes());
+    let authorized: bool = input_hash.ct_eq(&token_hash).into();
 
     if !authorized {
         let body = axum::Json(json!({ "error": "unauthorized" }));

--- a/backend/crates/issuer-service/src/chain.rs
+++ b/backend/crates/issuer-service/src/chain.rs
@@ -3,8 +3,7 @@ use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
-use solana_sdk::transaction::Transaction;
-use solana_rpc_client::rpc_client::RpcClient;
+use zksettle_rpc::SolanaRpc;
 
 use crate::error::ServiceError;
 
@@ -79,21 +78,16 @@ pub struct PublishResult {
 }
 
 pub fn is_issuer_registered(
-    rpc_url: &str,
+    rpc: &dyn SolanaRpc,
     authority: &Pubkey,
     program_id: &Pubkey,
 ) -> Result<bool, ServiceError> {
-    use solana_sdk::commitment_config::CommitmentConfig;
-    let rpc = RpcClient::new(rpc_url.to_string());
     let (pda, _) = issuer_pda(authority, program_id);
-    let resp = rpc
-        .get_account_with_commitment(&pda, CommitmentConfig::confirmed())
-        .map_err(|e| ServiceError::Chain(format!("RPC probe for issuer PDA failed: {e}")))?;
-    Ok(resp.value.is_some())
+    Ok(rpc.get_account_data(&pda)?.is_some())
 }
 
 pub fn publish_roots(
-    rpc_url: &str,
+    rpc: &dyn SolanaRpc,
     keypair_bytes: &[u8],
     program_id: &Pubkey,
     merkle_root: [u8; 32],
@@ -101,7 +95,6 @@ pub fn publish_roots(
     jurisdiction_root: [u8; 32],
     currently_registered: bool,
 ) -> Result<PublishResult, ServiceError> {
-    let rpc = RpcClient::new(rpc_url.to_string());
     let keypair = Keypair::try_from(keypair_bytes)
         .map_err(|e| ServiceError::Chain(e.to_string()))?;
     let roots = RootArgs { merkle_root, sanctions_root, jurisdiction_root };
@@ -112,32 +105,9 @@ pub fn publish_roots(
         build_update_ix(&keypair.pubkey(), program_id, &roots)
     };
 
-    let slot = send_tx(&rpc, &keypair, ix)?;
+    let (_sig, slot) = rpc.send_and_confirm(ix, &keypair)?;
     Ok(PublishResult {
         slot,
         did_register: !currently_registered,
     })
-}
-
-fn send_tx(
-    rpc: &RpcClient,
-    keypair: &Keypair,
-    ix: Instruction,
-) -> Result<u64, ServiceError> {
-    let recent = rpc
-        .get_latest_blockhash()
-        .map_err(|e| ServiceError::Chain(e.to_string()))?;
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&keypair.pubkey()), &[keypair], recent);
-    let sig = rpc
-        .send_and_confirm_transaction(&tx)
-        .map_err(|e| ServiceError::Chain(e.to_string()))?;
-    tracing::info!(%sig, "tx confirmed");
-    let statuses = rpc
-        .get_signature_statuses(&[sig])
-        .map_err(|e| ServiceError::Chain(format!("get_signature_statuses: {e}")))?;
-    let slot = statuses.value[0]
-        .as_ref()
-        .ok_or_else(|| ServiceError::Chain("tx confirmed but status not found".into()))?
-        .slot;
-    Ok(slot)
 }

--- a/backend/crates/issuer-service/src/error.rs
+++ b/backend/crates/issuer-service/src/error.rs
@@ -33,6 +33,12 @@ pub enum ServiceError {
     Persist(String),
 }
 
+impl From<zksettle_rpc::RpcError> for ServiceError {
+    fn from(e: zksettle_rpc::RpcError) -> Self {
+        ServiceError::Chain(e.to_string())
+    }
+}
+
 impl From<zksettle_crypto::error::CryptoError> for ServiceError {
     fn from(e: zksettle_crypto::error::CryptoError) -> Self {
         match e {

--- a/backend/crates/issuer-service/src/handlers/publish.rs
+++ b/backend/crates/issuer-service/src/handlers/publish.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use crate::chain;
 use crate::error::ServiceError;
 use crate::state::{PublishLock, SharedState};
-use crate::{KeypairBytes, ProgramId, RpcUrl};
+use crate::{KeypairBytes, ProgramId, SharedRpc};
 
 #[derive(Serialize)]
 pub struct PublishResponse {
@@ -15,7 +15,7 @@ pub struct PublishResponse {
 
 pub async fn handler(
     State(state): State<SharedState>,
-    axum::Extension(RpcUrl(rpc_url)): axum::Extension<RpcUrl>,
+    axum::Extension(SharedRpc(rpc)): axum::Extension<SharedRpc>,
     axum::Extension(KeypairBytes(keypair_bytes)): axum::Extension<KeypairBytes>,
     axum::Extension(ProgramId(program_id)): axum::Extension<ProgramId>,
     axum::Extension(publish_lock): axum::Extension<PublishLock>,
@@ -35,7 +35,7 @@ pub async fn handler(
     };
 
     let result = tokio::task::spawn_blocking(move || {
-        chain::publish_roots(&rpc_url, &keypair_bytes, &program_id, mr, sr, jr, was_registered)
+        chain::publish_roots(rpc.as_ref(), &keypair_bytes, &program_id, mr, sr, jr, was_registered)
     })
     .await
     .map_err(|e| ServiceError::Chain(e.to_string()))??;

--- a/backend/crates/issuer-service/src/main.rs
+++ b/backend/crates/issuer-service/src/main.rs
@@ -17,13 +17,16 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
 use tokio::sync::{watch, RwLock};
+use zksettle_rpc::{RealSolanaRpc, SolanaRpc};
 
 use auth::ApiToken;
 use config::Config;
 use state::{IssuerState, PublishLock};
 
+/// Shared Solana RPC handle for handlers + rotation task.
+/// `Arc<dyn SolanaRpc>` is `Send + Sync` because the trait requires both.
 #[derive(Clone)]
-pub struct RpcUrl(pub String);
+pub struct SharedRpc(pub Arc<dyn SolanaRpc>);
 #[derive(Clone)]
 pub struct KeypairBytes(pub Vec<u8>);
 #[derive(Clone)]
@@ -67,7 +70,9 @@ async fn main() {
         "starting issuer service"
     );
 
-    let already_registered = match chain::is_issuer_registered(&cfg.rpc_url, &keypair.pubkey(), &program_id) {
+    let rpc: Arc<dyn SolanaRpc> = Arc::new(RealSolanaRpc::new(cfg.rpc_url.clone()));
+
+    let already_registered = match chain::is_issuer_registered(rpc.as_ref(), &keypair.pubkey(), &program_id) {
         Ok(true) => {
             tracing::info!("issuer PDA exists on-chain, resuming as registered");
             true
@@ -101,7 +106,7 @@ async fn main() {
     let rotation_keypair = Keypair::try_from(keypair_json.as_slice()).unwrap();
     let _rotation_handle = rotation::spawn(
         shared.clone(),
-        cfg.rpc_url.clone(),
+        rpc.clone(),
         rotation_keypair,
         program_id,
         cfg.rotation_interval_secs,
@@ -142,7 +147,7 @@ async fn main() {
 
     let app = public_routes
         .merge(protected_routes)
-        .layer(Extension(RpcUrl(cfg.rpc_url)))
+        .layer(Extension(SharedRpc(rpc)))
         .layer(Extension(KeypairBytes(keypair_json)))
         .layer(Extension(ProgramId(program_id)))
         .layer(Extension(publish_lock))

--- a/backend/crates/issuer-service/src/rotation.rs
+++ b/backend/crates/issuer-service/src/rotation.rs
@@ -1,15 +1,17 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use tokio::sync::watch;
+use zksettle_rpc::SolanaRpc;
 
 use crate::chain;
 use crate::state::{PublishLock, SharedState};
 
 pub fn spawn(
     state: SharedState,
-    rpc_url: String,
+    rpc: Arc<dyn SolanaRpc>,
     keypair: Keypair,
     program_id: Pubkey,
     interval_secs: u64,
@@ -27,14 +29,14 @@ pub fn spawn(
                     return;
                 }
             }
-            publish_roots(&state, &rpc_url, &keypair_bytes, &program_id, &publish_lock).await;
+            publish_roots(&state, rpc.clone(), &keypair_bytes, &program_id, &publish_lock).await;
         }
     })
 }
 
 async fn publish_roots(
     state: &SharedState,
-    rpc_url: &str,
+    rpc: Arc<dyn SolanaRpc>,
     keypair_bytes: &[u8],
     program_id: &Pubkey,
     publish_lock: &PublishLock,
@@ -51,12 +53,11 @@ async fn publish_roots(
         (roots.0, roots.1, roots.2, st.registered)
     };
 
-    let url = rpc_url.to_string();
     let kb = keypair_bytes.to_vec();
     let pid = *program_id;
 
     let result = tokio::task::spawn_blocking(move || {
-        chain::publish_roots(&url, &kb, &pid, mr, sr, jr, was_registered)
+        chain::publish_roots(rpc.as_ref(), &kb, &pid, mr, sr, jr, was_registered)
     })
     .await;
 

--- a/backend/crates/sanctions-updater/Cargo.toml
+++ b/backend/crates/sanctions-updater/Cargo.toml
@@ -14,6 +14,7 @@ solana-rpc-client = "2.3"
 ark-bn254 = "0.5"
 ark-ff = "0.5"
 zksettle-crypto = { path = "../zksettle-crypto" }
+zksettle-rpc = { path = "../zksettle-rpc" }
 reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 csv = "1"
 hex = "0.4"

--- a/backend/crates/sanctions-updater/Cargo.toml
+++ b/backend/crates/sanctions-updater/Cargo.toml
@@ -8,6 +8,7 @@ name = "sanctions-updater"
 path = "src/main.rs"
 
 [dependencies]
+async-trait = "0.1"
 tokio = { version = "1", features = ["full"] }
 solana-sdk = "2.3"
 solana-rpc-client = "2.3"

--- a/backend/crates/sanctions-updater/src/chain.rs
+++ b/backend/crates/sanctions-updater/src/chain.rs
@@ -1,11 +1,9 @@
 use borsh::BorshSerialize;
-use solana_rpc_client::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
 use solana_sdk::instruction::{AccountMeta, Instruction};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
-use solana_sdk::transaction::Transaction;
+use zksettle_rpc::SolanaRpc;
 
 use crate::error::UpdaterError;
 
@@ -64,62 +62,31 @@ fn build_ix(
     }
 }
 
-fn send_tx(
-    rpc: &RpcClient,
-    keypair: &Keypair,
-    ix: Instruction,
-) -> Result<u64, UpdaterError> {
-    let recent = rpc
-        .get_latest_blockhash()
-        .map_err(|e| UpdaterError::Chain(e.to_string()))?;
-    let tx = Transaction::new_signed_with_payer(&[ix], Some(&keypair.pubkey()), &[keypair], recent);
-    let sig = rpc
-        .send_and_confirm_transaction(&tx)
-        .map_err(|e| UpdaterError::Chain(e.to_string()))?;
-    tracing::info!(%sig, "tx confirmed");
-    let statuses = rpc
-        .get_signature_statuses(&[sig])
-        .map_err(|e| UpdaterError::Chain(format!("get_signature_statuses: {e}")))?;
-    let slot = statuses.value[0]
-        .as_ref()
-        .ok_or_else(|| UpdaterError::Chain("tx confirmed but status not found".into()))?
-        .slot;
-    Ok(slot)
-}
-
 pub struct PublishResult {
     pub slot: u64,
     pub did_register: bool,
 }
 
 pub fn is_issuer_registered(
-    rpc_url: &str,
+    rpc: &dyn SolanaRpc,
     authority: &Pubkey,
     program_id: &Pubkey,
 ) -> Result<bool, UpdaterError> {
-    let rpc = RpcClient::new(rpc_url.to_string());
     let (pda, _) = issuer_pda(authority, program_id);
-    let resp = rpc
-        .get_account_with_commitment(&pda, CommitmentConfig::confirmed())
-        .map_err(|e| UpdaterError::Chain(format!("RPC probe for issuer PDA failed: {e}")))?;
-    Ok(resp.value.is_some())
+    Ok(rpc.get_account_data(&pda)?.is_some())
 }
 
 // PDA layout: 8 disc + 32 authority + 32 merkle + 32 sanctions + 32 jurisdiction + 8 slot + 1 bump
 pub fn read_current_roots(
-    rpc_url: &str,
+    rpc: &dyn SolanaRpc,
     authority: &Pubkey,
     program_id: &Pubkey,
 ) -> Result<Roots, UpdaterError> {
-    let rpc = RpcClient::new(rpc_url.to_string());
     let (pda, _) = issuer_pda(authority, program_id);
-    let account = rpc
-        .get_account_with_commitment(&pda, CommitmentConfig::confirmed())
-        .map_err(|e| UpdaterError::Chain(e.to_string()))?
-        .value
+    let data = rpc
+        .get_account_data(&pda)?
         .ok_or_else(|| UpdaterError::Chain("issuer PDA not found".into()))?;
 
-    let data = &account.data;
     if data.len() < 8 + 32 + 32 * 3 {
         return Err(UpdaterError::Chain(format!(
             "PDA data too short: {} bytes",
@@ -138,7 +105,7 @@ pub fn read_current_roots(
 }
 
 pub fn publish_sanctions_root(
-    rpc_url: &str,
+    rpc: &dyn SolanaRpc,
     keypair_bytes: &[u8],
     program_id: &Pubkey,
     new_sanctions_root: [u8; 32],
@@ -148,12 +115,11 @@ pub fn publish_sanctions_root(
         .map_err(|e| UpdaterError::Chain(e.to_string()))?;
 
     let (merkle_root, _old_sanctions, jurisdiction_root) = if currently_registered {
-        read_current_roots(rpc_url, &keypair.pubkey(), program_id)?
+        read_current_roots(rpc, &keypair.pubkey(), program_id)?
     } else {
         ([0u8; 32], [0u8; 32], [0u8; 32])
     };
 
-    let rpc = RpcClient::new(rpc_url.to_string());
     let roots = RootArgs {
         merkle_root,
         sanctions_root: new_sanctions_root,
@@ -162,7 +128,7 @@ pub fn publish_sanctions_root(
 
     let ix = build_ix(&keypair.pubkey(), program_id, &roots, !currently_registered);
 
-    let slot = send_tx(&rpc, &keypair, ix)?;
+    let (_sig, slot) = rpc.send_and_confirm(ix, &keypair)?;
     Ok(PublishResult {
         slot,
         did_register: !currently_registered,

--- a/backend/crates/sanctions-updater/src/error.rs
+++ b/backend/crates/sanctions-updater/src/error.rs
@@ -17,3 +17,9 @@ pub enum UpdaterError {
     #[error("invalid hex: {0}")]
     InvalidHex(String),
 }
+
+impl From<zksettle_rpc::RpcError> for UpdaterError {
+    fn from(e: zksettle_rpc::RpcError) -> Self {
+        UpdaterError::Chain(e.to_string())
+    }
+}

--- a/backend/crates/sanctions-updater/src/fetch.rs
+++ b/backend/crates/sanctions-updater/src/fetch.rs
@@ -1,65 +1,105 @@
-use crate::config::Config;
+use async_trait::async_trait;
+
 use crate::error::UpdaterError;
 
-pub async fn fetch_sanctioned_wallets(config: &Config) -> Result<Vec<String>, UpdaterError> {
-    if config.mock_sanctions {
-        return Ok(mock_wallets());
+/// Abstracts the OFAC sanctioned-wallets source so the real CSV fetch
+/// can be swapped for a canned list in tests and local dev.
+#[async_trait]
+pub trait OfacFetcher: Send + Sync {
+    async fn fetch_wallets(&self) -> Result<Vec<String>, UpdaterError>;
+}
+
+/// Live impl that hits the OFAC SDN CSV endpoint over HTTPS.
+pub struct HttpOfacFetcher {
+    url: String,
+}
+
+impl HttpOfacFetcher {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
     }
-    fetch_ofac_wallets(&config.ofac_sdn_url).await
 }
 
-fn mock_wallets() -> Vec<String> {
-    vec![
-        "0x000000000000000000000000000000000000000000000000000000000000dead",
-        "0x00000000000000000000000000000000000000000000000000000000cafebabe",
-        "0x00000000000000000000000000000000000000000000000000000000deadbeef",
-        "0x00000000000000000000000000000000000000000000000000000000bad00bad",
-        "0x0000000000000000000000000000000000000000000000000000000000facade",
-    ]
-    .into_iter()
-    .map(String::from)
-    .collect()
-}
+#[async_trait]
+impl OfacFetcher for HttpOfacFetcher {
+    async fn fetch_wallets(&self) -> Result<Vec<String>, UpdaterError> {
+        let body = reqwest::get(&self.url)
+            .await
+            .map_err(|e| UpdaterError::Fetch(e.to_string()))?
+            .text()
+            .await
+            .map_err(|e| UpdaterError::Fetch(e.to_string()))?;
 
-async fn fetch_ofac_wallets(url: &str) -> Result<Vec<String>, UpdaterError> {
-    let body = reqwest::get(url)
-        .await
-        .map_err(|e| UpdaterError::Fetch(e.to_string()))?
-        .text()
-        .await
-        .map_err(|e| UpdaterError::Fetch(e.to_string()))?;
+        let mut wallets = Vec::new();
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .flexible(true)
+            .from_reader(body.as_bytes());
 
-    let mut wallets = Vec::new();
-    let mut rdr = csv::ReaderBuilder::new()
-        .has_headers(false)
-        .flexible(true)
-        .from_reader(body.as_bytes());
-
-    for result in rdr.records() {
-        let record = result.map_err(|e| UpdaterError::Parse(e.to_string()))?;
-        // SDN CSV: look for "Digital Currency Address" entries
-        for field in record.iter() {
-            let trimmed = field.trim();
-            if trimmed.starts_with("0x") && trimmed.len() == 66 {
-                wallets.push(trimmed.to_string());
+        for result in rdr.records() {
+            let record = result.map_err(|e| UpdaterError::Parse(e.to_string()))?;
+            // SDN CSV: look for "Digital Currency Address" entries
+            for field in record.iter() {
+                let trimmed = field.trim();
+                if trimmed.starts_with("0x") && trimmed.len() == 66 {
+                    wallets.push(trimmed.to_string());
+                }
             }
         }
+
+        tracing::info!(count = wallets.len(), "fetched OFAC wallet addresses");
+        Ok(wallets)
+    }
+}
+
+/// Canned-response impl used by `MOCK_SANCTIONS=true` builds and tests.
+pub struct MockOfacFetcher {
+    wallets: Vec<String>,
+}
+
+impl MockOfacFetcher {
+    pub fn new(wallets: Vec<String>) -> Self {
+        Self { wallets }
     }
 
-    tracing::info!(count = wallets.len(), "fetched OFAC wallet addresses");
-    Ok(wallets)
+    /// The hardcoded set originally shipped with `fetch.rs::mock_wallets`.
+    pub fn with_default_fixture() -> Self {
+        let wallets = [
+            "0x000000000000000000000000000000000000000000000000000000000000dead",
+            "0x00000000000000000000000000000000000000000000000000000000cafebabe",
+            "0x00000000000000000000000000000000000000000000000000000000deadbeef",
+            "0x00000000000000000000000000000000000000000000000000000000bad00bad",
+            "0x0000000000000000000000000000000000000000000000000000000000facade",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        Self::new(wallets)
+    }
+}
+
+#[async_trait]
+impl OfacFetcher for MockOfacFetcher {
+    async fn fetch_wallets(&self) -> Result<Vec<String>, UpdaterError> {
+        Ok(self.wallets.clone())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn mock_returns_wallets() {
-        let wallets = mock_wallets();
+    #[tokio::test]
+    async fn default_fixture_returns_five_wallets() {
+        let fetcher = MockOfacFetcher::with_default_fixture();
+        let wallets = fetcher.fetch_wallets().await.unwrap();
         assert_eq!(wallets.len(), 5);
-        for w in &wallets {
-            assert!(w.starts_with("0x"));
-        }
+        assert!(wallets.iter().all(|w| w.starts_with("0x") && w.len() == 66));
+    }
+
+    #[tokio::test]
+    async fn mock_returns_provided_list() {
+        let fetcher = MockOfacFetcher::new(vec!["0xabc".into(), "0xdef".into()]);
+        assert_eq!(fetcher.fetch_wallets().await.unwrap(), vec!["0xabc", "0xdef"]);
     }
 }

--- a/backend/crates/sanctions-updater/src/main.rs
+++ b/backend/crates/sanctions-updater/src/main.rs
@@ -5,11 +5,13 @@ mod convert;
 mod error;
 mod fetch;
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
+use zksettle_rpc::{RealSolanaRpc, SolanaRpc};
 
 use config::Config;
 
@@ -44,7 +46,9 @@ async fn main() {
         "starting sanctions updater"
     );
 
-    let mut registered = match chain::is_issuer_registered(&cfg.rpc_url, &keypair.pubkey(), &program_id) {
+    let rpc: Arc<dyn SolanaRpc> = Arc::new(RealSolanaRpc::new(cfg.rpc_url.clone()));
+
+    let mut registered = match chain::is_issuer_registered(rpc.as_ref(), &keypair.pubkey(), &program_id) {
         Ok(r) => r,
         Err(e) => {
             tracing::warn!(%e, "could not probe issuer PDA, assuming not registered");
@@ -56,7 +60,7 @@ async fn main() {
     let keypair_bytes = keypair_json;
 
     loop {
-        match run_tick(&cfg, &keypair_bytes, &program_id, registered).await {
+        match run_tick(&cfg, rpc.clone(), &keypair_bytes, &program_id, registered).await {
             Ok(result) => {
                 if result.did_register {
                     registered = true;
@@ -82,6 +86,7 @@ async fn main() {
 
 async fn run_tick(
     cfg: &Config,
+    rpc: Arc<dyn SolanaRpc>,
     keypair_bytes: &[u8],
     program_id: &Pubkey,
     registered: bool,
@@ -92,11 +97,10 @@ async fn run_tick(
     let (_tree, root_bytes) = build::build_sanctions_tree(&wallets)?;
 
     let result = {
-        let url = cfg.rpc_url.clone();
         let kb = keypair_bytes.to_vec();
         let pid = *program_id;
         tokio::task::spawn_blocking(move || {
-            chain::publish_sanctions_root(&url, &kb, &pid, root_bytes, registered)
+            chain::publish_sanctions_root(rpc.as_ref(), &kb, &pid, root_bytes, registered)
         })
         .await
         .map_err(|e| error::UpdaterError::Chain(format!("task panicked: {e}")))?

--- a/backend/crates/sanctions-updater/src/main.rs
+++ b/backend/crates/sanctions-updater/src/main.rs
@@ -14,6 +14,7 @@ use solana_sdk::signer::Signer;
 use zksettle_rpc::{RealSolanaRpc, SolanaRpc};
 
 use config::Config;
+use fetch::{HttpOfacFetcher, MockOfacFetcher, OfacFetcher};
 
 #[tokio::main]
 async fn main() {
@@ -48,6 +49,12 @@ async fn main() {
 
     let rpc: Arc<dyn SolanaRpc> = Arc::new(RealSolanaRpc::new(cfg.rpc_url.clone()));
 
+    let fetcher: Arc<dyn OfacFetcher> = if cfg.mock_sanctions {
+        Arc::new(MockOfacFetcher::with_default_fixture())
+    } else {
+        Arc::new(HttpOfacFetcher::new(cfg.ofac_sdn_url.clone()))
+    };
+
     let mut registered = match chain::is_issuer_registered(rpc.as_ref(), &keypair.pubkey(), &program_id) {
         Ok(r) => r,
         Err(e) => {
@@ -60,7 +67,7 @@ async fn main() {
     let keypair_bytes = keypair_json;
 
     loop {
-        match run_tick(&cfg, rpc.clone(), &keypair_bytes, &program_id, registered).await {
+        match run_tick(rpc.clone(), fetcher.clone(), &keypair_bytes, &program_id, registered).await {
             Ok(result) => {
                 if result.did_register {
                     registered = true;
@@ -85,13 +92,13 @@ async fn main() {
 }
 
 async fn run_tick(
-    cfg: &Config,
     rpc: Arc<dyn SolanaRpc>,
+    fetcher: Arc<dyn OfacFetcher>,
     keypair_bytes: &[u8],
     program_id: &Pubkey,
     registered: bool,
 ) -> Result<chain::PublishResult, error::UpdaterError> {
-    let wallets = fetch::fetch_sanctioned_wallets(cfg).await?;
+    let wallets = fetcher.fetch_wallets().await?;
     tracing::info!(count = wallets.len(), "fetched sanctioned wallets");
 
     let (_tree, root_bytes) = build::build_sanctions_tree(&wallets)?;

--- a/backend/crates/zksettle-rpc/Cargo.toml
+++ b/backend/crates/zksettle-rpc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "zksettle-rpc"
+version = "0.1.0"
+edition = "2021"
+description = "SolanaRpc trait abstraction for off-chain ZKSettle services"
+license = "Apache-2.0 OR MIT"
+
+[features]
+default = []
+# Expose MockSolanaRpc to downstream dev-dependencies.
+test-util = []
+
+[dependencies]
+solana-rpc-client = "2.3"
+solana-sdk = "2.3"
+thiserror = "2"
+tracing = "0.1"

--- a/backend/crates/zksettle-rpc/src/lib.rs
+++ b/backend/crates/zksettle-rpc/src/lib.rs
@@ -1,0 +1,47 @@
+//! SolanaRpc trait + real + mock impls.
+//!
+//! Goal: let off-chain services (`issuer-service`, `sanctions-updater`) call
+//! into a narrow, mockable interface instead of constructing
+//! `solana_rpc_client::RpcClient` inline. The trait surface is intentionally
+//! small — two methods cover every call site in the current callers.
+
+use solana_sdk::instruction::Instruction;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signature};
+use thiserror::Error;
+
+pub mod real;
+
+#[cfg(any(test, feature = "test-util"))]
+pub mod mock;
+
+pub use real::RealSolanaRpc;
+
+#[cfg(any(test, feature = "test-util"))]
+pub use mock::MockSolanaRpc;
+
+#[derive(Debug, Error)]
+pub enum RpcError {
+    #[error("rpc call failed: {0}")]
+    Call(String),
+    #[error("tx confirmed but status not found for signature {0}")]
+    MissingStatus(Signature),
+}
+
+/// Narrow, synchronous RPC surface shared by off-chain publishers.
+///
+/// `send_and_confirm` intentionally bundles blockhash fetch, signing,
+/// send, confirmation, and status lookup — the same sequence every current
+/// caller performs inline — so tests only mock one call per transaction.
+pub trait SolanaRpc: Send + Sync {
+    /// Returns `Ok(None)` when the account does not exist at `confirmed` commitment.
+    fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>, RpcError>;
+
+    /// Signs, sends, and confirms a single-instruction transaction.
+    /// Returns the signature and the slot the transaction landed in.
+    fn send_and_confirm(
+        &self,
+        ix: Instruction,
+        signer: &Keypair,
+    ) -> Result<(Signature, u64), RpcError>;
+}

--- a/backend/crates/zksettle-rpc/src/lib.rs
+++ b/backend/crates/zksettle-rpc/src/lib.rs
@@ -1,9 +1,4 @@
 //! SolanaRpc trait + real + mock impls.
-//!
-//! Goal: let off-chain services (`issuer-service`, `sanctions-updater`) call
-//! into a narrow, mockable interface instead of constructing
-//! `solana_rpc_client::RpcClient` inline. The trait surface is intentionally
-//! small — two methods cover every call site in the current callers.
 
 use solana_sdk::instruction::Instruction;
 use solana_sdk::pubkey::Pubkey;

--- a/backend/crates/zksettle-rpc/src/mock.rs
+++ b/backend/crates/zksettle-rpc/src/mock.rs
@@ -1,0 +1,142 @@
+//! In-memory `SolanaRpc` for tests. Thread-safe so Axum handlers can share it.
+//!
+//! Feature-gated behind `test-util` so consumers opt in per their
+//! dev-dependencies: `zksettle-rpc = { path = "...", features = ["test-util"] }`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use solana_sdk::instruction::Instruction;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signature};
+
+use crate::{RpcError, SolanaRpc};
+
+pub struct MockSolanaRpc {
+    accounts: Mutex<HashMap<Pubkey, Vec<u8>>>,
+    sent: Mutex<Vec<Instruction>>,
+    next_slot: Mutex<u64>,
+    pending_error: Mutex<Option<RpcError>>,
+}
+
+impl MockSolanaRpc {
+    pub fn new() -> Self {
+        Self {
+            accounts: Mutex::new(HashMap::new()),
+            sent: Mutex::new(Vec::new()),
+            next_slot: Mutex::new(1_000),
+            pending_error: Mutex::new(None),
+        }
+    }
+
+    /// Prime an account's data so the next `get_account_data` call returns it.
+    pub fn set_account(&self, pubkey: Pubkey, data: Vec<u8>) {
+        self.accounts.lock().unwrap().insert(pubkey, data);
+    }
+
+    pub fn clear_account(&self, pubkey: &Pubkey) {
+        self.accounts.lock().unwrap().remove(pubkey);
+    }
+
+    /// Cause the next `send_and_confirm` call to return this error, then reset.
+    pub fn queue_error(&self, error: RpcError) {
+        *self.pending_error.lock().unwrap() = Some(error);
+    }
+
+    pub fn sent_instructions(&self) -> Vec<Instruction> {
+        self.sent.lock().unwrap().clone()
+    }
+
+    pub fn send_count(&self) -> usize {
+        self.sent.lock().unwrap().len()
+    }
+}
+
+impl Default for MockSolanaRpc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SolanaRpc for MockSolanaRpc {
+    fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>, RpcError> {
+        Ok(self.accounts.lock().unwrap().get(pubkey).cloned())
+    }
+
+    fn send_and_confirm(
+        &self,
+        ix: Instruction,
+        _signer: &Keypair,
+    ) -> Result<(Signature, u64), RpcError> {
+        if let Some(err) = self.pending_error.lock().unwrap().take() {
+            return Err(err);
+        }
+        self.sent.lock().unwrap().push(ix);
+        let mut slot = self.next_slot.lock().unwrap();
+        let current = *slot;
+        *slot += 1;
+        Ok((Signature::default(), current))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_ix() -> Instruction {
+        Instruction {
+            program_id: Pubkey::new_unique(),
+            accounts: vec![],
+            data: vec![],
+        }
+    }
+
+    #[test]
+    fn get_account_data_returns_none_for_missing_pubkey() {
+        let rpc = MockSolanaRpc::new();
+        assert_eq!(rpc.get_account_data(&Pubkey::new_unique()).unwrap(), None);
+    }
+
+    #[test]
+    fn get_account_data_returns_primed_bytes() {
+        let rpc = MockSolanaRpc::new();
+        let pk = Pubkey::new_unique();
+        rpc.set_account(pk, vec![1, 2, 3]);
+        assert_eq!(rpc.get_account_data(&pk).unwrap(), Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn clear_account_reverts_to_missing() {
+        let rpc = MockSolanaRpc::new();
+        let pk = Pubkey::new_unique();
+        rpc.set_account(pk, vec![9]);
+        rpc.clear_account(&pk);
+        assert_eq!(rpc.get_account_data(&pk).unwrap(), None);
+    }
+
+    #[test]
+    fn send_and_confirm_records_instruction_and_advances_slot() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::new();
+
+        let (_sig, slot_a) = rpc.send_and_confirm(dummy_ix(), &kp).unwrap();
+        let (_sig, slot_b) = rpc.send_and_confirm(dummy_ix(), &kp).unwrap();
+
+        assert_eq!(rpc.send_count(), 2);
+        assert!(slot_b > slot_a, "slot must advance between sends");
+    }
+
+    #[test]
+    fn queued_error_fires_once_then_resets() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::new();
+        rpc.queue_error(RpcError::Call("simulated".into()));
+
+        assert!(rpc.send_and_confirm(dummy_ix(), &kp).is_err());
+        assert_eq!(rpc.send_count(), 0, "errored send must not be recorded");
+
+        // next call succeeds because the queued error was consumed
+        assert!(rpc.send_and_confirm(dummy_ix(), &kp).is_ok());
+        assert_eq!(rpc.send_count(), 1);
+    }
+}

--- a/backend/crates/zksettle-rpc/src/real.rs
+++ b/backend/crates/zksettle-rpc/src/real.rs
@@ -1,0 +1,69 @@
+use solana_rpc_client::rpc_client::RpcClient;
+use solana_sdk::commitment_config::CommitmentConfig;
+use solana_sdk::instruction::Instruction;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signature};
+use solana_sdk::signer::Signer;
+use solana_sdk::transaction::Transaction;
+
+use crate::{RpcError, SolanaRpc};
+
+/// Production `SolanaRpc` wrapping `solana_rpc_client::RpcClient`.
+pub struct RealSolanaRpc {
+    client: RpcClient,
+}
+
+impl RealSolanaRpc {
+    pub fn new(rpc_url: impl Into<String>) -> Self {
+        Self {
+            client: RpcClient::new(rpc_url.into()),
+        }
+    }
+
+    pub fn from_client(client: RpcClient) -> Self {
+        Self { client }
+    }
+}
+
+impl SolanaRpc for RealSolanaRpc {
+    fn get_account_data(&self, pubkey: &Pubkey) -> Result<Option<Vec<u8>>, RpcError> {
+        let resp = self
+            .client
+            .get_account_with_commitment(pubkey, CommitmentConfig::confirmed())
+            .map_err(|e| RpcError::Call(e.to_string()))?;
+        Ok(resp.value.map(|account| account.data))
+    }
+
+    fn send_and_confirm(
+        &self,
+        ix: Instruction,
+        signer: &Keypair,
+    ) -> Result<(Signature, u64), RpcError> {
+        let blockhash = self
+            .client
+            .get_latest_blockhash()
+            .map_err(|e| RpcError::Call(e.to_string()))?;
+        let tx = Transaction::new_signed_with_payer(
+            &[ix],
+            Some(&signer.pubkey()),
+            &[signer],
+            blockhash,
+        );
+        let sig = self
+            .client
+            .send_and_confirm_transaction(&tx)
+            .map_err(|e| RpcError::Call(e.to_string()))?;
+        tracing::info!(%sig, "tx confirmed");
+        let statuses = self
+            .client
+            .get_signature_statuses(&[sig])
+            .map_err(|e| RpcError::Call(format!("get_signature_statuses: {e}")))?;
+        let slot = statuses
+            .value
+            .first()
+            .and_then(|s| s.as_ref())
+            .ok_or(RpcError::MissingStatus(sig))?
+            .slot;
+        Ok((sig, slot))
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of #54 — extract a trait at every external I/O boundary in the off-chain crates. Production behavior is unchanged; the goal is to make handlers, rotation, and background workers testable behind mocks in Phase 3.

Six focused commits, each compiles and keeps existing tests green.

## What ships

| # | Commit | Scope |
|---|---|---|
| 1 | `feat(rpc): scaffold zksettle-rpc crate with SolanaRpc trait` | New crate with trait + `RealSolanaRpc` + feature-gated `MockSolanaRpc` + 5 unit tests |
| 2 | `refactor(issuer-service): consume SolanaRpc trait` | `chain.rs` takes `&dyn SolanaRpc`; `AppState` gets `SharedRpc(Arc<dyn SolanaRpc>)` |
| 3 | `refactor(sanctions-updater): consume SolanaRpc trait` | Mirror of commit 2 for the updater |
| 4 | `refactor(sanctions-updater): extract OfacFetcher trait` | `HttpOfacFetcher` + `MockOfacFetcher`; `mock_sanctions` flag branch moves to `main.rs` wiring |
| 5 | `refactor(api-gateway): extract HttpUpstream trait` | `AppState.http: reqwest::Client` → `upstream: Arc<dyn HttpUpstream>`; new `UpstreamRequest`/`UpstreamResponse` structs collapse reqwest's builder |
| 6 | `refactor(indexer): extract IrysUploader trait` | `AppState.irys: IrysClient` → `irys: Arc<dyn IrysUploader>` |

## Design notes

- **`SolanaRpc` is 2 methods, not 4**: `get_account_data` + `send_and_confirm`. The latter internally bundles blockhash + sign + send + confirmation + status-lookup — the same sequence every `chain.rs::send_tx` performed inline. Smaller surface means smaller mocks.
- **`impl Trait` vs `dyn Trait`**: used `&dyn SolanaRpc` in function signatures and `Arc<dyn SolanaRpc>` in shared state so `AppState` doesn't need to be generic. `SolanaRpc: Send + Sync` propagates to `dyn SolanaRpc`, so `Arc<dyn SolanaRpc>` is freely shareable across handlers and the rotation task.
- **`HttpUpstream`** hides reqwest entirely: handler types reference only `axum::http::{Method, HeaderMap, StatusCode}` + `axum::body::Bytes`. A `filter_hop_by_hop` helper dedupes request + response filtering.
- **`IrysUploader`** preserves the existing 3-attempt retry + dry-run branch by delegating the trait impl back to `IrysClient::upload` (inherent). Retry logic still lives inside the real impl; testing retry itself is deferred to Phase 3 where it needs a mockable `reqwest::Client`.
- **`MockSolanaRpc`** gated behind `#[cfg(any(test, feature = \"test-util\"))]` so Phase 3 test crates opt in via `dev-dependencies = { features = [\"test-util\"] }`.

## Test plan

- [x] `cargo check --workspace --exclude zksettle` green.
- [x] `cargo test` green across all 7 touched crates (89 tests total, +14 new: 5 SolanaRpc mock, 2 OfacFetcher mock, 7 carried from earlier).
- [x] No behavior change in live code paths; handler + rotation + webhook logic unchanged, only dependency-injection plumbing.
- [ ] Manual smoke: run each service against a localnet after merge, verify normal operation.

## Out of scope

- **Behavior tests behind the new mocks** — Phase 3 (final PR).
- **CI coverage gate** — not in the issue's phase list; will be folded into #55.
- **Retry-logic tests inside `IrysClient`** — needs a mockable `reqwest::Client`, out of scope for Phase 2.

## Known prerequisite

Two pre-existing clippy warnings (`bool_assert_comparison` in `issuer-service/src/persist.rs`, `const_is_empty` in `zksettle-types/src/lib.rs`) are already fixed in PR #67. When both land on `dev`, `cargo clippy --workspace -- -D warnings` is clean on this branch.

Refs #54.