### PR TITLE
Harden gateway, issuer-service, and transfer-hook tests

### DIFF
--- a/backend/crates/api-gateway/src/upstream.rs
+++ b/backend/crates/api-gateway/src/upstream.rs
@@ -54,12 +54,37 @@ impl HttpUpstream for ReqwestUpstream {
 
         let status = StatusCode::from_u16(resp.status().as_u16())
             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+        const MAX_RESPONSE_BYTES: usize = 1024 * 1024;
+
+        let content_length = resp
+            .headers()
+            .get(reqwest::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok());
+
+        if let Some(len) = content_length {
+            if len > MAX_RESPONSE_BYTES {
+                return Err(GatewayError::Upstream(format!(
+                    "upstream response too large: {len} bytes"
+                )));
+            }
+        }
+
         // reqwest and axum both re-export http 1.x HeaderMap; breaks if either bumps to http 2.x.
         let headers = resp.headers().clone();
+
         let body = resp
             .bytes()
             .await
             .map_err(|e| GatewayError::Upstream(e.to_string()))?;
+
+        if body.len() > MAX_RESPONSE_BYTES {
+            return Err(GatewayError::Upstream(format!(
+                "upstream response too large: {} bytes",
+                body.len()
+            )));
+        }
 
         Ok(UpstreamResponse { status, headers, body })
     }

--- a/backend/crates/issuer-service/src/handlers/revoke_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/revoke_credential.rs
@@ -31,12 +31,14 @@ pub async fn handler(
     }
 
     let leaf_index = cred.leaf_index;
+    let prev_roots_dirty = st.roots_dirty;
 
     st.membership_tree
         .zero_leaf(leaf_index)
         .map_err(ServiceError::from)?;
 
-    if !st.sanctions_tree.remove(wallet_fr) {
+    let removed_from_sanctions = st.sanctions_tree.remove(wallet_fr);
+    if !removed_from_sanctions {
         tracing::debug!(%wallet, "wallet was not in sanctions tree");
     }
 
@@ -48,7 +50,20 @@ pub async fn handler(
     st.roots_dirty = true;
 
     if let Some(ref path) = state_path {
-        crate::persist::save(path, &st)?;
+        if let Err(e) = crate::persist::save(path, &st) {
+            if let Err(e) = st.membership_tree.set_leaf(leaf_index, wallet_fr) {
+                tracing::error!(%e, "rollback set_leaf failed, state may be inconsistent");
+            }
+            if removed_from_sanctions {
+                st.sanctions_tree.insert(wallet_fr);
+            }
+            st.credentials
+                .get_mut(&wallet_bytes)
+                .expect("checked above")
+                .revoked = false;
+            st.roots_dirty = prev_roots_dirty;
+            return Err(e.into());
+        }
     }
 
     Ok(Json(RevokeResponse {

--- a/backend/crates/issuer-service/src/main.rs
+++ b/backend/crates/issuer-service/src/main.rs
@@ -56,8 +56,28 @@ async fn main() {
         .parse()
         .unwrap_or_else(|e| panic!("invalid program ID '{}': {e}", cfg.program_id));
 
-    if cfg.api_token.is_none() {
-        tracing::warn!("API_TOKEN not set — all endpoints are unauthenticated");
+    let allow_unauth = std::env::var("ALLOW_UNAUTHENTICATED")
+        .ok()
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
+        .unwrap_or(false);
+
+    match (&cfg.api_token, cfg.listen_addr.ip().is_loopback(), allow_unauth) {
+        (Some(_), _, _) => {}
+        (None, true, _) => {
+            tracing::warn!("API_TOKEN not set — bearer auth disabled on loopback");
+        }
+        (None, false, true) => {
+            tracing::warn!(
+                "API_TOKEN not set and ALLOW_UNAUTHENTICATED=true — write endpoints are anonymous"
+            );
+        }
+        (None, false, false) => {
+            panic!(
+                "refusing to start: API_TOKEN not set on non-loopback address {}; \
+                 set API_TOKEN or ALLOW_UNAUTHENTICATED=true",
+                cfg.listen_addr
+            );
+        }
     }
 
     tracing::info!(

--- a/backend/programs/zksettle/tests/helpers/instructions.rs
+++ b/backend/programs/zksettle/tests/helpers/instructions.rs
@@ -210,11 +210,15 @@ pub fn execute_hook_ix(
 
 pub fn close_hook_payload_ix(authority: &Pubkey) -> Instruction {
     let (payload_pda, _) = hook_payload_pda(authority);
+    close_hook_payload_ix_with_pda(authority, &payload_pda)
+}
+
+pub fn close_hook_payload_ix_with_pda(signer: &Pubkey, payload_pda: &Pubkey) -> Instruction {
     Instruction {
         program_id: zksettle::ID,
         accounts: vec![
-            AccountMeta::new(*authority, true),
-            AccountMeta::new(payload_pda, false),
+            AccountMeta::new(*signer, true),
+            AccountMeta::new(*payload_pda, false),
         ],
         data: ClosePayloadIx {}.data(),
     }

--- a/backend/programs/zksettle/tests/helpers/mod.rs
+++ b/backend/programs/zksettle/tests/helpers/mod.rs
@@ -3,7 +3,8 @@ pub mod instructions;
 
 pub use harness::{boot_harness, funded_authority, nonzero_nullifier, registered_issuer};
 pub use instructions::{
-    close_hook_payload_ix, create_token2022_mint_with_hook_ixs, default_light_args,
+    close_hook_payload_ix, close_hook_payload_ix_with_pda, create_token2022_mint_with_hook_ixs,
+    default_light_args,
     execute_hook_ix, extra_meta_pda, hook_payload_pda, init_extra_meta_ix, issuer_pda, register_ix,
     set_hook_payload_ix, update_ix, ANCHOR_ERROR_CODE_OFFSET, CONSTRAINT_SEEDS,
 };

--- a/backend/programs/zksettle/tests/transfer_hook_smoke.rs
+++ b/backend/programs/zksettle/tests/transfer_hook_smoke.rs
@@ -25,9 +25,10 @@ use zksettle::error::ZkSettleError;
 use zksettle::instructions::transfer_hook::{ExtraAccountMetaInput, MAX_HOOK_PROOF_BYTES};
 
 use helpers::{
-    boot_harness, close_hook_payload_ix, create_token2022_mint_with_hook_ixs, default_light_args,
-    execute_hook_ix, extra_meta_pda, hook_payload_pda, init_extra_meta_ix, nonzero_nullifier,
-    registered_issuer, set_hook_payload_ix, ANCHOR_ERROR_CODE_OFFSET, CONSTRAINT_SEEDS,
+    boot_harness, close_hook_payload_ix, close_hook_payload_ix_with_pda,
+    create_token2022_mint_with_hook_ixs, default_light_args, execute_hook_ix, extra_meta_pda,
+    hook_payload_pda, init_extra_meta_ix, nonzero_nullifier, registered_issuer,
+    set_hook_payload_ix, ANCHOR_ERROR_CODE_OFFSET, CONSTRAINT_SEEDS,
 };
 
 async fn stage_default_payload(
@@ -340,9 +341,11 @@ async fn close_hook_payload_wrong_authority_fails() {
 
     let wrong = helpers::funded_authority(&mut rpc, 10_000_000_000).await;
 
+    // Attacker signs but targets the legit PDA — seed mismatch yields ConstraintSeeds.
+    let (legit_pda, _) = hook_payload_pda(&authority.pubkey());
     let result = rpc
         .create_and_send_transaction(
-            &[close_hook_payload_ix(&wrong.pubkey())],
+            &[close_hook_payload_ix_with_pda(&wrong.pubkey(), &legit_pda)],
             &wrong.pubkey(),
             &[&wrong],
         )


### PR DESCRIPTION
Cap upstream response body at 1 MiB with Content-Length pre-check and post-read guard to prevent OOM from oversized upstream responses.

Roll back in-memory state when persist::save fails during credential revocation, preventing divergence between memory and disk on I/O errors.

Refuse to start issuer-service without API_TOKEN on non-loopback addresses unless ALLOW_UNAUTHENTICATED is explicitly set, closing a fail-open auth gap.

Fix close_hook_payload_wrong_authority_fails to target the legit PDA with the attacker's signer, matching the light_smoke.rs pattern for proper ConstraintSeeds rejection.