### PR TITLE
test(off-chain): cover handlers, rotation, chain, auth, proxy, irys via mocks (Phase 3 of #54)

### DIFF
--- a/backend/crates/api-gateway/Cargo.toml
+++ b/backend/crates/api-gateway/Cargo.toml
@@ -9,6 +9,11 @@ license = "Apache-2.0 OR MIT"
 name = "api-gateway"
 path = "src/main.rs"
 
+[features]
+default = []
+# Expose MockHttpUpstream to downstream dev-dependencies + own tests.
+test-util = []
+
 [dependencies]
 zksettle-types = { path = "../zksettle-types", features = ["borsh", "serde"] }
 async-trait = "0.1"

--- a/backend/crates/api-gateway/src/auth.rs
+++ b/backend/crates/api-gateway/src/auth.rs
@@ -8,6 +8,7 @@ use crate::error::GatewayError;
 use crate::key_store::hash_key;
 use crate::AppState;
 
+#[derive(Debug)]
 pub struct AuthenticatedKey(pub ApiKeyRecord);
 
 impl FromRequestParts<Arc<AppState>> for AuthenticatedKey {
@@ -38,5 +39,100 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedKey {
             .ok_or(GatewayError::KeyNotFound)?;
 
         Ok(AuthenticatedKey(record))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::http::Request;
+    use zksettle_types::gateway::Tier;
+
+    use super::*;
+    use crate::config::Config;
+    use crate::key_store::KeyStore;
+    use crate::metering::Metering;
+    use crate::rate_limit::RateLimitStore;
+    use crate::upstream::MockHttpUpstream;
+
+    fn state_with_key(raw_key: &str) -> Arc<AppState> {
+        let keys = KeyStore::new();
+        keys.insert(raw_key, "alice".into(), Tier::Developer, 0);
+        Arc::new(AppState {
+            config: Config {
+                port: 4000,
+                upstream_url: "http://127.0.0.1:0".into(),
+                log_level: "error".into(),
+                admin_key: None,
+                allow_open_keys: true,
+            },
+            keys,
+            metering: Metering::new(),
+            rate_limiter: RateLimitStore::new(),
+            upstream: Arc::new(MockHttpUpstream::new()),
+        })
+    }
+
+    async fn extract(state: &Arc<AppState>, req: Request<()>) -> Result<AuthenticatedKey, GatewayError> {
+        let (mut parts, _) = req.into_parts();
+        AuthenticatedKey::from_request_parts(&mut parts, state).await
+    }
+
+    #[tokio::test]
+    async fn missing_authorization_header_returns_unauthorized() {
+        let state = state_with_key("zks_one");
+        let req = Request::builder().uri("/").body(()).unwrap();
+        let err = extract(&state, req).await.unwrap_err();
+        assert!(matches!(err, GatewayError::Unauthorized));
+    }
+
+    #[tokio::test]
+    async fn header_without_bearer_prefix_returns_unauthorized() {
+        let state = state_with_key("zks_one");
+        let req = Request::builder()
+            .uri("/")
+            .header("authorization", "Token zks_one")
+            .body(())
+            .unwrap();
+        let err = extract(&state, req).await.unwrap_err();
+        assert!(matches!(err, GatewayError::Unauthorized));
+    }
+
+    #[tokio::test]
+    async fn empty_bearer_token_returns_unauthorized() {
+        let state = state_with_key("zks_one");
+        let req = Request::builder()
+            .uri("/")
+            .header("authorization", "Bearer ")
+            .body(())
+            .unwrap();
+        let err = extract(&state, req).await.unwrap_err();
+        assert!(matches!(err, GatewayError::Unauthorized));
+    }
+
+    #[tokio::test]
+    async fn unknown_key_returns_key_not_found() {
+        let state = state_with_key("zks_known");
+        let req = Request::builder()
+            .uri("/")
+            .header("authorization", "Bearer zks_unknown")
+            .body(())
+            .unwrap();
+        let err = extract(&state, req).await.unwrap_err();
+        assert!(matches!(err, GatewayError::KeyNotFound));
+    }
+
+    #[tokio::test]
+    async fn valid_key_returns_record_with_owner() {
+        let state = state_with_key("zks_alice");
+        let req = Request::builder()
+            .uri("/")
+            .header("authorization", "Bearer zks_alice")
+            .body(())
+            .unwrap();
+        let AuthenticatedKey(record) = extract(&state, req).await.unwrap();
+        assert_eq!(record.owner, "alice");
+        assert_eq!(record.tier, Tier::Developer);
     }
 }

--- a/backend/crates/api-gateway/src/auth.rs
+++ b/backend/crates/api-gateway/src/auth.rs
@@ -74,7 +74,10 @@ mod tests {
         })
     }
 
-    async fn extract(state: &Arc<AppState>, req: Request<()>) -> Result<AuthenticatedKey, GatewayError> {
+    async fn extract(
+        state: &Arc<AppState>,
+        req: Request<()>,
+    ) -> Result<AuthenticatedKey, GatewayError> {
         let (mut parts, _) = req.into_parts();
         AuthenticatedKey::from_request_parts(&mut parts, state).await
     }

--- a/backend/crates/api-gateway/src/proxy.rs
+++ b/backend/crates/api-gateway/src/proxy.rs
@@ -251,16 +251,16 @@ mod tests {
             state.metering.increment(&rec.key_hash, now);
         }
 
-        let err = proxy_to_upstream(
-            State(state.clone()),
-            AuthenticatedKey(rec),
-            build_request(),
-        )
-        .await
-        .unwrap_err();
+        let err = proxy_to_upstream(State(state.clone()), AuthenticatedKey(rec), build_request())
+            .await
+            .unwrap_err();
 
         assert!(matches!(err, GatewayError::QuotaExhausted));
-        assert_eq!(mock.sent_count(), 0, "must not call upstream after quota check");
+        assert_eq!(
+            mock.sent_count(),
+            0,
+            "must not call upstream after quota check"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/backend/crates/api-gateway/src/proxy.rs
+++ b/backend/crates/api-gateway/src/proxy.rs
@@ -119,4 +119,164 @@ mod tests {
         assert!(!is_hop_by_hop("accept"));
         assert!(!is_hop_by_hop("x-custom-header"));
     }
+
+    use axum::body::Body;
+    use axum::http::{Method, StatusCode};
+    use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use zksettle_types::gateway::{ApiKeyRecord, Tier};
+
+    use crate::config::Config;
+    use crate::key_store::{hash_key, KeyStore};
+    use crate::metering::Metering;
+    use crate::rate_limit::RateLimitStore;
+    use crate::upstream::{MockHttpUpstream, UpstreamResponse};
+
+    fn record() -> ApiKeyRecord {
+        ApiKeyRecord {
+            key_hash: hash_key("zks_test"),
+            tier: Tier::Developer,
+            owner: "alice".into(),
+            created_at: 0,
+        }
+    }
+
+    fn state(mock: Arc<MockHttpUpstream>) -> Arc<AppState> {
+        Arc::new(AppState {
+            config: Config {
+                port: 4000,
+                upstream_url: "http://upstream.example".into(),
+                log_level: "error".into(),
+                admin_key: None,
+                allow_open_keys: true,
+            },
+            keys: KeyStore::new(),
+            metering: Metering::new(),
+            rate_limiter: RateLimitStore::new(),
+            upstream: mock,
+        })
+    }
+
+    fn build_request() -> Request {
+        Request::builder()
+            .method(Method::GET)
+            .uri("/v1/issuers/foo?x=1")
+            .header("x-keep", "yes")
+            .header("connection", "should-be-stripped")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn happy_path_forwards_request_and_increments_metering() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-upstream", "value".parse().unwrap());
+        mock.queue_response(UpstreamResponse {
+            status: StatusCode::OK,
+            headers,
+            body: axum::body::Bytes::from_static(b"hello"),
+        });
+        let state = state(mock.clone());
+        let rec = record();
+
+        let resp = proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(rec.clone()),
+            build_request(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        // handler uses SystemTime::now() internally; query with the same clock
+        assert_eq!(state.metering.current_count(&rec.key_hash, now_secs()), 1);
+
+        let sent = mock.last_sent().expect("mock recorded send");
+        assert_eq!(sent.method, Method::GET);
+        assert_eq!(sent.url, "http://upstream.example/issuers/foo?x=1");
+        assert!(
+            sent.headers.contains_key("x-keep"),
+            "non-hop-by-hop headers must reach upstream"
+        );
+        assert!(
+            !sent.headers.contains_key("connection"),
+            "hop-by-hop headers must be stripped"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn upstream_5xx_is_propagated_and_metering_does_not_increment() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        mock.queue_response(UpstreamResponse {
+            status: StatusCode::BAD_GATEWAY,
+            headers: HeaderMap::new(),
+            body: axum::body::Bytes::new(),
+        });
+        let state = state(mock.clone());
+        let rec = record();
+
+        let resp = proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(rec.clone()),
+            build_request(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            state.metering.current_count(&rec.key_hash, now_secs()),
+            0,
+            "non-success upstream response must not consume quota"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn quota_exhausted_short_circuits_before_upstream_call() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        let state = state(mock.clone());
+        let rec = record();
+        // pre-fill the metering counter with the same wall clock the handler
+        // will read so the period-rollover branch doesn't reset us to zero
+        let now = now_secs();
+        for _ in 0..rec.tier.monthly_limit() {
+            state.metering.increment(&rec.key_hash, now);
+        }
+
+        let err = proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(rec),
+            build_request(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, GatewayError::QuotaExhausted));
+        assert_eq!(mock.sent_count(), 0, "must not call upstream after quota check");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn upstream_transport_error_propagates_as_upstream_variant() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        mock.queue_error(GatewayError::Upstream("network down".into()));
+        let state = state(mock.clone());
+
+        let err = proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(record()),
+            build_request(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, GatewayError::Upstream(_)));
+    }
 }

--- a/backend/crates/api-gateway/src/upstream.rs
+++ b/backend/crates/api-gateway/src/upstream.rs
@@ -11,7 +11,7 @@ use reqwest::Client;
 
 use crate::error::GatewayError;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct UpstreamRequest {
     pub method: Method,
     pub url: String,
@@ -108,10 +108,6 @@ pub mod mock {
     use axum::body::Bytes;
     use axum::http::{HeaderMap, StatusCode};
 
-    /// In-memory `HttpUpstream` for tests. Holds a FIFO queue of canned
-    /// responses; each `send` consumes one. Records every request for
-    /// post-hoc assertions. `queue_error` injects a one-shot upstream
-    /// failure to exercise error branches.
     pub struct MockHttpUpstream {
         responses: Mutex<VecDeque<UpstreamResponse>>,
         sent: Mutex<Vec<UpstreamRequest>>,
@@ -127,12 +123,10 @@ pub mod mock {
             }
         }
 
-        /// Queue a response for the next `send` call. Calls drain in FIFO order.
         pub fn queue_response(&self, resp: UpstreamResponse) {
             self.responses.lock().unwrap().push_back(resp);
         }
 
-        /// Convenience: queue a 200 OK with empty body.
         pub fn queue_ok(&self) {
             self.queue_response(UpstreamResponse {
                 status: StatusCode::OK,
@@ -141,7 +135,6 @@ pub mod mock {
             });
         }
 
-        /// Cause the next `send` to fail with this error, then reset.
         pub fn queue_error(&self, error: GatewayError) {
             *self.pending_error.lock().unwrap() = Some(error);
         }
@@ -151,12 +144,7 @@ pub mod mock {
         }
 
         pub fn last_sent(&self) -> Option<UpstreamRequest> {
-            self.sent.lock().unwrap().last().map(|r| UpstreamRequest {
-                method: r.method.clone(),
-                url: r.url.clone(),
-                headers: r.headers.clone(),
-                body: r.body.clone(),
-            })
+            self.sent.lock().unwrap().last().cloned()
         }
     }
 
@@ -272,14 +260,7 @@ mod tests {
         assert_eq!(mock.sent_count(), 1);
     }
 
-    /// Tests for the production `ReqwestUpstream` size guard. We can't use
-    /// the mock here — the guard lives inside `ReqwestUpstream::send`. So we
-    /// spin up a raw TCP server that emits hand-crafted HTTP/1.1 responses
-    /// (no axum/hyper involved) and point reqwest at it. This lets us
-    /// independently exercise:
-    ///   - the `1024 * 1024` constant (line 60)
-    ///   - the Content-Length guard (line 69)
-    ///   - the body-length guard reached only when CL is absent (line 84)
+    // ReqwestUpstream size guard tests — raw TCP server to exercise CL and body-length guards.
     mod size_guard {
         use super::*;
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -287,8 +268,6 @@ mod tests {
 
         const MAX_BYTES: usize = 1024 * 1024;
 
-        /// Spin up a tokio TCP server that sends `response_bytes` verbatim
-        /// for every accepted connection, then closes. Returns its port.
         async fn spawn_raw_server(response_bytes: Vec<u8>) -> u16 {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             let port = listener.local_addr().unwrap().port();
@@ -320,12 +299,7 @@ mod tests {
             }
         }
 
-        /// Body well above the `*→+` mutation's MAX (=2048) but well under
-        /// the real MAX (=1MB) succeeds. Kills:
-        ///   - line 60 `*` → `+` (mutated MAX=2048; 4KB rejected)
-        ///   - line 60 `*` → `/` (mutated MAX=1; 4KB rejected)
-        ///   - line 69 `>` → `<` (mutated: 4KB < 1MB true → reject)
-        ///   - line 84 `>` → `<` (same logic on body.len())
+        // Kills: *→+, *→/ on MAX constant; >→< on CL and body guards
         #[tokio::test]
         async fn under_limit_response_succeeds() {
             let body = vec![b'a'; 4096];
@@ -343,10 +317,7 @@ mod tests {
             assert_eq!(result.body.len(), 4096);
         }
 
-        /// Content-Length header above MAX is rejected before reading the
-        /// body. Kills:
-        ///   - line 69 `>` → `==` (mutated: 2MB == 1MB false → no error)
-        ///   - line 69 `>` → `<`  (mutated: 2MB < 1MB false → no error)
+        // Kills: >→==, >→< on CL guard
         #[tokio::test]
         async fn oversized_content_length_header_is_rejected() {
             // Lie about CL: claim 2MB, send empty body, close. Reqwest will
@@ -367,10 +338,7 @@ mod tests {
             );
         }
 
-        /// Boundary case: body exactly at MAX must succeed. Kills:
-        ///   - line 69 `>` → `>=` (mutated: 1MB >= 1MB true → reject)
-        ///   - line 69 `>` → `==` (mutated: 1MB == 1MB true → reject)
-        ///   - line 84 `>` → `>=` (same boundary on body.len())
+        // Kills: >→>=, >→== on CL and body guards (boundary)
         #[tokio::test]
         async fn exactly_max_size_response_succeeds() {
             let body = vec![0u8; MAX_BYTES];
@@ -390,10 +358,7 @@ mod tests {
             assert_eq!(result.body.len(), MAX_BYTES);
         }
 
-        /// Without a Content-Length header, the line-69 guard cannot trip,
-        /// so the line-84 body-length guard becomes the only defense. Kills:
-        ///   - line 84 `>` → `==` (mutated: oversized != MAX → no error)
-        ///   - line 84 `>` → `<`  (mutated: oversized < MAX false → no error)
+        // Kills: >→==, >→< on body-length guard (no CL header)
         #[tokio::test]
         async fn oversized_body_without_content_length_is_rejected() {
             let body = vec![0u8; MAX_BYTES + 1];

--- a/backend/crates/api-gateway/src/upstream.rs
+++ b/backend/crates/api-gateway/src/upstream.rs
@@ -270,4 +270,145 @@ mod tests {
         .unwrap();
         assert_eq!(mock.sent_count(), 1);
     }
+
+    /// Tests for the production `ReqwestUpstream` size guard. We can't use
+    /// the mock here — the guard lives inside `ReqwestUpstream::send`. So we
+    /// spin up a raw TCP server that emits hand-crafted HTTP/1.1 responses
+    /// (no axum/hyper involved) and point reqwest at it. This lets us
+    /// independently exercise:
+    ///   - the `1024 * 1024` constant (line 60)
+    ///   - the Content-Length guard (line 69)
+    ///   - the body-length guard reached only when CL is absent (line 84)
+    mod size_guard {
+        use super::*;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        const MAX_BYTES: usize = 1024 * 1024;
+
+        /// Spin up a tokio TCP server that sends `response_bytes` verbatim
+        /// for every accepted connection, then closes. Returns its port.
+        async fn spawn_raw_server(response_bytes: Vec<u8>) -> u16 {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            tokio::spawn(async move {
+                loop {
+                    let (mut sock, _) = match listener.accept().await {
+                        Ok(s) => s,
+                        Err(_) => return,
+                    };
+                    let bytes = response_bytes.clone();
+                    tokio::spawn(async move {
+                        // drain the request line + headers (best effort)
+                        let mut buf = vec![0u8; 4096];
+                        let _ = sock.read(&mut buf).await;
+                        let _ = sock.write_all(&bytes).await;
+                        let _ = sock.shutdown().await;
+                    });
+                }
+            });
+            port
+        }
+
+        fn req(port: u16) -> UpstreamRequest {
+            UpstreamRequest {
+                method: Method::GET,
+                url: format!("http://127.0.0.1:{port}/"),
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            }
+        }
+
+        /// Body well above the `*→+` mutation's MAX (=2048) but well under
+        /// the real MAX (=1MB) succeeds. Kills:
+        ///   - line 60 `*` → `+` (mutated MAX=2048; 4KB rejected)
+        ///   - line 60 `*` → `/` (mutated MAX=1; 4KB rejected)
+        ///   - line 69 `>` → `<` (mutated: 4KB < 1MB true → reject)
+        ///   - line 84 `>` → `<` (same logic on body.len())
+        #[tokio::test]
+        async fn under_limit_response_succeeds() {
+            let body = vec![b'a'; 4096];
+            let mut resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .into_bytes();
+            resp.extend_from_slice(&body);
+            let port = spawn_raw_server(resp).await;
+
+            let upstream = ReqwestUpstream::new(Client::new());
+            let result = upstream.send(req(port)).await.expect("must accept 4KB");
+            assert_eq!(result.status, StatusCode::OK);
+            assert_eq!(result.body.len(), 4096);
+        }
+
+        /// Content-Length header above MAX is rejected before reading the
+        /// body. Kills:
+        ///   - line 69 `>` → `==` (mutated: 2MB == 1MB false → no error)
+        ///   - line 69 `>` → `<`  (mutated: 2MB < 1MB false → no error)
+        #[tokio::test]
+        async fn oversized_content_length_header_is_rejected() {
+            // Lie about CL: claim 2MB, send empty body, close. Reqwest will
+            // hand the headers to our code BEFORE attempting body read — our
+            // line-69 guard fires immediately.
+            let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 2097152\r\nConnection: close\r\n\r\n"
+                .to_vec();
+            let port = spawn_raw_server(resp).await;
+
+            let upstream = ReqwestUpstream::new(Client::new());
+            let err = upstream
+                .send(req(port))
+                .await
+                .expect_err("oversized CL must be rejected");
+            assert!(
+                matches!(&err, GatewayError::Upstream(msg) if msg.contains("too large")),
+                "unexpected error: {err:?}"
+            );
+        }
+
+        /// Boundary case: body exactly at MAX must succeed. Kills:
+        ///   - line 69 `>` → `>=` (mutated: 1MB >= 1MB true → reject)
+        ///   - line 69 `>` → `==` (mutated: 1MB == 1MB true → reject)
+        ///   - line 84 `>` → `>=` (same boundary on body.len())
+        #[tokio::test]
+        async fn exactly_max_size_response_succeeds() {
+            let body = vec![0u8; MAX_BYTES];
+            let mut resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                MAX_BYTES
+            )
+            .into_bytes();
+            resp.extend_from_slice(&body);
+            let port = spawn_raw_server(resp).await;
+
+            let upstream = ReqwestUpstream::new(Client::new());
+            let result = upstream
+                .send(req(port))
+                .await
+                .expect("body exactly at MAX must pass");
+            assert_eq!(result.body.len(), MAX_BYTES);
+        }
+
+        /// Without a Content-Length header, the line-69 guard cannot trip,
+        /// so the line-84 body-length guard becomes the only defense. Kills:
+        ///   - line 84 `>` → `==` (mutated: oversized != MAX → no error)
+        ///   - line 84 `>` → `<`  (mutated: oversized < MAX false → no error)
+        #[tokio::test]
+        async fn oversized_body_without_content_length_is_rejected() {
+            let body = vec![0u8; MAX_BYTES + 1];
+            let mut resp = b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n".to_vec();
+            resp.extend_from_slice(&body);
+            let port = spawn_raw_server(resp).await;
+
+            let upstream = ReqwestUpstream::new(Client::new());
+            let err = upstream
+                .send(req(port))
+                .await
+                .expect_err("oversized chunked-style body must be rejected");
+            assert!(
+                matches!(&err, GatewayError::Upstream(msg) if msg.contains("too large")),
+                "unexpected error: {err:?}"
+            );
+        }
+    }
 }

--- a/backend/crates/api-gateway/src/upstream.rs
+++ b/backend/crates/api-gateway/src/upstream.rs
@@ -88,7 +88,11 @@ impl HttpUpstream for ReqwestUpstream {
             )));
         }
 
-        Ok(UpstreamResponse { status, headers, body })
+        Ok(UpstreamResponse {
+            status,
+            headers,
+            body,
+        })
     }
 }
 
@@ -168,11 +172,9 @@ pub mod mock {
                 return Err(err);
             }
             self.sent.lock().unwrap().push(req);
-            self.responses
-                .lock()
-                .unwrap()
-                .pop_front()
-                .ok_or_else(|| GatewayError::Upstream("MockHttpUpstream: no queued response".into()))
+            self.responses.lock().unwrap().pop_front().ok_or_else(|| {
+                GatewayError::Upstream("MockHttpUpstream: no queued response".into())
+            })
         }
     }
 }

--- a/backend/crates/api-gateway/src/upstream.rs
+++ b/backend/crates/api-gateway/src/upstream.rs
@@ -11,6 +11,7 @@ use reqwest::Client;
 
 use crate::error::GatewayError;
 
+#[derive(Debug)]
 pub struct UpstreamRequest {
     pub method: Method,
     pub url: String,
@@ -18,6 +19,7 @@ pub struct UpstreamRequest {
     pub body: Bytes,
 }
 
+#[derive(Debug)]
 pub struct UpstreamResponse {
     pub status: StatusCode,
     pub headers: HeaderMap,
@@ -87,5 +89,183 @@ impl HttpUpstream for ReqwestUpstream {
         }
 
         Ok(UpstreamResponse { status, headers, body })
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+pub mod mock {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    use super::{HttpUpstream, UpstreamRequest, UpstreamResponse};
+    use crate::error::GatewayError;
+    use async_trait::async_trait;
+    use axum::body::Bytes;
+    use axum::http::{HeaderMap, StatusCode};
+
+    /// In-memory `HttpUpstream` for tests. Holds a FIFO queue of canned
+    /// responses; each `send` consumes one. Records every request for
+    /// post-hoc assertions. `queue_error` injects a one-shot upstream
+    /// failure to exercise error branches.
+    pub struct MockHttpUpstream {
+        responses: Mutex<VecDeque<UpstreamResponse>>,
+        sent: Mutex<Vec<UpstreamRequest>>,
+        pending_error: Mutex<Option<GatewayError>>,
+    }
+
+    impl MockHttpUpstream {
+        pub fn new() -> Self {
+            Self {
+                responses: Mutex::new(VecDeque::new()),
+                sent: Mutex::new(Vec::new()),
+                pending_error: Mutex::new(None),
+            }
+        }
+
+        /// Queue a response for the next `send` call. Calls drain in FIFO order.
+        pub fn queue_response(&self, resp: UpstreamResponse) {
+            self.responses.lock().unwrap().push_back(resp);
+        }
+
+        /// Convenience: queue a 200 OK with empty body.
+        pub fn queue_ok(&self) {
+            self.queue_response(UpstreamResponse {
+                status: StatusCode::OK,
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            });
+        }
+
+        /// Cause the next `send` to fail with this error, then reset.
+        pub fn queue_error(&self, error: GatewayError) {
+            *self.pending_error.lock().unwrap() = Some(error);
+        }
+
+        pub fn sent_count(&self) -> usize {
+            self.sent.lock().unwrap().len()
+        }
+
+        pub fn last_sent(&self) -> Option<UpstreamRequest> {
+            self.sent.lock().unwrap().last().map(|r| UpstreamRequest {
+                method: r.method.clone(),
+                url: r.url.clone(),
+                headers: r.headers.clone(),
+                body: r.body.clone(),
+            })
+        }
+    }
+
+    impl Default for MockHttpUpstream {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait]
+    impl HttpUpstream for MockHttpUpstream {
+        async fn send(&self, req: UpstreamRequest) -> Result<UpstreamResponse, GatewayError> {
+            if let Some(err) = self.pending_error.lock().unwrap().take() {
+                return Err(err);
+            }
+            self.sent.lock().unwrap().push(req);
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| GatewayError::Upstream("MockHttpUpstream: no queued response".into()))
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+pub use mock::MockHttpUpstream;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_returns_queued_response_in_fifo_order() {
+        let mock = MockHttpUpstream::new();
+        mock.queue_response(UpstreamResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: Bytes::from_static(b"first"),
+        });
+        mock.queue_response(UpstreamResponse {
+            status: StatusCode::CREATED,
+            headers: HeaderMap::new(),
+            body: Bytes::from_static(b"second"),
+        });
+
+        let r1 = mock
+            .send(UpstreamRequest {
+                method: Method::GET,
+                url: "http://x/1".into(),
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(r1.status, StatusCode::OK);
+        assert_eq!(r1.body, Bytes::from_static(b"first"));
+
+        let r2 = mock
+            .send(UpstreamRequest {
+                method: Method::POST,
+                url: "http://x/2".into(),
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(r2.status, StatusCode::CREATED);
+
+        assert_eq!(mock.sent_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn mock_send_errors_when_no_response_queued() {
+        let mock = MockHttpUpstream::new();
+        let err = mock
+            .send(UpstreamRequest {
+                method: Method::GET,
+                url: "http://x".into(),
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, GatewayError::Upstream(_)));
+    }
+
+    #[tokio::test]
+    async fn queued_error_fires_once_and_does_not_record_send() {
+        let mock = MockHttpUpstream::new();
+        mock.queue_error(GatewayError::Upstream("boom".into()));
+        mock.queue_ok();
+
+        let err = mock
+            .send(UpstreamRequest {
+                method: Method::GET,
+                url: "http://x".into(),
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, GatewayError::Upstream(_)));
+        assert_eq!(mock.sent_count(), 0, "errored send must not be recorded");
+
+        // next call succeeds because the queued error was consumed
+        mock.send(UpstreamRequest {
+            method: Method::GET,
+            url: "http://x".into(),
+            headers: HeaderMap::new(),
+            body: Bytes::new(),
+        })
+        .await
+        .unwrap();
+        assert_eq!(mock.sent_count(), 1);
     }
 }

--- a/backend/crates/indexer/Cargo.toml
+++ b/backend/crates/indexer/Cargo.toml
@@ -9,6 +9,11 @@ license = "Apache-2.0 OR MIT"
 name = "indexer"
 path = "src/main.rs"
 
+[features]
+default = []
+# Expose MockIrysUploader to downstream dev-dependencies + own tests.
+test-util = []
+
 [dependencies]
 zksettle-types = { path = "../zksettle-types", features = ["borsh", "serde"] }
 async-trait = "0.1"

--- a/backend/crates/indexer/src/irys/client.rs
+++ b/backend/crates/indexer/src/irys/client.rs
@@ -39,8 +39,8 @@ impl IrysClient {
             return Ok("dry-run".into());
         }
 
-        let body = serde_json::to_vec(&record)
-            .map_err(|e| IndexerError::IrysUpload(e.to_string()))?;
+        let body =
+            serde_json::to_vec(&record).map_err(|e| IndexerError::IrysUpload(e.to_string()))?;
 
         let url = format!("{}/tx/solana", self.node_url);
 
@@ -51,17 +51,16 @@ impl IrysClient {
                 tokio::time::sleep(delay).await;
             }
 
-            match self.http.post(&url)
+            match self
+                .http
+                .post(&url)
                 .header("Content-Type", "application/json")
                 .body(body.clone())
                 .send()
                 .await
             {
                 Ok(resp) if resp.status().is_success() => {
-                    let tx_id = resp
-                        .text()
-                        .await
-                        .unwrap_or_else(|_| "unknown".into());
+                    let tx_id = resp.text().await.unwrap_or_else(|_| "unknown".into());
                     info!(tx_id = %tx_id, "uploaded attestation to irys");
                     return Ok(tx_id);
                 }

--- a/backend/crates/indexer/src/irys/client.rs
+++ b/backend/crates/indexer/src/irys/client.rs
@@ -87,3 +87,50 @@ impl IrysClient {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_event() -> ProofSettled {
+        ProofSettled {
+            issuer: [1u8; 32],
+            nullifier_hash: [2u8; 32],
+            merkle_root: [3u8; 32],
+            sanctions_root: [4u8; 32],
+            jurisdiction_root: [5u8; 32],
+            mint: [6u8; 32],
+            recipient: [7u8; 32],
+            amount: 1_000_000,
+            epoch: 1,
+            timestamp: 1_700_000_000,
+            slot: 42,
+            payer: [8u8; 32],
+        }
+    }
+
+    #[tokio::test]
+    async fn dry_run_when_no_wallet_key_returns_dry_run_marker() {
+        let client = IrysClient::new("http://unused".into(), None, Client::new());
+        let tx = client.upload(&fixture_event()).await.unwrap();
+        assert_eq!(tx, "dry-run");
+    }
+
+    #[tokio::test]
+    async fn live_mode_does_not_short_circuit_to_dry_run() {
+        // wallet key present -> dry_run flag is false. Pointing at an
+        // unreachable address (port 0) the upload must NOT return "dry-run";
+        // the real branch is taken and fails with IrysUpload after retries.
+        let client = IrysClient::new(
+            "http://127.0.0.1:1".into(),
+            Some("any-key"),
+            Client::builder()
+                .timeout(std::time::Duration::from_millis(50))
+                .connect_timeout(std::time::Duration::from_millis(50))
+                .build()
+                .unwrap(),
+        );
+        let result = client.upload(&fixture_event()).await;
+        assert!(matches!(result, Err(IndexerError::IrysUpload(_))));
+    }
+}

--- a/backend/crates/indexer/src/irys/mod.rs
+++ b/backend/crates/indexer/src/irys/mod.rs
@@ -134,4 +134,24 @@ mod tests {
         mock.upload(&fixture_event()).await.unwrap();
         assert_eq!(mock.upload_count(), 1);
     }
+
+    /// Exercises the `IrysUploader` trait impl on `IrysClient` through a
+    /// `dyn IrysUploader` indirection. The inherent `IrysClient::upload`
+    /// already has its own dry-run test, but the trait-impl wrapper at
+    /// `mod.rs:19` is a separate function that mutation testing flagged as
+    /// uncovered: replacing the body with `Ok(String::new())` or
+    /// `Ok("xyzzy".into())` would otherwise pass undetected. Asserting the
+    /// exact `"dry-run"` marker (not just `is_ok()`) kills both.
+    #[tokio::test]
+    async fn trait_dispatch_on_irys_client_returns_dry_run_marker() {
+        use std::sync::Arc;
+
+        let uploader: Arc<dyn IrysUploader> = Arc::new(client::IrysClient::new(
+            "http://unused".into(),
+            None,
+            reqwest::Client::new(),
+        ));
+        let tx = uploader.upload(&fixture_event()).await.unwrap();
+        assert_eq!(tx, "dry-run");
+    }
 }

--- a/backend/crates/indexer/src/irys/mod.rs
+++ b/backend/crates/indexer/src/irys/mod.rs
@@ -19,3 +19,119 @@ impl IrysUploader for client::IrysClient {
         client::IrysClient::upload(self, event).await
     }
 }
+
+#[cfg(any(test, feature = "test-util"))]
+pub mod mock {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// In-memory `IrysUploader` for tests. Records uploads, lets tests
+    /// inject one-shot errors, and returns a configurable canned tx_id.
+    pub struct MockIrysUploader {
+        recorded: Mutex<Vec<ProofSettled>>,
+        tx_id: Mutex<String>,
+        pending_error: Mutex<Option<IndexerError>>,
+    }
+
+    impl MockIrysUploader {
+        pub fn new() -> Self {
+            Self {
+                recorded: Mutex::new(Vec::new()),
+                tx_id: Mutex::new("mock-tx-id".into()),
+                pending_error: Mutex::new(None),
+            }
+        }
+
+        pub fn set_tx_id(&self, id: impl Into<String>) {
+            *self.tx_id.lock().unwrap() = id.into();
+        }
+
+        pub fn queue_error(&self, error: IndexerError) {
+            *self.pending_error.lock().unwrap() = Some(error);
+        }
+
+        pub fn upload_count(&self) -> usize {
+            self.recorded.lock().unwrap().len()
+        }
+
+        pub fn recorded_uploads(&self) -> Vec<ProofSettled> {
+            self.recorded.lock().unwrap().clone()
+        }
+    }
+
+    impl Default for MockIrysUploader {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    #[async_trait]
+    impl IrysUploader for MockIrysUploader {
+        async fn upload(&self, event: &ProofSettled) -> Result<String, IndexerError> {
+            if let Some(err) = self.pending_error.lock().unwrap().take() {
+                return Err(err);
+            }
+            self.recorded.lock().unwrap().push(event.clone());
+            Ok(self.tx_id.lock().unwrap().clone())
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+pub use mock::MockIrysUploader;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_event() -> ProofSettled {
+        ProofSettled {
+            issuer: [1u8; 32],
+            nullifier_hash: [2u8; 32],
+            merkle_root: [3u8; 32],
+            sanctions_root: [4u8; 32],
+            jurisdiction_root: [5u8; 32],
+            mint: [6u8; 32],
+            recipient: [7u8; 32],
+            amount: 1_000_000,
+            epoch: 1,
+            timestamp: 1_700_000_000,
+            slot: 42,
+            payer: [8u8; 32],
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_records_uploads_and_returns_tx_id() {
+        let mock = MockIrysUploader::new();
+        mock.set_tx_id("custom-tx");
+
+        let event = fixture_event();
+        let tx = mock.upload(&event).await.unwrap();
+
+        assert_eq!(tx, "custom-tx");
+        assert_eq!(mock.upload_count(), 1);
+        assert_eq!(mock.recorded_uploads()[0].nullifier_hash, [2u8; 32]);
+    }
+
+    #[tokio::test]
+    async fn mock_default_tx_id_is_mock_tx_id() {
+        let mock = MockIrysUploader::new();
+        let tx = mock.upload(&fixture_event()).await.unwrap();
+        assert_eq!(tx, "mock-tx-id");
+    }
+
+    #[tokio::test]
+    async fn queued_error_fires_once_and_does_not_record() {
+        let mock = MockIrysUploader::new();
+        mock.queue_error(IndexerError::IrysUpload("simulated".into()));
+
+        let err = mock.upload(&fixture_event()).await.unwrap_err();
+        assert!(matches!(err, IndexerError::IrysUpload(_)));
+        assert_eq!(mock.upload_count(), 0);
+
+        mock.upload(&fixture_event()).await.unwrap();
+        assert_eq!(mock.upload_count(), 1);
+    }
+}

--- a/backend/crates/indexer/src/irys/mod.rs
+++ b/backend/crates/indexer/src/irys/mod.rs
@@ -27,8 +27,6 @@ pub mod mock {
 
     use super::*;
 
-    /// In-memory `IrysUploader` for tests. Records uploads, lets tests
-    /// inject one-shot errors, and returns a configurable canned tx_id.
     pub struct MockIrysUploader {
         recorded: Mutex<Vec<ProofSettled>>,
         tx_id: Mutex<String>,
@@ -136,13 +134,7 @@ mod tests {
         assert_eq!(mock.upload_count(), 1);
     }
 
-    /// Exercises the `IrysUploader` trait impl on `IrysClient` through a
-    /// `dyn IrysUploader` indirection. The inherent `IrysClient::upload`
-    /// already has its own dry-run test, but the trait-impl wrapper at
-    /// `mod.rs:19` is a separate function that mutation testing flagged as
-    /// uncovered: replacing the body with `Ok(String::new())` or
-    /// `Ok("xyzzy".into())` would otherwise pass undetected. Asserting the
-    /// exact `"dry-run"` marker (not just `is_ok()`) kills both.
+    // Covers trait-impl wrapper at mod.rs:19 — mutation testing flagged it uncovered.
     #[tokio::test]
     async fn trait_dispatch_on_irys_client_returns_dry_run_marker() {
         use std::sync::Arc;

--- a/backend/crates/issuer-service/Cargo.toml
+++ b/backend/crates/issuer-service/Cargo.toml
@@ -32,3 +32,4 @@ mutants = "0.0.3"
 [dev-dependencies]
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
+zksettle-rpc = { path = "../zksettle-rpc", features = ["test-util"] }

--- a/backend/crates/issuer-service/src/handlers/add_wallet.rs
+++ b/backend/crates/issuer-service/src/handlers/add_wallet.rs
@@ -78,7 +78,9 @@ mod tests {
         let resp = handler(
             State(state.clone()),
             empty_state_path(),
-            Json(AddWalletRequest { wallet: hex.clone() }),
+            Json(AddWalletRequest {
+                wallet: hex.clone(),
+            }),
         )
         .await
         .unwrap()
@@ -100,7 +102,9 @@ mod tests {
         let _ = handler(
             State(state.clone()),
             empty_state_path(),
-            Json(AddWalletRequest { wallet: hex.clone() }),
+            Json(AddWalletRequest {
+                wallet: hex.clone(),
+            }),
         )
         .await
         .unwrap();
@@ -122,7 +126,9 @@ mod tests {
         let err = handler(
             State(state),
             empty_state_path(),
-            Json(AddWalletRequest { wallet: "bad-hex".into() }),
+            Json(AddWalletRequest {
+                wallet: "bad-hex".into(),
+            }),
         )
         .await
         .unwrap_err();

--- a/backend/crates/issuer-service/src/handlers/add_wallet.rs
+++ b/backend/crates/issuer-service/src/handlers/add_wallet.rs
@@ -97,7 +97,7 @@ mod tests {
         let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
         let hex = format!("0x{}", hex::encode([2u8; 32]));
 
-        handler(
+        let _ = handler(
             State(state.clone()),
             empty_state_path(),
             Json(AddWalletRequest { wallet: hex.clone() }),

--- a/backend/crates/issuer-service/src/handlers/add_wallet.rs
+++ b/backend/crates/issuer-service/src/handlers/add_wallet.rs
@@ -11,7 +11,7 @@ pub struct AddWalletRequest {
     pub wallet: String,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct AddWalletResponse {
     pub wallet: String,
     pub message: &'static str,
@@ -54,4 +54,78 @@ pub async fn handler(
         wallet: req.wallet,
         message: "added to membership tree",
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::state::IssuerState;
+    use crate::StatePath;
+
+    fn empty_state_path() -> axum::Extension<StatePath> {
+        axum::Extension(StatePath(None))
+    }
+
+    #[tokio::test]
+    async fn happy_path_inserts_credential_and_marks_dirty() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let hex = format!("0x{}", hex::encode([1u8; 32]));
+
+        let resp = handler(
+            State(state.clone()),
+            empty_state_path(),
+            Json(AddWalletRequest { wallet: hex.clone() }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        assert_eq!(resp.wallet, hex);
+        let st = state.read().await;
+        assert_eq!(st.credentials.len(), 1);
+        assert!(st.credentials.contains_key(&[1u8; 32]));
+        assert!(st.roots_dirty, "insertion must flag roots_dirty");
+        assert_eq!(st.credentials[&[1u8; 32]].jurisdiction, "UNKNOWN");
+    }
+
+    #[tokio::test]
+    async fn duplicate_wallet_returns_conflict_and_does_not_double_insert() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let hex = format!("0x{}", hex::encode([2u8; 32]));
+
+        handler(
+            State(state.clone()),
+            empty_state_path(),
+            Json(AddWalletRequest { wallet: hex.clone() }),
+        )
+        .await
+        .unwrap();
+
+        let err = handler(
+            State(state.clone()),
+            empty_state_path(),
+            Json(AddWalletRequest { wallet: hex }),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ServiceError::DuplicateWallet));
+        assert_eq!(state.read().await.credentials.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_hex_returns_invalid_hex() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let err = handler(
+            State(state),
+            empty_state_path(),
+            Json(AddWalletRequest { wallet: "bad-hex".into() }),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ServiceError::InvalidHex(_)));
+    }
 }

--- a/backend/crates/issuer-service/src/handlers/get_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/get_credential.rs
@@ -17,3 +17,55 @@ pub async fn handler(
         .map(Json)
         .ok_or(ServiceError::WalletNotFound)
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::state::IssuerState;
+
+    fn state_with(wallet: [u8; 32]) -> SharedState {
+        let mut st = IssuerState::new();
+        st.credentials.insert(
+            wallet,
+            CredentialRecord {
+                wallet,
+                leaf_index: 0,
+                jurisdiction: "US".into(),
+                issued_at: 1234,
+                revoked: false,
+            },
+        );
+        Arc::new(RwLock::new(st))
+    }
+
+    #[tokio::test]
+    async fn returns_credential_for_known_wallet() {
+        let wallet = [7u8; 32];
+        let state = state_with(wallet);
+        let hex = format!("0x{}", hex::encode(wallet));
+
+        let resp = handler(State(state), Path(hex)).await.unwrap();
+        assert_eq!(resp.0.wallet, wallet);
+        assert_eq!(resp.0.jurisdiction, "US");
+    }
+
+    #[tokio::test]
+    async fn missing_wallet_returns_wallet_not_found() {
+        let state = state_with([7u8; 32]);
+        let other = format!("0x{}", hex::encode([99u8; 32]));
+
+        let err = handler(State(state), Path(other)).await.unwrap_err();
+        assert!(matches!(err, ServiceError::WalletNotFound));
+    }
+
+    #[tokio::test]
+    async fn invalid_hex_returns_invalid_hex() {
+        let state = state_with([7u8; 32]);
+        let err = handler(State(state), Path("not-hex".into())).await.unwrap_err();
+        assert!(matches!(err, ServiceError::InvalidHex(_)));
+    }
+}

--- a/backend/crates/issuer-service/src/handlers/get_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/get_credential.rs
@@ -65,7 +65,9 @@ mod tests {
     #[tokio::test]
     async fn invalid_hex_returns_invalid_hex() {
         let state = state_with([7u8; 32]);
-        let err = handler(State(state), Path("not-hex".into())).await.unwrap_err();
+        let err = handler(State(state), Path("not-hex".into()))
+            .await
+            .unwrap_err();
         assert!(matches!(err, ServiceError::InvalidHex(_)));
     }
 }

--- a/backend/crates/issuer-service/src/handlers/get_proof.rs
+++ b/backend/crates/issuer-service/src/handlers/get_proof.rs
@@ -6,7 +6,7 @@ use crate::convert::{fr_to_bytes_be, wallet_hex_to_bytes};
 use crate::error::ServiceError;
 use crate::state::SharedState;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct MembershipProofResponse {
     pub wallet: String,
     pub leaf_index: usize,
@@ -41,4 +41,87 @@ pub async fn handler(
         path_indices: proof.path_indices.to_vec(),
         root: hex::encode(fr_to_bytes_be(&root)),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ark_bn254::Fr;
+    use tokio::sync::RwLock;
+    use zksettle_crypto::{verify_merkle_proof, MerkleProof, MERKLE_DEPTH};
+
+    use super::*;
+    use crate::convert::{bytes_be_to_fr, wallet_to_fr};
+    use crate::state::{CredentialRecord, IssuerState};
+
+    fn state_with_wallet(wallet: [u8; 32], revoked: bool) -> SharedState {
+        let mut st = IssuerState::new();
+        let hex = format!("0x{}", hex::encode(wallet));
+        st.membership_tree.insert(wallet_to_fr(&hex).unwrap());
+        st.credentials.insert(
+            wallet,
+            CredentialRecord {
+                wallet,
+                leaf_index: 0,
+                jurisdiction: "US".into(),
+                issued_at: 0,
+                revoked,
+            },
+        );
+        Arc::new(RwLock::new(st))
+    }
+
+    fn parse_path(hex_path: &[String]) -> [Fr; MERKLE_DEPTH] {
+        let mut out = [Fr::default(); MERKLE_DEPTH];
+        for (i, h) in hex_path.iter().enumerate() {
+            let bytes = hex::decode(h).unwrap();
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            out[i] = bytes_be_to_fr(&arr);
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn returns_verifiable_proof_for_known_wallet() {
+        let wallet = [3u8; 32];
+        let state = state_with_wallet(wallet, false);
+        let hex = format!("0x{}", hex::encode(wallet));
+
+        let resp = handler(State(state), Path(hex.clone())).await.unwrap().0;
+
+        let leaf = wallet_to_fr(&hex).unwrap();
+        let path: [Fr; MERKLE_DEPTH] = parse_path(&resp.path);
+        let mut path_indices = [0u8; MERKLE_DEPTH];
+        for (i, &b) in resp.path_indices.iter().enumerate() {
+            path_indices[i] = b;
+        }
+        let proof = MerkleProof { path, path_indices };
+
+        let root_bytes = hex::decode(&resp.root).unwrap();
+        let mut root_arr = [0u8; 32];
+        root_arr.copy_from_slice(&root_bytes);
+        let root = bytes_be_to_fr(&root_arr);
+
+        assert!(verify_merkle_proof(leaf, &proof, root));
+    }
+
+    #[tokio::test]
+    async fn missing_wallet_returns_wallet_not_found() {
+        let state = Arc::new(RwLock::new(IssuerState::new()));
+        let err = handler(State(state), Path(format!("0x{}", hex::encode([1u8; 32]))))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::WalletNotFound));
+    }
+
+    #[tokio::test]
+    async fn revoked_wallet_returns_wallet_revoked() {
+        let wallet = [4u8; 32];
+        let state = state_with_wallet(wallet, true);
+        let hex = format!("0x{}", hex::encode(wallet));
+        let err = handler(State(state), Path(hex)).await.unwrap_err();
+        assert!(matches!(err, ServiceError::WalletRevoked));
+    }
 }

--- a/backend/crates/issuer-service/src/handlers/get_proof.rs
+++ b/backend/crates/issuer-service/src/handlers/get_proof.rs
@@ -37,7 +37,11 @@ pub async fn handler(
     Ok(Json(MembershipProofResponse {
         wallet,
         leaf_index: cred.leaf_index,
-        path: proof.path.iter().map(|f| hex::encode(fr_to_bytes_be(f))).collect(),
+        path: proof
+            .path
+            .iter()
+            .map(|f| hex::encode(fr_to_bytes_be(f)))
+            .collect(),
         path_indices: proof.path_indices.to_vec(),
         root: hex::encode(fr_to_bytes_be(&root)),
     }))

--- a/backend/crates/issuer-service/src/handlers/get_roots.rs
+++ b/backend/crates/issuer-service/src/handlers/get_roots.rs
@@ -57,7 +57,8 @@ mod tests {
     async fn wallet_count_reflects_inserted_credentials() {
         let mut st = IssuerState::new();
         let wallet_hex = format!("0x{}", hex::encode([1u8; 32]));
-        st.membership_tree.insert(wallet_to_fr(&wallet_hex).unwrap());
+        st.membership_tree
+            .insert(wallet_to_fr(&wallet_hex).unwrap());
         st.credentials.insert(
             [1u8; 32],
             CredentialRecord {

--- a/backend/crates/issuer-service/src/handlers/get_roots.rs
+++ b/backend/crates/issuer-service/src/handlers/get_roots.rs
@@ -25,3 +25,65 @@ pub async fn handler(State(state): State<SharedState>) -> Json<RootsResponse> {
         wallet_count: st.wallet_count(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::convert::wallet_to_fr;
+    use crate::state::{CredentialRecord, IssuerState};
+
+    fn shared_state(state: IssuerState) -> SharedState {
+        Arc::new(RwLock::new(state))
+    }
+
+    #[tokio::test]
+    async fn empty_state_returns_zeroed_roots_and_no_wallets() {
+        let state = shared_state(IssuerState::new());
+        let body = handler(State(state)).await.0;
+
+        assert_eq!(body.wallet_count, 0);
+        assert_eq!(body.last_publish_slot, 0);
+        // 32-byte hex encodes to 64 chars
+        assert_eq!(body.membership_root.len(), 64);
+        assert_eq!(body.sanctions_root.len(), 64);
+        assert_eq!(body.jurisdiction_root.len(), 64);
+    }
+
+    #[tokio::test]
+    async fn wallet_count_reflects_inserted_credentials() {
+        let mut st = IssuerState::new();
+        let wallet_hex = format!("0x{}", hex::encode([1u8; 32]));
+        st.membership_tree.insert(wallet_to_fr(&wallet_hex).unwrap());
+        st.credentials.insert(
+            [1u8; 32],
+            CredentialRecord {
+                wallet: [1u8; 32],
+                leaf_index: 0,
+                jurisdiction: "US".into(),
+                issued_at: 1,
+                revoked: false,
+            },
+        );
+        st.last_publish_slot = 1234;
+
+        let body = handler(State(shared_state(st))).await.0;
+        assert_eq!(body.wallet_count, 1);
+        assert_eq!(body.last_publish_slot, 1234);
+    }
+
+    #[tokio::test]
+    async fn membership_root_changes_after_insert() {
+        let empty_body = handler(State(shared_state(IssuerState::new()))).await.0;
+
+        let mut st = IssuerState::new();
+        st.membership_tree
+            .insert(wallet_to_fr(&format!("0x{}", hex::encode([9u8; 32]))).unwrap());
+        let inserted_body = handler(State(shared_state(st))).await.0;
+
+        assert_ne!(empty_body.membership_root, inserted_body.membership_root);
+    }
+}

--- a/backend/crates/issuer-service/src/handlers/get_sanctions_proof.rs
+++ b/backend/crates/issuer-service/src/handlers/get_sanctions_proof.rs
@@ -34,7 +34,11 @@ pub async fn handler(
 
     Ok(Json(SanctionsProofResponse {
         wallet,
-        path: proof.path.iter().map(|f| hex::encode(fr_to_bytes_be(f))).collect(),
+        path: proof
+            .path
+            .iter()
+            .map(|f| hex::encode(fr_to_bytes_be(f)))
+            .collect(),
         path_indices: proof.path_indices.to_vec(),
         leaf_value: hex::encode(fr_to_bytes_be(&proof.leaf_value)),
         root: hex::encode(fr_to_bytes_be(&root)),

--- a/backend/crates/issuer-service/src/handlers/get_sanctions_proof.rs
+++ b/backend/crates/issuer-service/src/handlers/get_sanctions_proof.rs
@@ -6,7 +6,7 @@ use crate::convert::{fr_to_bytes_be, wallet_hex_to_bytes, wallet_to_fr};
 use crate::error::ServiceError;
 use crate::state::SharedState;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct SanctionsProofResponse {
     pub wallet: String,
     pub path: Vec<String>,
@@ -39,4 +39,59 @@ pub async fn handler(
         leaf_value: hex::encode(fr_to_bytes_be(&proof.leaf_value)),
         root: hex::encode(fr_to_bytes_be(&root)),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use ark_ff::AdditiveGroup;
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::state::{CredentialRecord, IssuerState};
+
+    #[tokio::test]
+    async fn clean_wallet_yields_zero_leaf_exclusion_proof() {
+        let state = Arc::new(RwLock::new(IssuerState::new()));
+        let wallet = format!("0x{}", hex::encode([5u8; 32]));
+
+        let resp = handler(State(state), Path(wallet.clone())).await.unwrap().0;
+
+        // exclusion proof must show the wallet's slot holds Fr::ZERO
+        let leaf_bytes = hex::decode(&resp.leaf_value).unwrap();
+        assert_eq!(leaf_bytes, fr_to_bytes_be(&ark_bn254::Fr::ZERO));
+        assert_eq!(resp.wallet, wallet);
+    }
+
+    #[tokio::test]
+    async fn revoked_credential_short_circuits_to_wallet_revoked() {
+        let mut st = IssuerState::new();
+        let wallet = [6u8; 32];
+        st.credentials.insert(
+            wallet,
+            CredentialRecord {
+                wallet,
+                leaf_index: 0,
+                jurisdiction: "US".into(),
+                issued_at: 0,
+                revoked: true,
+            },
+        );
+        let hex = format!("0x{}", hex::encode(wallet));
+
+        let err = handler(State(Arc::new(RwLock::new(st))), Path(hex))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::WalletRevoked));
+    }
+
+    #[tokio::test]
+    async fn invalid_hex_returns_invalid_hex() {
+        let state = Arc::new(RwLock::new(IssuerState::new()));
+        let err = handler(State(state), Path("not-hex".into()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::InvalidHex(_)));
+    }
 }

--- a/backend/crates/issuer-service/src/handlers/health.rs
+++ b/backend/crates/issuer-service/src/handlers/health.rs
@@ -9,3 +9,14 @@ pub struct HealthResponse {
 pub async fn handler() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn health_returns_ok() {
+        let response = handler().await;
+        assert_eq!(response.0.status, "ok");
+    }
+}

--- a/backend/crates/issuer-service/src/handlers/issue_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/issue_credential.rs
@@ -135,7 +135,7 @@ mod tests {
         let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
         let hex = format!("0x{}", hex::encode([3u8; 32]));
 
-        handler(
+        let _ = handler(
             State(state.clone()),
             empty_state_path(),
             Json(IssueRequest {

--- a/backend/crates/issuer-service/src/handlers/issue_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/issue_credential.rs
@@ -17,7 +17,7 @@ fn default_jurisdiction() -> String {
     "US".to_string()
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct IssueResponse {
     pub wallet: String,
     pub leaf_index: usize,
@@ -69,10 +69,109 @@ pub async fn handler(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
     use super::*;
+    use crate::state::IssuerState;
+    use crate::StatePath;
+
+    fn empty_state_path() -> axum::Extension<StatePath> {
+        axum::Extension(StatePath(None))
+    }
 
     #[test]
     fn default_jurisdiction_is_us() {
         assert_eq!(default_jurisdiction(), "US");
+    }
+
+    #[tokio::test]
+    async fn happy_path_inserts_with_provided_jurisdiction() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let hex = format!("0x{}", hex::encode([1u8; 32]));
+
+        let resp = handler(
+            State(state.clone()),
+            empty_state_path(),
+            Json(IssueRequest {
+                wallet: hex.clone(),
+                jurisdiction: "BR".into(),
+            }),
+        )
+        .await
+        .unwrap()
+        .0;
+
+        assert_eq!(resp.jurisdiction, "BR");
+        assert_eq!(resp.leaf_index, 0);
+        let st = state.read().await;
+        assert_eq!(st.credentials[&[1u8; 32]].jurisdiction, "BR");
+        assert!(st.roots_dirty);
+    }
+
+    #[tokio::test]
+    async fn second_credential_gets_next_leaf_index() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+
+        for (i, byte) in [1u8, 2u8].iter().enumerate() {
+            let resp = handler(
+                State(state.clone()),
+                empty_state_path(),
+                Json(IssueRequest {
+                    wallet: format!("0x{}", hex::encode([*byte; 32])),
+                    jurisdiction: "US".into(),
+                }),
+            )
+            .await
+            .unwrap()
+            .0;
+            assert_eq!(resp.leaf_index, i);
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_wallet_returns_conflict() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let hex = format!("0x{}", hex::encode([3u8; 32]));
+
+        handler(
+            State(state.clone()),
+            empty_state_path(),
+            Json(IssueRequest {
+                wallet: hex.clone(),
+                jurisdiction: "US".into(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let err = handler(
+            State(state),
+            empty_state_path(),
+            Json(IssueRequest {
+                wallet: hex,
+                jurisdiction: "US".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ServiceError::DuplicateWallet));
+    }
+
+    #[tokio::test]
+    async fn invalid_hex_returns_invalid_hex() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let err = handler(
+            State(state),
+            empty_state_path(),
+            Json(IssueRequest {
+                wallet: "bad-hex".into(),
+                jurisdiction: "US".into(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ServiceError::InvalidHex(_)));
     }
 }

--- a/backend/crates/issuer-service/src/handlers/publish.rs
+++ b/backend/crates/issuer-service/src/handlers/publish.rs
@@ -7,7 +7,7 @@ use crate::error::ServiceError;
 use crate::state::{PublishLock, SharedState};
 use crate::{KeypairBytes, ProgramId, SharedRpc};
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct PublishResponse {
     pub slot: u64,
     pub registered: bool,
@@ -53,4 +53,95 @@ pub async fn handler(
         slot: result.slot,
         registered,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::signature::Keypair;
+    use tokio::sync::{Mutex, RwLock};
+    use zksettle_rpc::{MockSolanaRpc, RpcError, SolanaRpc};
+
+    use super::*;
+    use crate::state::IssuerState;
+
+    struct Harness {
+        state: SharedState,
+        rpc: Arc<MockSolanaRpc>,
+        keypair_bytes: Vec<u8>,
+        program_id: Pubkey,
+        publish_lock: PublishLock,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            let kp = Keypair::new();
+            Self {
+                state: Arc::new(RwLock::new(IssuerState::new())),
+                rpc: Arc::new(MockSolanaRpc::new()),
+                keypair_bytes: kp.to_bytes().to_vec(),
+                program_id: Pubkey::new_unique(),
+                publish_lock: Arc::new(Mutex::new(())),
+            }
+        }
+
+        async fn call(&self) -> Result<Json<PublishResponse>, ServiceError> {
+            let rpc_dyn: Arc<dyn SolanaRpc> = self.rpc.clone();
+            handler(
+                State(self.state.clone()),
+                axum::Extension(SharedRpc(rpc_dyn)),
+                axum::Extension(KeypairBytes(self.keypair_bytes.clone())),
+                axum::Extension(ProgramId(self.program_id)),
+                axum::Extension(self.publish_lock.clone()),
+            )
+            .await
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn first_publish_sends_register_tx_and_marks_registered() {
+        let h = Harness::new();
+        h.state.write().await.roots_dirty = true;
+
+        let resp = h.call().await.unwrap().0;
+
+        assert!(resp.registered);
+        assert!(resp.slot >= 1_000, "MockSolanaRpc starts slot at 1_000");
+        assert_eq!(h.rpc.send_count(), 1);
+        let st = h.state.read().await;
+        assert!(st.registered);
+        assert!(!st.roots_dirty, "publish must clear roots_dirty");
+        assert_eq!(st.last_publish_slot, resp.slot);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn already_registered_clean_roots_short_circuits_without_rpc() {
+        let h = Harness::new();
+        {
+            let mut st = h.state.write().await;
+            st.registered = true;
+            st.roots_dirty = false;
+            st.last_publish_slot = 42;
+        }
+
+        let resp = h.call().await.unwrap().0;
+        assert!(resp.registered);
+        assert_eq!(resp.slot, 42);
+        assert_eq!(h.rpc.send_count(), 0, "must not call RPC when nothing changed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_failure_propagates_as_chain_error() {
+        let h = Harness::new();
+        h.state.write().await.roots_dirty = true;
+        h.rpc.queue_error(RpcError::Call("simulated rpc down".into()));
+
+        let err = h.call().await.unwrap_err();
+        assert!(matches!(err, ServiceError::Chain(_)));
+        let st = h.state.read().await;
+        assert!(!st.registered, "failed publish must not flip registered");
+        assert!(st.roots_dirty, "failed publish must keep roots_dirty");
+    }
 }

--- a/backend/crates/issuer-service/src/handlers/publish.rs
+++ b/backend/crates/issuer-service/src/handlers/publish.rs
@@ -36,7 +36,15 @@ pub async fn handler(
     };
 
     let result = tokio::task::spawn_blocking(move || {
-        chain::publish_roots(rpc.as_ref(), &keypair_bytes, &program_id, mr, sr, jr, was_registered)
+        chain::publish_roots(
+            rpc.as_ref(),
+            &keypair_bytes,
+            &program_id,
+            mr,
+            sr,
+            jr,
+            was_registered,
+        )
     })
     .await
     .map_err(|e| ServiceError::Chain(e.to_string()))??;
@@ -129,14 +137,19 @@ mod tests {
         let resp = h.call().await.unwrap().0;
         assert!(resp.registered);
         assert_eq!(resp.slot, 42);
-        assert_eq!(h.rpc.send_count(), 0, "must not call RPC when nothing changed");
+        assert_eq!(
+            h.rpc.send_count(),
+            0,
+            "must not call RPC when nothing changed"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_failure_propagates_as_chain_error() {
         let h = Harness::new();
         h.state.write().await.roots_dirty = true;
-        h.rpc.queue_error(RpcError::Call("simulated rpc down".into()));
+        h.rpc
+            .queue_error(RpcError::Call("simulated rpc down".into()));
 
         let err = h.call().await.unwrap_err();
         assert!(matches!(err, ServiceError::Chain(_)));

--- a/backend/crates/issuer-service/src/handlers/revoke_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/revoke_credential.rs
@@ -62,7 +62,7 @@ pub async fn handler(
                 .expect("checked above")
                 .revoked = false;
             st.roots_dirty = prev_roots_dirty;
-            return Err(e.into());
+            return Err(e);
         }
     }
 

--- a/backend/crates/issuer-service/src/handlers/revoke_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/revoke_credential.rs
@@ -88,7 +88,8 @@ mod tests {
 
     fn state_with_wallet(wallet: [u8; 32], revoked: bool) -> SharedState {
         let mut st = IssuerState::new();
-        st.membership_tree.insert(wallet_to_fr(&format!("0x{}", hex::encode(wallet))).unwrap());
+        st.membership_tree
+            .insert(wallet_to_fr(&format!("0x{}", hex::encode(wallet))).unwrap());
         st.credentials.insert(
             wallet,
             CredentialRecord {

--- a/backend/crates/issuer-service/src/handlers/revoke_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/revoke_credential.rs
@@ -38,9 +38,7 @@ pub async fn handler(
         .map_err(ServiceError::from)?;
 
     let removed_from_sanctions = st.sanctions_tree.remove(wallet_fr);
-    if !removed_from_sanctions {
-        tracing::debug!(%wallet, "wallet was not in sanctions tree");
-    }
+    tracing::debug!(%wallet, in_sanctions = removed_from_sanctions, "credential revoke applied");
 
     st.credentials
         .get_mut(&wallet_bytes)
@@ -148,5 +146,44 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ServiceError::InvalidHex(_)));
+    }
+
+    /// When the wallet IS in the sanctions tree at revoke time, the handler
+    /// must remove it from the sanctions tree (so an exclusion proof later
+    /// succeeds and the sanctions root reverts to the empty root). The other
+    /// 4 tests above never insert into the sanctions tree, leaving this
+    /// branch unexercised — mutation testing flagged that gap.
+    #[tokio::test]
+    async fn revoking_wallet_in_sanctions_tree_removes_it_from_sanctions() {
+        let wallet = [4u8; 32];
+        let hex = format!("0x{}", hex::encode(wallet));
+        let wallet_fr = wallet_to_fr(&hex).unwrap();
+
+        let state = state_with_wallet(wallet, false);
+        let empty_root = {
+            let mut st = state.write().await;
+            let empty_root = st.sanctions_tree.root();
+            st.sanctions_tree.insert(wallet_fr);
+            assert_ne!(
+                st.sanctions_tree.root(),
+                empty_root,
+                "precondition: insert must change the sanctions root"
+            );
+            empty_root
+        };
+
+        let resp = handler(State(state.clone()), empty_state_path(), Path(hex))
+            .await
+            .unwrap()
+            .0;
+        assert!(resp.revoked);
+
+        let st = state.read().await;
+        assert!(st.credentials[&wallet].revoked);
+        assert_eq!(
+            st.sanctions_tree.root(),
+            empty_root,
+            "sanctions root must revert to empty after the only entry is removed"
+        );
     }
 }

--- a/backend/crates/issuer-service/src/handlers/revoke_credential.rs
+++ b/backend/crates/issuer-service/src/handlers/revoke_credential.rs
@@ -6,7 +6,7 @@ use crate::convert::{wallet_hex_to_bytes, wallet_to_fr};
 use crate::error::ServiceError;
 use crate::state::SharedState;
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct RevokeResponse {
     pub wallet: String,
     pub revoked: bool,
@@ -70,4 +70,82 @@ pub async fn handler(
         wallet,
         revoked: true,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::RwLock;
+
+    use super::*;
+    use crate::state::{CredentialRecord, IssuerState};
+    use crate::StatePath;
+
+    fn empty_state_path() -> axum::Extension<StatePath> {
+        axum::Extension(StatePath(None))
+    }
+
+    fn state_with_wallet(wallet: [u8; 32], revoked: bool) -> SharedState {
+        let mut st = IssuerState::new();
+        st.membership_tree.insert(wallet_to_fr(&format!("0x{}", hex::encode(wallet))).unwrap());
+        st.credentials.insert(
+            wallet,
+            CredentialRecord {
+                wallet,
+                leaf_index: 0,
+                jurisdiction: "US".into(),
+                issued_at: 0,
+                revoked,
+            },
+        );
+        Arc::new(RwLock::new(st))
+    }
+
+    #[tokio::test]
+    async fn happy_path_marks_revoked_and_flips_dirty() {
+        let wallet = [1u8; 32];
+        let state = state_with_wallet(wallet, false);
+        let hex = format!("0x{}", hex::encode(wallet));
+
+        let resp = handler(State(state.clone()), empty_state_path(), Path(hex.clone()))
+            .await
+            .unwrap()
+            .0;
+
+        assert!(resp.revoked);
+        let st = state.read().await;
+        assert!(st.credentials[&wallet].revoked);
+        assert!(st.roots_dirty);
+    }
+
+    #[tokio::test]
+    async fn missing_wallet_returns_wallet_not_found() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let hex = format!("0x{}", hex::encode([99u8; 32]));
+        let err = handler(State(state), empty_state_path(), Path(hex))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::WalletNotFound));
+    }
+
+    #[tokio::test]
+    async fn already_revoked_returns_conflict() {
+        let wallet = [2u8; 32];
+        let state = state_with_wallet(wallet, true);
+        let hex = format!("0x{}", hex::encode(wallet));
+        let err = handler(State(state), empty_state_path(), Path(hex))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::AlreadyRevoked));
+    }
+
+    #[tokio::test]
+    async fn invalid_hex_returns_invalid_hex() {
+        let state: SharedState = Arc::new(RwLock::new(IssuerState::new()));
+        let err = handler(State(state), empty_state_path(), Path("bad".into()))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ServiceError::InvalidHex(_)));
+    }
 }

--- a/backend/crates/issuer-service/src/rotation.rs
+++ b/backend/crates/issuer-service/src/rotation.rs
@@ -82,3 +82,96 @@ async fn publish_roots(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::{Mutex, RwLock};
+    use zksettle_rpc::{MockSolanaRpc, RpcError};
+
+    use super::*;
+    use crate::state::IssuerState;
+
+    fn fixture(
+        roots_dirty: bool,
+        registered: bool,
+    ) -> (SharedState, Arc<MockSolanaRpc>, Vec<u8>, Pubkey, PublishLock) {
+        let mut st = IssuerState::new();
+        st.roots_dirty = roots_dirty;
+        st.registered = registered;
+        let kp = Keypair::new();
+        (
+            Arc::new(RwLock::new(st)),
+            Arc::new(MockSolanaRpc::new()),
+            kp.to_bytes().to_vec(),
+            Pubkey::new_unique(),
+            Arc::new(Mutex::new(())),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dirty_roots_trigger_publish_and_clear_dirty() {
+        let (state, rpc, kb, pid, lock) = fixture(true, false);
+        let rpc_dyn: Arc<dyn SolanaRpc> = rpc.clone();
+
+        publish_roots(&state, rpc_dyn, &kb, &pid, &lock).await;
+
+        assert_eq!(rpc.send_count(), 1);
+        let st = state.read().await;
+        assert!(st.registered, "first publish flips registered");
+        assert!(!st.roots_dirty, "publish clears roots_dirty");
+        assert!(st.last_publish_slot >= 1_000);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_roots_when_registered_skips_publish() {
+        let (state, rpc, kb, pid, lock) = fixture(false, true);
+        let rpc_dyn: Arc<dyn SolanaRpc> = rpc.clone();
+
+        publish_roots(&state, rpc_dyn, &kb, &pid, &lock).await;
+
+        assert_eq!(rpc.send_count(), 0, "must not publish when nothing changed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clean_roots_when_unregistered_still_publishes_to_register() {
+        let (state, rpc, kb, pid, lock) = fixture(false, false);
+        let rpc_dyn: Arc<dyn SolanaRpc> = rpc.clone();
+
+        publish_roots(&state, rpc_dyn, &kb, &pid, &lock).await;
+
+        assert_eq!(rpc.send_count(), 1, "must register even with clean roots");
+        assert!(state.read().await.registered);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_failure_does_not_mutate_state() {
+        let (state, rpc, kb, pid, lock) = fixture(true, false);
+        rpc.queue_error(RpcError::Call("simulated".into()));
+        let rpc_dyn: Arc<dyn SolanaRpc> = rpc.clone();
+
+        publish_roots(&state, rpc_dyn, &kb, &pid, &lock).await;
+
+        let st = state.read().await;
+        assert!(!st.registered, "failed RPC must not flip registered");
+        assert!(st.roots_dirty, "failed RPC must keep roots_dirty for retry");
+        assert_eq!(st.last_publish_slot, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_signal_terminates_spawn_loop_quickly() {
+        // Sanity check on spawn(): with a long interval, sending shutdown
+        // before the first sleep elapses still terminates the task.
+        let (state, rpc, _kb, pid, lock) = fixture(true, false);
+        let kp = Keypair::new();
+        let (tx, rx) = watch::channel(());
+
+        let handle = spawn(state, rpc.clone(), kp, pid, 3600, rx, lock);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = tx.send(());
+
+        let join_result =
+            tokio::time::timeout(Duration::from_secs(2), handle).await;
+        assert!(join_result.is_ok(), "rotation task must exit on shutdown");
+    }
+}

--- a/backend/crates/issuer-service/src/rotation.rs
+++ b/backend/crates/issuer-service/src/rotation.rs
@@ -29,7 +29,14 @@ pub fn spawn(
                     return;
                 }
             }
-            publish_roots(&state, rpc.clone(), &keypair_bytes, &program_id, &publish_lock).await;
+            publish_roots(
+                &state,
+                rpc.clone(),
+                &keypair_bytes,
+                &program_id,
+                &publish_lock,
+            )
+            .await;
         }
     })
 }
@@ -94,7 +101,13 @@ mod tests {
     fn fixture(
         roots_dirty: bool,
         registered: bool,
-    ) -> (SharedState, Arc<MockSolanaRpc>, Vec<u8>, Pubkey, PublishLock) {
+    ) -> (
+        SharedState,
+        Arc<MockSolanaRpc>,
+        Vec<u8>,
+        Pubkey,
+        PublishLock,
+    ) {
         let mut st = IssuerState::new();
         st.roots_dirty = roots_dirty;
         st.registered = registered;
@@ -170,8 +183,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
         let _ = tx.send(());
 
-        let join_result =
-            tokio::time::timeout(Duration::from_secs(2), handle).await;
+        let join_result = tokio::time::timeout(Duration::from_secs(2), handle).await;
         assert!(join_result.is_ok(), "rotation task must exit on shutdown");
     }
 }

--- a/backend/crates/sanctions-updater/Cargo.toml
+++ b/backend/crates/sanctions-updater/Cargo.toml
@@ -27,3 +27,6 @@ borsh = "1"
 sha2 = "0.10"
 serde_json = "1"
 mutants = "0.0.3"
+
+[dev-dependencies]
+zksettle-rpc = { path = "../zksettle-rpc", features = ["test-util"] }

--- a/backend/crates/sanctions-updater/src/chain.rs
+++ b/backend/crates/sanctions-updater/src/chain.rs
@@ -38,7 +38,11 @@ fn build_ix(
     register: bool,
 ) -> Instruction {
     let (pda, _) = issuer_pda(authority, program_id);
-    let name = if register { "register_issuer" } else { "update_issuer_root" };
+    let name = if register {
+        "register_issuer"
+    } else {
+        "update_issuer_root"
+    };
     let mut data = discriminator(name).to_vec();
     roots.serialize(&mut data).unwrap();
 
@@ -52,7 +56,10 @@ fn build_ix(
     ];
     if register {
         #[allow(deprecated)]
-        accounts.push(AccountMeta::new_readonly(solana_sdk::system_program::ID, false));
+        accounts.push(AccountMeta::new_readonly(
+            solana_sdk::system_program::ID,
+            false,
+        ));
     }
 
     Instruction {
@@ -115,8 +122,8 @@ pub fn publish_sanctions_root(
     new_sanctions_root: [u8; 32],
     currently_registered: bool,
 ) -> Result<PublishResult, UpdaterError> {
-    let keypair = Keypair::try_from(keypair_bytes)
-        .map_err(|e| UpdaterError::Chain(e.to_string()))?;
+    let keypair =
+        Keypair::try_from(keypair_bytes).map_err(|e| UpdaterError::Chain(e.to_string()))?;
 
     let (merkle_root, _old_sanctions, jurisdiction_root) = if currently_registered {
         read_current_roots(rpc, &keypair.pubkey(), program_id)?
@@ -171,7 +178,10 @@ mod tests {
 
     #[test]
     fn discriminator_different_names_differ() {
-        assert_ne!(discriminator("register_issuer"), discriminator("update_issuer_root"));
+        assert_ne!(
+            discriminator("register_issuer"),
+            discriminator("update_issuer_root")
+        );
     }
 
     #[test]
@@ -280,14 +290,8 @@ mod tests {
         let (pda, _) = issuer_pda(&kp.pubkey(), &program);
         rpc.set_account(pda, pda_payload([1u8; 32], [2u8; 32], [3u8; 32]));
 
-        let result = publish_sanctions_root(
-            &rpc,
-            &kp.to_bytes(),
-            &program,
-            [99u8; 32],
-            true,
-        )
-        .unwrap();
+        let result =
+            publish_sanctions_root(&rpc, &kp.to_bytes(), &program, [99u8; 32], true).unwrap();
 
         assert!(!result.did_register);
         assert_eq!(rpc.send_count(), 1);

--- a/backend/crates/sanctions-updater/src/chain.rs
+++ b/backend/crates/sanctions-updater/src/chain.rs
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn publish_sanctions_root_when_registered_uses_update_discriminator() {
         let rpc = MockSolanaRpc::new();
-        let kp = Keypair::from_bytes(&keypair_bytes()).unwrap();
+        let kp = Keypair::try_from(&keypair_bytes()[..]).unwrap();
         let program = Pubkey::new_unique();
         let (pda, _) = issuer_pda(&kp.pubkey(), &program);
         rpc.set_account(pda, pda_payload([1u8; 32], [2u8; 32], [3u8; 32]));

--- a/backend/crates/sanctions-updater/src/chain.rs
+++ b/backend/crates/sanctions-updater/src/chain.rs
@@ -62,6 +62,7 @@ fn build_ix(
     }
 }
 
+#[derive(Debug)]
 pub struct PublishResult {
     pub slot: u64,
     pub did_register: bool,
@@ -179,5 +180,137 @@ mod tests {
         let hash = sha2::Sha256::digest(b"global:register_issuer");
         let expected: [u8; 8] = hash[..8].try_into().unwrap();
         assert_eq!(discriminator("register_issuer"), expected);
+    }
+
+    use zksettle_rpc::{MockSolanaRpc, RpcError};
+
+    fn keypair_bytes() -> Vec<u8> {
+        Keypair::new().to_bytes().to_vec()
+    }
+
+    /// Builds a 137-byte payload matching the on-chain Issuer PDA layout
+    /// (8 disc + 32 authority + 32 merkle + 32 sanctions + 32 jurisdiction
+    /// + 8 slot + 1 bump) used by `read_current_roots`.
+    fn pda_payload(merkle: [u8; 32], sanctions: [u8; 32], jurisdiction: [u8; 32]) -> Vec<u8> {
+        let mut buf = vec![0u8; 8 + 32]; // disc + authority padding
+        buf.extend_from_slice(&merkle);
+        buf.extend_from_slice(&sanctions);
+        buf.extend_from_slice(&jurisdiction);
+        buf.extend_from_slice(&[0u8; 8]); // slot
+        buf.push(255); // bump
+        buf
+    }
+
+    #[test]
+    fn is_issuer_registered_returns_true_when_account_exists() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::new();
+        let program = Pubkey::new_unique();
+        let (pda, _) = issuer_pda(&kp.pubkey(), &program);
+        rpc.set_account(pda, vec![0u8; 137]);
+
+        assert!(is_issuer_registered(&rpc, &kp.pubkey(), &program).unwrap());
+    }
+
+    #[test]
+    fn is_issuer_registered_returns_false_when_account_missing() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::new();
+        let program = Pubkey::new_unique();
+        assert!(!is_issuer_registered(&rpc, &kp.pubkey(), &program).unwrap());
+    }
+
+    #[test]
+    fn read_current_roots_extracts_three_root_slices() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::new();
+        let program = Pubkey::new_unique();
+        let (pda, _) = issuer_pda(&kp.pubkey(), &program);
+
+        let merkle = [11u8; 32];
+        let sanctions = [22u8; 32];
+        let jurisdiction = [33u8; 32];
+        rpc.set_account(pda, pda_payload(merkle, sanctions, jurisdiction));
+
+        let (m, s, j) = read_current_roots(&rpc, &kp.pubkey(), &program).unwrap();
+        assert_eq!(m, merkle);
+        assert_eq!(s, sanctions);
+        assert_eq!(j, jurisdiction);
+    }
+
+    #[test]
+    fn read_current_roots_errors_when_pda_missing() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::new();
+        let err = read_current_roots(&rpc, &kp.pubkey(), &Pubkey::new_unique()).unwrap_err();
+        assert!(matches!(err, UpdaterError::Chain(msg) if msg.contains("not found")));
+    }
+
+    #[test]
+    fn read_current_roots_errors_when_data_too_short() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::new();
+        let program = Pubkey::new_unique();
+        let (pda, _) = issuer_pda(&kp.pubkey(), &program);
+        rpc.set_account(pda, vec![0u8; 64]); // need ≥136
+
+        let err = read_current_roots(&rpc, &kp.pubkey(), &program).unwrap_err();
+        assert!(matches!(err, UpdaterError::Chain(msg) if msg.contains("too short")));
+    }
+
+    #[test]
+    fn publish_sanctions_root_first_call_uses_register_discriminator() {
+        let rpc = MockSolanaRpc::new();
+        let kb = keypair_bytes();
+        let program = Pubkey::new_unique();
+
+        let result = publish_sanctions_root(&rpc, &kb, &program, [9u8; 32], false).unwrap();
+
+        assert!(result.did_register);
+        assert_eq!(rpc.send_count(), 1);
+        let sent = &rpc.sent_instructions()[0];
+        assert_eq!(&sent.data[..8], &discriminator("register_issuer"));
+    }
+
+    #[test]
+    fn publish_sanctions_root_when_registered_uses_update_discriminator() {
+        let rpc = MockSolanaRpc::new();
+        let kp = Keypair::from_bytes(&keypair_bytes()).unwrap();
+        let program = Pubkey::new_unique();
+        let (pda, _) = issuer_pda(&kp.pubkey(), &program);
+        rpc.set_account(pda, pda_payload([1u8; 32], [2u8; 32], [3u8; 32]));
+
+        let result = publish_sanctions_root(
+            &rpc,
+            &kp.to_bytes(),
+            &program,
+            [99u8; 32],
+            true,
+        )
+        .unwrap();
+
+        assert!(!result.did_register);
+        assert_eq!(rpc.send_count(), 1);
+        let sent = &rpc.sent_instructions()[0];
+        assert_eq!(&sent.data[..8], &discriminator("update_issuer_root"));
+        // body must carry the new sanctions root, not the old one
+        assert!(sent.data.windows(32).any(|w| w == [99u8; 32]));
+    }
+
+    #[test]
+    fn publish_sanctions_root_propagates_rpc_failure() {
+        let rpc = MockSolanaRpc::new();
+        rpc.queue_error(RpcError::Call("simulated".into()));
+
+        let err = publish_sanctions_root(
+            &rpc,
+            &keypair_bytes(),
+            &Pubkey::new_unique(),
+            [0u8; 32],
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, UpdaterError::Chain(_)));
+        assert_eq!(rpc.send_count(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Phase 3 of #54 — behavior tests behind the trait doubles shipped in Phase 2 (#69). Closes #54 when merged.

10 commits, 9 files of source modified (mostly test modules added at the bottom), zero production behavior change. ~50 new unit / integration tests covering every untested handler, rotation tick, chain RPC path, auth case, proxy branch, and Irys client mode.

## What's new

| # | Commit | Adds |
|---|---|---|
| 1 | `test(off-chain): add MockHttpUpstream and MockIrysUploader behind test-util feature` | Two missing mocks + `[features] test-util` on api-gateway and indexer + dev-dep wiring on issuer-service and sanctions-updater. 6 self-tests. |
| 2 | `test(issuer-service): cover read-only handlers` | health (1), get_roots (3), get_credential (3) |
| 3 | `test(issuer-service): cover proof handlers and add_wallet` | get_proof (3, includes verify_merkle_proof roundtrip), get_sanctions_proof (3), add_wallet (3) |
| 4 | `test(issuer-service): cover mutating handlers including publish via MockSolanaRpc` | issue_credential (4), revoke_credential (4), publish (3 multi-thread tokio tests with `MockSolanaRpc`) |
| 5 | `test(issuer-service): cover rotation publish loop with MockSolanaRpc` | rotation::publish_roots (4 branches) + spawn shutdown sanity (1) |
| 6 | `test(sanctions-updater): cover chain RPC paths via MockSolanaRpc` | is_issuer_registered (2), read_current_roots (3), publish_sanctions_root (3) |
| 7 | `test(api-gateway): cover bearer auth extractor and proxy handler` | auth (5), proxy with `MockHttpUpstream` (4) |
| 8 | `test(indexer): cover IrysClient dry-run and live branches` | dry-run + live error path (2) |
| 9 | `test: clippy fixes across Phase 3 test additions` | useless_conversion in revoke handler, deprecated Keypair::from_bytes, two unused Json must_use |
| 10 | `style(off-chain): apply rustfmt to Phase 3 test additions` | scoped formatting; unrelated workspace fmt drift left out |

## Conventions followed

- Inline `#[cfg(test)] mod tests` in each file under test (matches PR #67 + #69 precedent — no separate `tests/` dir).
- `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` for `publish` handler, rotation, and proxy tests because they exercise `spawn_blocking` paths that deadlock on the single-threaded runtime.
- Mock structs use `Mutex`-guarded state + `queue_error` + `sent_count` getters (same shape as `MockSolanaRpc` from Phase 2).
- Cross-crate mocks gated `#[cfg(any(test, feature = "test-util"))]`; downstream consumers opt in via `[dev-dependencies] features = ["test-util"]`.
- `assert!(matches!(...))` for error-variant checks.
- No env-var mutation in tests (uses `SystemTime::now()` only where the production code reads it).
- Several existing `Response`/`Result` types get `#[derive(Debug)]` so `Result::unwrap_err` compiles in tests — same pattern Phase 2 introduced for `UpstreamRequest`/`UpstreamResponse`.

## Test plan

- [x] `cargo test --workspace --exclude zksettle` — all crates green.
- [x] `cargo clippy --workspace --exclude zksettle --lib --bins --tests -- -D warnings` — clean.
- [x] No test touches live network, RPC, or filesystem outside `tempdir`.
- [ ] CI green.

## Out of scope

- **issuer-service router integration test** — would require splitting `main.rs` into `lib.rs + main.rs` (api-gateway shape). Tracked as separate follow-up.
- **`IrysClient` retry-budget test** — needs a mockable `reqwest::Client` inside `IrysClient`, not just trait-level mock.
- **CI coverage gate** — folded into #55 (cargo-mutants).
- **Workspace-wide rustfmt cleanup** — left for separate PR.

Closes #54.