### PR TITLE
Feature/issue 82 postgres migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,36 @@
+# ── API Gateway ──────────────────────────────────────────────
 GATEWAY_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway
 GATEWAY_PORT=4000
 GATEWAY_UPSTREAM_URL=http://localhost:3000
+GATEWAY_INDEXER_URL=http://localhost:3001
 GATEWAY_ADMIN_KEY=
 GATEWAY_ALLOW_OPEN_KEYS=true
 GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:3000
+GATEWAY_LOG_LEVEL=info
+
+# ── Indexer ──────────────────────────────────────────────────
+INDEXER_PORT=3001
+INDEXER_HELIUS_AUTH_TOKEN=
+INDEXER_IRYS_NODE_URL=https://node2.irys.xyz
+INDEXER_IRYS_WALLET_KEY=
+INDEXER_PROGRAM_ID=
+INDEXER_LOG_LEVEL=info
+INDEXER_DEDUP_PATH=./data/dedup
+INDEXER_DEDUP_CAPACITY=1000000
+INDEXER_DEDUP_TTL_SECS=86400
+
+# ── Issuer Service ───────────────────────────────────────────
+RPC_URL=http://127.0.0.1:8899
+KEYPAIR_PATH=~/.config/solana/id.json
+PROGRAM_ID=zkSet11ezkSet11ezkSet11ezkSet11ezkSet11ezkS
+ROTATION_INTERVAL_SECS=43200
+LISTEN_ADDR=127.0.0.1:3000
+STATE_PATH=
+API_TOKEN=
+ALLOW_UNAUTHENTICATED=false
+
+# ── Testing ───────────────────────────────────────────────────
+TEST_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway_test
+
+# ── Build ────────────────────────────────────────────────────
+VK_PATH=default.vk

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+GATEWAY_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway
+GATEWAY_PORT=4000
+GATEWAY_UPSTREAM_URL=http://localhost:3000
+GATEWAY_ADMIN_KEY=
+GATEWAY_ALLOW_OPEN_KEYS=true
+GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 backend/programs/zksettle/src/generated_vk.rs
 .env
 .env.*
+!.env.example

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,8 @@
+target/
+node_modules/
+mutants.out/
+mutants.out.old/
+.git/
+.env*
+*.pem
+*.key

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -60,7 +60,7 @@ version = "2.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a2c365c0245cbb8959de725fc2b44c754b673fdf34c9a7f9d4a25c35a7bf1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "solana-epoch-schedule",
  "solana-hash 2.3.0",
  "solana-pubkey 2.4.0",
@@ -103,6 +103,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -122,6 +133,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "aligned-sized"
@@ -368,6 +385,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +445,7 @@ name = "api-gateway"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "api-gateway-migration",
  "async-trait",
  "axum 0.8.9",
  "dashmap",
@@ -387,8 +455,10 @@ dependencies = [
  "mutants",
  "rand 0.9.4",
  "reqwest 0.12.28",
+ "sea-orm",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
@@ -398,6 +468,14 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zksettle-types",
+]
+
+[[package]]
+name = "api-gateway-migration"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "sea-orm-migration",
 ]
 
 [[package]]
@@ -445,7 +523,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "ark-ff 0.5.0",
  "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
@@ -565,7 +643,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
@@ -694,6 +772,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +802,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -935,6 +1044,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1269,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1413,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1294,6 +1440,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1493,12 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1348,6 +1540,15 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -1449,6 +1650,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1481,6 +1697,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1610,6 +1835,16 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
@@ -1626,6 +1861,19 @@ checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core 0.23.0",
  "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1652,6 +1900,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1698,6 +1957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1708,6 +1968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1725,6 +1986,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1749,6 +2032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1774,6 +2058,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -1876,6 +2166,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1975,6 +2268,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,6 +2369,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -2144,6 +2470,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2382,11 +2719,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2413,6 +2759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2775,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2441,6 +2802,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "hmac"
@@ -2470,6 +2840,15 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2879,6 +3258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,6 +3292,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "issuer-service"
@@ -3078,6 +3474,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -3099,6 +3498,24 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3162,6 +3579,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
 dependencies = [
  "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3978,6 +4405,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,6 +4435,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -4118,6 +4566,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,6 +4643,22 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -4250,6 +4727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4285,6 +4763,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opaque-debug"
@@ -4366,6 +4850,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4892,12 @@ dependencies = [
  "fnv",
  "unicode-width",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4394,7 +4917,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -4421,6 +4944,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4433,6 +4965,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
 dependencies = [
  "num",
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4491,6 +5032,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4505,6 +5057,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polyval"
@@ -4618,6 +5176,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
+]
+
+[[package]]
 name = "progenitor-client"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4630,6 +5201,26 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4889,6 +5480,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4916,6 +5516,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -5087,6 +5696,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5094,6 +5732,26 @@ checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5110,6 +5768,23 @@ dependencies = [
  "mime_guess",
  "rand 0.8.6",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh 1.6.1",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5300,6 +5975,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5323,6 +6007,183 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "sea-bae"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sea-orm"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive_more",
+ "futures-util",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-binder",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "strum",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+dependencies = [
+ "chrono",
+ "clap",
+ "dotenvy",
+ "glob",
+ "regex",
+ "sea-schema",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+dependencies = [
+ "async-trait",
+ "clap",
+ "dotenvy",
+ "sea-orm",
+ "sea-orm-cli",
+ "sea-schema",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.32.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "inherent",
+ "ordered-float",
+ "rust_decimal",
+ "sea-query-derive",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-binder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "rust_decimal",
+ "sea-query",
+ "serde_json",
+ "sqlx",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
+dependencies = [
+ "futures",
+ "sea-query",
+ "sea-query-binder",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -5470,6 +6331,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,6 +6454,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5564,6 +6463,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5582,6 +6487,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -5968,7 +6876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ca69a299a6c969b18ea381a02b40c9e4dda04b2af0d15a007c1184c82163bbb"
 dependencies = [
  "agave-feature-set",
- "ahash",
+ "ahash 0.8.12",
  "log",
  "solana-bpf-loader-program",
  "solana-compute-budget-program",
@@ -6301,7 +7209,7 @@ version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93b93971e289d6425f88e6e3cb6668c4b05df78b3c518c249be55ced8efd6b6d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "lazy_static",
  "solana-epoch-schedule",
  "solana-hash 2.3.0",
@@ -8186,6 +9094,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9065,6 +9982,215 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bigdecimal",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.2",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rust_decimal",
+ "rustls 0.23.38",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bigdecimal",
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "rust_decimal",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bigdecimal",
+ "bitflags 2.11.1",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "num-bigint 0.4.6",
+ "once_cell",
+ "rand 0.8.6",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9077,10 +10203,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 
 [[package]]
 name = "subtle"
@@ -9460,6 +10603,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9726,10 +10880,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -9803,6 +10978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9810,6 +10991,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -9887,6 +11069,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9895,6 +11083,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -10025,11 +11214,30 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "programs/*",
     "crates/*",
+    "crates/api-gateway/migration",
 ]
 resolver = "2"
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,15 +6,21 @@ RUN cargo build --release
 
 FROM debian:bookworm-slim AS api-gateway
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN useradd -r -s /usr/sbin/nologin appuser
 COPY --from=builder /app/target/release/api-gateway /usr/local/bin/
+USER appuser
 CMD ["api-gateway"]
 
 FROM debian:bookworm-slim AS issuer-service
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN useradd -r -s /usr/sbin/nologin appuser
 COPY --from=builder /app/target/release/issuer-service /usr/local/bin/
+USER appuser
 CMD ["issuer-service"]
 
 FROM debian:bookworm-slim AS indexer
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN useradd -r -s /usr/sbin/nologin appuser
 COPY --from=builder /app/target/release/indexer /usr/local/bin/
+USER appuser
 CMD ["indexer"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.82-slim AS builder
+WORKDIR /app
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim AS api-gateway
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/api-gateway /usr/local/bin/
+CMD ["api-gateway"]
+
+FROM debian:bookworm-slim AS issuer-service
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/issuer-service /usr/local/bin/
+CMD ["issuer-service"]
+
+FROM debian:bookworm-slim AS indexer
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/indexer /usr/local/bin/
+CMD ["indexer"]

--- a/backend/crates/api-gateway/Cargo.toml
+++ b/backend/crates/api-gateway/Cargo.toml
@@ -34,7 +34,10 @@ rand = "0.9"
 sha2 = "0.10"
 subtle = "2"
 mutants = "0.0.3"
+sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
+api-gateway-migration = { path = "migration" }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+serial_test = "3"

--- a/backend/crates/api-gateway/migration/Cargo.toml
+++ b/backend/crates/api-gateway/migration/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "api-gateway-migration"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = "0.1"
+sea-orm-migration = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }

--- a/backend/crates/api-gateway/migration/src/lib.rs
+++ b/backend/crates/api-gateway/migration/src/lib.rs
@@ -1,0 +1,14 @@
+pub use sea_orm_migration::prelude::*;
+
+mod m20260426_001_create_gateway_tables;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(
+            m20260426_001_create_gateway_tables::Migration,
+        )]
+    }
+}

--- a/backend/crates/api-gateway/migration/src/m20260426_001_create_gateway_tables.rs
+++ b/backend/crates/api-gateway/migration/src/m20260426_001_create_gateway_tables.rs
@@ -1,0 +1,151 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(ApiKeys::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(ApiKeys::KeyHash)
+                            .string_len(64)
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(ApiKeys::Owner).text().not_null())
+                    .col(ColumnDef::new(ApiKeys::Tier).text().not_null())
+                    .col(ColumnDef::new(ApiKeys::CreatedAt).big_integer().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(UsageRecords::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(UsageRecords::KeyHash)
+                            .string_len(64)
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(UsageRecords::RequestCount)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(UsageRecords::PeriodStart)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(UsageRecords::LastRequest)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(UsageRecords::Table, UsageRecords::KeyHash)
+                            .to(ApiKeys::Table, ApiKeys::KeyHash)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(DailyUsage::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(DailyUsage::KeyHash)
+                            .string_len(64)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(DailyUsage::DayStart)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(DailyUsage::Count)
+                            .big_integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .col(DailyUsage::KeyHash)
+                            .col(DailyUsage::DayStart),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .from(DailyUsage::Table, DailyUsage::KeyHash)
+                            .to(ApiKeys::Table, ApiKeys::KeyHash)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_daily_usage_key")
+                    .table(DailyUsage::Table)
+                    .col(DailyUsage::KeyHash)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(DailyUsage::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(UsageRecords::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(ApiKeys::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum ApiKeys {
+    Table,
+    KeyHash,
+    Owner,
+    Tier,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum UsageRecords {
+    Table,
+    KeyHash,
+    RequestCount,
+    PeriodStart,
+    LastRequest,
+}
+
+#[derive(DeriveIden)]
+enum DailyUsage {
+    Table,
+    KeyHash,
+    DayStart,
+    Count,
+}

--- a/backend/crates/api-gateway/src/auth.rs
+++ b/backend/crates/api-gateway/src/auth.rs
@@ -5,7 +5,7 @@ use axum::http::request::Parts;
 use zksettle_types::gateway::ApiKeyRecord;
 
 use crate::error::GatewayError;
-use crate::key_store::hash_key;
+use crate::key_store;
 use crate::AppState;
 
 #[derive(Debug)]
@@ -32,10 +32,9 @@ impl FromRequestParts<Arc<AppState>> for AuthenticatedKey {
             return Err(GatewayError::Unauthorized);
         }
 
-        let hash = hash_key(token);
-        let record = state
-            .keys
-            .lookup_by_hash(&hash)
+        let hash = key_store::hash_key(token);
+        let record = key_store::lookup_by_hash(&state.db, &hash)
+            .await?
             .ok_or(GatewayError::KeyNotFound)?;
 
         Ok(AuthenticatedKey(record))
@@ -51,14 +50,17 @@ mod tests {
 
     use super::*;
     use crate::config::Config;
-    use crate::key_store::KeyStore;
-    use crate::metering::Metering;
     use crate::rate_limit::RateLimitStore;
     use crate::upstream::MockHttpUpstream;
+    use crate::{test_cleanup, test_db};
+    use serial_test::serial;
 
-    fn state_with_key(raw_key: &str) -> Arc<AppState> {
-        let keys = KeyStore::new();
-        keys.insert(raw_key, "alice".into(), Tier::Developer, 0);
+    async fn state_with_key(raw_key: &str) -> Arc<AppState> {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        key_store::insert(&db, raw_key, "alice".into(), Tier::Developer, 0)
+            .await
+            .unwrap();
         Arc::new(AppState {
             config: Config {
                 port: 4000,
@@ -68,9 +70,9 @@ mod tests {
                 allow_open_keys: true,
                 cors_allowed_origins: vec![],
                 indexer_url: None,
+                database_url: String::new(),
             },
-            keys,
-            metering: Metering::new(),
+            db,
             rate_limiter: RateLimitStore::new(),
             upstream: Arc::new(MockHttpUpstream::new()),
         })
@@ -85,16 +87,18 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn missing_authorization_header_returns_unauthorized() {
-        let state = state_with_key("zks_one");
+        let state = state_with_key("zks_one").await;
         let req = Request::builder().uri("/").body(()).unwrap();
         let err = extract(&state, req).await.unwrap_err();
         assert!(matches!(err, GatewayError::Unauthorized));
     }
 
     #[tokio::test]
+    #[serial]
     async fn header_without_bearer_prefix_returns_unauthorized() {
-        let state = state_with_key("zks_one");
+        let state = state_with_key("zks_one").await;
         let req = Request::builder()
             .uri("/")
             .header("authorization", "Token zks_one")
@@ -105,8 +109,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn empty_bearer_token_returns_unauthorized() {
-        let state = state_with_key("zks_one");
+        let state = state_with_key("zks_one").await;
         let req = Request::builder()
             .uri("/")
             .header("authorization", "Bearer ")
@@ -117,8 +122,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn unknown_key_returns_key_not_found() {
-        let state = state_with_key("zks_known");
+        let state = state_with_key("zks_known").await;
         let req = Request::builder()
             .uri("/")
             .header("authorization", "Bearer zks_unknown")
@@ -129,8 +135,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn valid_key_returns_record_with_owner() {
-        let state = state_with_key("zks_alice");
+        let state = state_with_key("zks_alice").await;
         let req = Request::builder()
             .uri("/")
             .header("authorization", "Bearer zks_alice")

--- a/backend/crates/api-gateway/src/config/db.rs
+++ b/backend/crates/api-gateway/src/config/db.rs
@@ -1,0 +1,21 @@
+use api_gateway_migration::{Migrator, MigratorTrait};
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+
+use crate::error::GatewayError;
+
+pub async fn connect_and_migrate(database_url: &str) -> Result<DatabaseConnection, GatewayError> {
+    let mut opts = ConnectOptions::new(database_url);
+    opts.max_connections(20)
+        .min_connections(2)
+        .sqlx_logging(false);
+
+    let db = Database::connect(opts)
+        .await
+        .map_err(|e| GatewayError::Database(e.to_string()))?;
+
+    Migrator::up(&db, None)
+        .await
+        .map_err(|e| GatewayError::Database(format!("migration failed: {e}")))?;
+
+    Ok(db)
+}

--- a/backend/crates/api-gateway/src/config/mod.rs
+++ b/backend/crates/api-gateway/src/config/mod.rs
@@ -1,0 +1,4 @@
+mod settings;
+pub mod db;
+
+pub use settings::Config;

--- a/backend/crates/api-gateway/src/config/settings.rs
+++ b/backend/crates/api-gateway/src/config/settings.rs
@@ -13,6 +13,7 @@ pub struct Config {
     /// Origins allowed via CORS. Empty = CORS disabled (browser callers blocked).
     /// Set `GATEWAY_CORS_ALLOWED_ORIGINS=https://app.example.com,http://localhost:3000`.
     pub cors_allowed_origins: Vec<String>,
+    pub database_url: String,
 }
 
 impl std::fmt::Debug for Config {
@@ -25,6 +26,7 @@ impl std::fmt::Debug for Config {
             .field("admin_key", &self.admin_key.as_ref().map(|_| "[REDACTED]"))
             .field("allow_open_keys", &self.allow_open_keys)
             .field("cors_allowed_origins", &self.cors_allowed_origins)
+            .field("database_url", &"[REDACTED]")
             .finish()
     }
 }
@@ -46,6 +48,7 @@ impl Config {
             cors_allowed_origins: read_var("GATEWAY_CORS_ALLOWED_ORIGINS")
                 .map(|v| parse_origins(&v))
                 .unwrap_or_default(),
+            database_url: read_var("GATEWAY_DATABASE_URL")?,
         })
     }
 }
@@ -100,9 +103,11 @@ mod tests {
             allow_open_keys: false,
             cors_allowed_origins: vec![],
             indexer_url: None,
+            database_url: "postgres://secret@localhost/db".into(),
         };
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains("my_admin_secret"));
+        assert!(!dbg.contains("postgres://secret"));
         assert!(dbg.contains("[REDACTED]"));
     }
 }

--- a/backend/crates/api-gateway/src/entity/api_key.rs
+++ b/backend/crates/api-gateway/src/entity/api_key.rs
@@ -1,0 +1,33 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "api_keys")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub key_hash: String,
+    pub owner: String,
+    pub tier: String,
+    pub created_at: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(has_one = "super::usage_record::Entity")]
+    UsageRecord,
+    #[sea_orm(has_many = "super::daily_usage::Entity")]
+    DailyUsage,
+}
+
+impl Related<super::usage_record::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::UsageRecord.def()
+    }
+}
+
+impl Related<super::daily_usage::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::DailyUsage.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/crates/api-gateway/src/entity/daily_usage.rs
+++ b/backend/crates/api-gateway/src/entity/daily_usage.rs
@@ -1,0 +1,29 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "daily_usage")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub key_hash: String,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub day_start: i64,
+    pub count: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::api_key::Entity",
+        from = "Column::KeyHash",
+        to = "super::api_key::Column::KeyHash"
+    )]
+    ApiKey,
+}
+
+impl Related<super::api_key::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::ApiKey.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/crates/api-gateway/src/entity/mod.rs
+++ b/backend/crates/api-gateway/src/entity/mod.rs
@@ -1,0 +1,3 @@
+pub mod api_key;
+pub mod daily_usage;
+pub mod usage_record;

--- a/backend/crates/api-gateway/src/entity/usage_record.rs
+++ b/backend/crates/api-gateway/src/entity/usage_record.rs
@@ -1,0 +1,29 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "usage_records")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub key_hash: String,
+    pub request_count: i64,
+    pub period_start: i64,
+    pub last_request: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::api_key::Entity",
+        from = "Column::KeyHash",
+        to = "super::api_key::Column::KeyHash"
+    )]
+    ApiKey,
+}
+
+impl Related<super::api_key::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::ApiKey.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/crates/api-gateway/src/error.rs
+++ b/backend/crates/api-gateway/src/error.rs
@@ -1,5 +1,6 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use sea_orm::DbErr;
 use serde::Serialize;
 use thiserror::Error;
 
@@ -29,6 +30,9 @@ pub enum GatewayError {
 
     #[error("configuration error: {0}")]
     Config(String),
+
+    #[error("database error: {0}")]
+    Database(String),
 }
 
 #[derive(Serialize)]
@@ -44,11 +48,36 @@ impl IntoResponse for GatewayError {
             Self::Forbidden => StatusCode::FORBIDDEN,
             Self::NotFound => StatusCode::NOT_FOUND,
             Self::Upstream(_) => StatusCode::BAD_GATEWAY,
-            Self::Config(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Config(_) | Self::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
         let body = ErrorBody {
             error: self.to_string(),
         };
         (status, axum::Json(body)).into_response()
+    }
+}
+
+impl From<DbErr> for GatewayError {
+    fn from(err: DbErr) -> Self {
+        Self::Database(err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn database_error_returns_500() {
+        let err = GatewayError::Database("connection refused".into());
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn db_err_converts_to_gateway_error() {
+        let db_err = DbErr::Conn(sea_orm::RuntimeErr::Internal("fail".into()));
+        let gw_err: GatewayError = db_err.into();
+        assert!(matches!(gw_err, GatewayError::Database(_)));
     }
 }

--- a/backend/crates/api-gateway/src/key_store.rs
+++ b/backend/crates/api-gateway/src/key_store.rs
@@ -1,51 +1,60 @@
-use dashmap::DashMap;
+use sea_orm::*;
 use sha2::{Digest, Sha256};
 use zksettle_types::gateway::{ApiKeyRecord, Tier};
 
-#[derive(Default)]
-pub struct KeyStore {
-    keys: DashMap<String, ApiKeyRecord>,
+use crate::entity::api_key;
+use crate::error::GatewayError;
+
+fn model_to_record(m: api_key::Model) -> Result<ApiKeyRecord, GatewayError> {
+    let tier: Tier = m
+        .tier
+        .parse()
+        .map_err(|e: String| GatewayError::Database(e))?;
+    Ok(ApiKeyRecord {
+        key_hash: m.key_hash,
+        tier,
+        owner: m.owner,
+        created_at: m.created_at as u64,
+    })
 }
 
-impl KeyStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
+pub async fn insert(
+    db: &DatabaseConnection,
+    raw_key: &str,
+    owner: String,
+    tier: Tier,
+    created_at: u64,
+) -> Result<(), GatewayError> {
+    let hash = hash_key(raw_key);
+    let model = api_key::ActiveModel {
+        key_hash: Set(hash),
+        owner: Set(owner),
+        tier: Set(tier.to_string()),
+        created_at: Set(created_at as i64),
+    };
+    api_key::Entity::insert(model).exec(db).await?;
+    Ok(())
+}
 
-    pub fn insert(&self, raw_key: &str, owner: String, tier: Tier, created_at: u64) {
-        let hash = hash_key(raw_key);
-        self.keys.insert(
-            hash.clone(),
-            ApiKeyRecord {
-                key_hash: hash,
-                tier,
-                owner,
-                created_at,
-            },
-        );
-    }
+pub async fn lookup_by_hash(
+    db: &DatabaseConnection,
+    key_hash: &str,
+) -> Result<Option<ApiKeyRecord>, GatewayError> {
+    let result = api_key::Entity::find_by_id(key_hash).one(db).await?;
+    result.map(model_to_record).transpose()
+}
 
-    pub fn lookup(&self, raw_key: &str) -> Option<ApiKeyRecord> {
-        let hash = hash_key(raw_key);
-        self.keys.get(&hash).map(|r| r.clone())
-    }
+pub async fn remove_by_hash(
+    db: &DatabaseConnection,
+    key_hash: &str,
+) -> Result<bool, GatewayError> {
+    let result = api_key::Entity::delete_by_id(key_hash).exec(db).await?;
+    Ok(result.rows_affected > 0)
+}
 
-    pub fn lookup_by_hash(&self, key_hash: &str) -> Option<ApiKeyRecord> {
-        self.keys.get(key_hash).map(|r| r.clone())
-    }
-
-    pub fn remove(&self, raw_key: &str) -> bool {
-        let hash = hash_key(raw_key);
-        self.keys.remove(&hash).is_some()
-    }
-
-    pub fn remove_by_hash(&self, key_hash: &str) -> bool {
-        self.keys.remove(key_hash).is_some()
-    }
-
-    pub fn list(&self) -> Vec<ApiKeyRecord> {
-        self.keys.iter().map(|r| r.value().clone()).collect()
-    }
+pub async fn list(db: &DatabaseConnection) -> Result<Vec<ApiKeyRecord>, GatewayError> {
+    let results = api_key::Entity::find().all(db).await?;
+    results.into_iter().map(model_to_record).collect()
 }
 
 pub fn hash_key(raw: &str) -> String {
@@ -63,60 +72,95 @@ pub fn generate_key() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{test_cleanup, test_db};
+    use serial_test::serial;
 
-    #[test]
-    fn insert_and_lookup() {
-        let store = KeyStore::new();
-        store.insert("test-key", "alice".into(), Tier::Developer, 1000);
-        let record = store.lookup("test-key").unwrap();
+    #[tokio::test]
+    #[serial]
+    async fn insert_and_lookup() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        insert(&db, "test-key", "alice".into(), Tier::Developer, 1000)
+            .await
+            .unwrap();
+        let record = lookup_by_hash(&db, &hash_key("test-key"))
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(record.owner, "alice");
         assert_eq!(record.tier, Tier::Developer);
     }
 
-    #[test]
-    fn lookup_missing_returns_none() {
-        let store = KeyStore::new();
-        assert!(store.lookup("nonexistent").is_none());
+    #[tokio::test]
+    #[serial]
+    async fn lookup_missing_returns_none() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        assert!(lookup_by_hash(&db, &hash_key("nonexistent"))
+            .await
+            .unwrap()
+            .is_none());
     }
 
-    #[test]
-    fn remove_key() {
-        let store = KeyStore::new();
-        store.insert("key", "bob".into(), Tier::Startup, 2000);
-        assert!(store.remove("key"));
-        assert!(store.lookup("key").is_none());
+    #[tokio::test]
+    #[serial]
+    async fn remove_key() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        insert(&db, "key", "bob".into(), Tier::Startup, 2000)
+            .await
+            .unwrap();
+        let hash = hash_key("key");
+        assert!(remove_by_hash(&db, &hash).await.unwrap());
+        assert!(lookup_by_hash(&db, &hash).await.unwrap().is_none());
     }
 
-    #[test]
-    fn remove_by_hash_returns_false_when_unknown() {
-        let store = KeyStore::new();
-        assert!(!store.remove_by_hash("0".repeat(64).as_str()));
+    #[tokio::test]
+    #[serial]
+    async fn remove_by_hash_returns_false_when_unknown() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        assert!(!remove_by_hash(&db, &"0".repeat(64)).await.unwrap());
     }
 
-    #[test]
-    fn remove_by_hash_evicts_existing() {
-        let store = KeyStore::new();
-        store.insert("k", "owner".into(), Tier::Developer, 1);
-        let hash = hash_key("k");
-        assert!(store.remove_by_hash(&hash));
-        assert!(store.lookup("k").is_none());
-    }
-
-    #[test]
-    fn list_returns_all_records() {
-        let store = KeyStore::new();
-        store.insert("a", "alice".into(), Tier::Developer, 100);
-        store.insert("b", "bob".into(), Tier::Startup, 200);
-        let mut owners: Vec<String> = store.list().into_iter().map(|r| r.owner).collect();
+    #[tokio::test]
+    #[serial]
+    async fn list_returns_all_records() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        insert(&db, "a", "alice".into(), Tier::Developer, 100)
+            .await
+            .unwrap();
+        insert(&db, "b", "bob".into(), Tier::Startup, 200)
+            .await
+            .unwrap();
+        let mut owners: Vec<String> = list(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|r| r.owner)
+            .collect();
         owners.sort();
         assert_eq!(owners, vec!["alice".to_string(), "bob".to_string()]);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn insert_duplicate_key_hash_errors() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        insert(&db, "dup", "alice".into(), Tier::Developer, 100)
+            .await
+            .unwrap();
+        let result = insert(&db, "dup", "bob".into(), Tier::Developer, 200).await;
+        assert!(result.is_err());
     }
 
     #[test]
     fn generated_key_has_prefix() {
         let key = generate_key();
         assert!(key.starts_with("zks_"));
-        assert_eq!(key.len(), 4 + 64); // "zks_" + 32 bytes hex
+        assert_eq!(key.len(), 4 + 64);
     }
 
     #[test]

--- a/backend/crates/api-gateway/src/lib.rs
+++ b/backend/crates/api-gateway/src/lib.rs
@@ -4,12 +4,14 @@ use std::time::Duration;
 use axum::http::{HeaderValue, Method};
 use axum::routing::{any, delete, get};
 use axum::Router;
+use sea_orm::DatabaseConnection;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing::warn;
 
 pub mod auth;
 pub mod config;
+pub mod entity;
 pub mod error;
 pub mod key_store;
 pub mod metering;
@@ -19,15 +21,12 @@ pub mod routes;
 pub mod upstream;
 
 use config::Config;
-use key_store::KeyStore;
-use metering::Metering;
 use rate_limit::RateLimitStore;
 use upstream::HttpUpstream;
 
 pub struct AppState {
     pub config: Config,
-    pub keys: KeyStore,
-    pub metering: Metering,
+    pub db: DatabaseConnection,
     pub rate_limiter: RateLimitStore,
     pub upstream: Arc<dyn HttpUpstream>,
 }
@@ -89,7 +88,21 @@ fn build_cors_layer(allowed_origins: &[String]) -> CorsLayer {
 }
 
 #[cfg(test)]
-pub fn test_state() -> Arc<AppState> {
+pub async fn test_db() -> DatabaseConnection {
+    let url = std::env::var("TEST_DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway_test".into());
+    config::db::connect_and_migrate(&url).await.expect("test DB connect")
+}
+
+#[cfg(test)]
+pub async fn test_cleanup(db: &DatabaseConnection) {
+    use sea_orm::EntityTrait;
+    entity::api_key::Entity::delete_many().exec(db).await.unwrap();
+}
+
+#[cfg(test)]
+pub async fn test_state() -> Arc<AppState> {
+    let db = test_db().await;
     let config = Config {
         port: 4000,
         upstream_url: "http://localhost:0".into(),
@@ -98,19 +111,19 @@ pub fn test_state() -> Arc<AppState> {
         allow_open_keys: true,
         cors_allowed_origins: vec![],
         indexer_url: None,
+        database_url: String::new(),
     };
     Arc::new(AppState {
         config,
-        keys: KeyStore::new(),
-        metering: Metering::new(),
+        db,
         rate_limiter: RateLimitStore::new(),
         upstream: Arc::new(upstream::ReqwestUpstream::new(reqwest::Client::new())),
     })
 }
 
 #[cfg(test)]
-pub fn test_app() -> Router {
-    build_router(test_state())
+pub async fn test_app() -> Router {
+    build_router(test_state().await)
 }
 
 #[cfg(test)]
@@ -118,9 +131,11 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use serial_test::serial;
     use tower::ServiceExt;
 
-    fn app_with_origins(origins: Vec<&str>) -> Router {
+    async fn app_with_origins(origins: Vec<&str>) -> Router {
+        let db = test_db().await;
         let config = Config {
             port: 4000,
             upstream_url: "http://localhost:0".into(),
@@ -129,11 +144,11 @@ mod tests {
             allow_open_keys: true,
             cors_allowed_origins: origins.into_iter().map(String::from).collect(),
             indexer_url: None,
+            database_url: String::new(),
         };
         let state = Arc::new(AppState {
             config,
-            keys: KeyStore::new(),
-            metering: Metering::new(),
+            db,
             rate_limiter: RateLimitStore::new(),
             upstream: Arc::new(upstream::ReqwestUpstream::new(reqwest::Client::new())),
         });
@@ -141,8 +156,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn cors_preflight_allowed_origin_returns_200() {
-        let app = app_with_origins(vec!["http://localhost:3000"]);
+        let app = app_with_origins(vec!["http://localhost:3000"]).await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -164,8 +180,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn cors_preflight_disallowed_origin_blocked() {
-        let app = app_with_origins(vec!["http://localhost:3000"]);
+        let app = app_with_origins(vec!["http://localhost:3000"]).await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -186,8 +203,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn cors_empty_origins_no_allow_header() {
-        let app = app_with_origins(vec![]);
+        let app = app_with_origins(vec![]).await;
         let resp = app
             .oneshot(
                 Request::builder()

--- a/backend/crates/api-gateway/src/main.rs
+++ b/backend/crates/api-gateway/src/main.rs
@@ -5,9 +5,7 @@ use tokio::net::TcpListener;
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
-use api_gateway::config::Config;
-use api_gateway::key_store::KeyStore;
-use api_gateway::metering::Metering;
+use api_gateway::config::{db, Config};
 use api_gateway::rate_limit::RateLimitStore;
 use api_gateway::upstream::ReqwestUpstream;
 use api_gateway::{build_router, AppState};
@@ -24,6 +22,11 @@ async fn main() -> anyhow::Result<()> {
         .json()
         .init();
 
+    info!("connecting to database and running migrations");
+    let db = db::connect_and_migrate(&config.database_url)
+        .await
+        .context("database setup")?;
+
     let http = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .connect_timeout(std::time::Duration::from_secs(10))
@@ -32,8 +35,7 @@ async fn main() -> anyhow::Result<()> {
 
     let state = Arc::new(AppState {
         config: config.clone(),
-        keys: KeyStore::new(),
-        metering: Metering::new(),
+        db,
         rate_limiter: RateLimitStore::new(),
         upstream: Arc::new(ReqwestUpstream::new(http)),
     });

--- a/backend/crates/api-gateway/src/metering.rs
+++ b/backend/crates/api-gateway/src/metering.rs
@@ -1,134 +1,155 @@
-use std::collections::BTreeMap;
-
-use dashmap::DashMap;
+use sea_orm::*;
 use zksettle_types::gateway::{DailyUsage, UsageRecord};
 
-const PERIOD_SECS: u64 = 30 * 24 * 60 * 60; // 30 days
-const DAY_SECS: u64 = 24 * 60 * 60;
-/// Cap the per-key daily history to bound memory. ~1 year is plenty for a
-/// 30-day rolling chart with headroom for late requests against past windows.
-const MAX_DAILY_BUCKETS: usize = 400;
+use crate::entity::{daily_usage, usage_record};
+use crate::error::GatewayError;
 
-#[derive(Default)]
-pub struct Metering {
-    usage: DashMap<String, UsageRecord>,
-    /// `key_hash` → `day_start_unix` → request count for that day.
-    daily: DashMap<String, BTreeMap<u64, u64>>,
+const PERIOD_SECS: u64 = 30 * 24 * 60 * 60;
+const DAY_SECS: u64 = 24 * 60 * 60;
+const MAX_DAILY_BUCKETS: u64 = 400;
+
+pub async fn increment(
+    db: &DatabaseConnection,
+    key_hash: &str,
+    now: u64,
+) -> Result<(), GatewayError> {
+    let now_i = now as i64;
+    let period = PERIOD_SECS as i64;
+
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"INSERT INTO usage_records (key_hash, request_count, period_start, last_request)
+           VALUES ($1, 1, $2, $2)
+           ON CONFLICT (key_hash) DO UPDATE SET
+             request_count = CASE
+               WHEN $2 - usage_records.period_start >= $3 THEN 1
+               ELSE usage_records.request_count + 1
+             END,
+             period_start = CASE
+               WHEN $2 - usage_records.period_start >= $3 THEN $2
+               ELSE usage_records.period_start
+             END,
+             last_request = $2"#,
+        [key_hash.into(), now_i.into(), period.into()],
+    ))
+    .await?;
+
+    let day = day_start(now) as i64;
+
+    db.execute(Statement::from_sql_and_values(
+        DbBackend::Postgres,
+        r#"INSERT INTO daily_usage (key_hash, day_start, count)
+           VALUES ($1, $2, 1)
+           ON CONFLICT (key_hash, day_start) DO UPDATE SET count = daily_usage.count + 1"#,
+        [key_hash.into(), day.into()],
+    ))
+    .await?;
+
+    prune_old_buckets(db, key_hash, now).await?;
+
+    Ok(())
 }
 
-impl Metering {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn increment(&self, key_hash: &str, now: u64) {
-        self.usage
-            .entry(key_hash.to_owned())
-            .and_modify(|u| {
-                if now - u.period_start >= PERIOD_SECS {
-                    u.request_count = 1;
-                    u.period_start = now;
-                } else {
-                    u.request_count += 1;
-                }
-                u.last_request = now;
-            })
-            .or_insert_with(|| {
-                let mut r = UsageRecord::new(now);
-                r.request_count = 1;
-                r
-            });
-
-        let day = day_start(now);
-        let mut bucket = self.daily.entry(key_hash.to_owned()).or_default();
-        *bucket.entry(day).or_insert(0) += 1;
-        prune_old_buckets(&mut bucket);
-    }
-
-    pub fn get(&self, key_hash: &str, now: u64) -> UsageRecord {
-        match self.usage.get(key_hash) {
-            Some(u) => {
-                let u = u.clone();
-                if now - u.period_start >= PERIOD_SECS {
-                    UsageRecord::new(now)
-                } else {
-                    u
-                }
+pub async fn get(
+    db: &DatabaseConnection,
+    key_hash: &str,
+    now: u64,
+) -> Result<UsageRecord, GatewayError> {
+    let result = usage_record::Entity::find_by_id(key_hash).one(db).await?;
+    match result {
+        Some(rec) => {
+            if now as i64 - rec.period_start >= PERIOD_SECS as i64 {
+                Ok(UsageRecord::new(now))
+            } else {
+                Ok(UsageRecord {
+                    request_count: rec.request_count as u64,
+                    period_start: rec.period_start as u64,
+                    last_request: rec.last_request as u64,
+                })
             }
-            None => UsageRecord::new(now),
         }
+        None => Ok(UsageRecord::new(now)),
     }
+}
 
-    pub fn current_count(&self, key_hash: &str, now: u64) -> u64 {
-        self.get(key_hash, now).request_count
+pub async fn current_count(
+    db: &DatabaseConnection,
+    key_hash: &str,
+    now: u64,
+) -> Result<u64, GatewayError> {
+    Ok(get(db, key_hash, now).await?.request_count)
+}
+
+pub async fn daily_history(
+    db: &DatabaseConnection,
+    key_hash: &str,
+    now: u64,
+    days: u32,
+) -> Result<Vec<DailyUsage>, GatewayError> {
+    if days == 0 {
+        return Ok(Vec::new());
     }
+    let today = day_start(now);
 
-    pub fn remove(&self, key_hash: &str) {
-        self.usage.remove(key_hash);
-        self.daily.remove(key_hash);
+    let cutoff = today.saturating_sub((days as u64 - 1) * DAY_SECS) as i64;
+
+    let rows = daily_usage::Entity::find()
+        .filter(daily_usage::Column::KeyHash.eq(key_hash))
+        .filter(daily_usage::Column::DayStart.gte(cutoff))
+        .all(db)
+        .await?;
+
+    let counts: std::collections::BTreeMap<i64, i64> =
+        rows.into_iter().map(|r| (r.day_start, r.count)).collect();
+
+    let mut out = Vec::with_capacity(days as usize);
+    for offset in (0..days as u64).rev() {
+        let day = today.saturating_sub(offset * DAY_SECS);
+        let count = counts.get(&(day as i64)).copied().unwrap_or(0);
+        out.push(DailyUsage {
+            date: format_day(day),
+            count: count as u64,
+        });
     }
+    Ok(out)
+}
 
-    /// Returns up to `days` daily-usage rows for `key_hash`, ending at today
-    /// (UTC). Always exactly `days` entries, oldest first, zero-filled where
-    /// no requests occurred. `days = 0` returns an empty vec.
-    pub fn daily_history(&self, key_hash: &str, now: u64, days: u32) -> Vec<DailyUsage> {
-        if days == 0 {
-            return Vec::new();
-        }
-        let today = day_start(now);
-        let counts = self
-            .daily
-            .get(key_hash)
-            .map(|b| b.clone())
-            .unwrap_or_default();
+async fn prune_old_buckets(
+    db: &DatabaseConnection,
+    key_hash: &str,
+    now: u64,
+) -> Result<(), GatewayError> {
+    let cutoff = (now.saturating_sub(MAX_DAILY_BUCKETS * DAY_SECS)) as i64;
 
-        let mut out = Vec::with_capacity(days as usize);
-        for offset in (0..days as u64).rev() {
-            let day = today.saturating_sub(offset * DAY_SECS);
-            let count = counts.get(&day).copied().unwrap_or(0);
-            out.push(DailyUsage {
-                date: format_day(day),
-                count,
-            });
-        }
-        out
-    }
+    daily_usage::Entity::delete_many()
+        .filter(daily_usage::Column::KeyHash.eq(key_hash))
+        .filter(daily_usage::Column::DayStart.lt(cutoff))
+        .exec(db)
+        .await?;
+
+    Ok(())
 }
 
 fn day_start(unix_secs: u64) -> u64 {
     (unix_secs / DAY_SECS) * DAY_SECS
 }
 
-fn prune_old_buckets(bucket: &mut BTreeMap<u64, u64>) {
-    while bucket.len() > MAX_DAILY_BUCKETS {
-        if let Some((&oldest, _)) = bucket.iter().next() {
-            bucket.remove(&oldest);
-        } else {
-            break;
-        }
-    }
-}
-
-/// Format a UTC day-start unix timestamp as `YYYY-MM-DD` using a
-/// proleptic-Gregorian conversion. Avoids pulling in `chrono` for one helper.
 fn format_day(day_start_unix: u64) -> String {
     let days_since_epoch = (day_start_unix / DAY_SECS) as i64;
     let (y, m, d) = civil_from_days(days_since_epoch);
     format!("{y:04}-{m:02}-{d:02}")
 }
 
-/// Howard Hinnant's `civil_from_days` (public domain) — converts days since
-/// 1970-01-01 (UTC) to (year, month, day) on the proleptic Gregorian calendar.
 fn civil_from_days(z: i64) -> (i32, u32, u32) {
     let z = z + 719_468;
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = (z - era * 146_097) as u64; // [0, 146097)
-    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399)
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
     let y = yoe as i64 + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365)
-    let mp = (5 * doy + 2) / 153; // [0, 11)
-    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
-    let m = if mp < 10 { mp + 3 } else { mp.wrapping_sub(9) }; // [1, 12]
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp.wrapping_sub(9) };
     let y = if m <= 2 { y + 1 } else { y };
     (y as i32, m as u32, d as u32)
 }
@@ -136,74 +157,107 @@ fn civil_from_days(z: i64) -> (i32, u32, u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::key_store;
+    use crate::{test_cleanup, test_db};
+    use serial_test::serial;
 
-    #[test]
-    fn increment_from_zero() {
-        let m = Metering::new();
-        m.increment("k1", 1000);
-        assert_eq!(m.current_count("k1", 1000), 1);
+    async fn seed_key(db: &DatabaseConnection, raw: &str) -> String {
+        key_store::insert(db, raw, "test-owner".into(), zksettle_types::gateway::Tier::Developer, 0)
+            .await
+            .unwrap();
+        key_store::hash_key(raw)
     }
 
-    #[test]
-    fn increment_accumulates() {
-        let m = Metering::new();
-        m.increment("k1", 1000);
-        m.increment("k1", 1001);
-        m.increment("k1", 1002);
-        assert_eq!(m.current_count("k1", 1002), 3);
+    #[tokio::test]
+    #[serial]
+    async fn increment_from_zero() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-k1").await;
+        increment(&db, &kh, 1000).await.unwrap();
+        assert_eq!(current_count(&db, &kh, 1000).await.unwrap(), 1);
     }
 
-    #[test]
-    fn period_rollover_resets_count() {
-        let m = Metering::new();
-        m.increment("k1", 1000);
-        m.increment("k1", 1001);
+    #[tokio::test]
+    #[serial]
+    async fn increment_accumulates() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-k2").await;
+        increment(&db, &kh, 1000).await.unwrap();
+        increment(&db, &kh, 1001).await.unwrap();
+        increment(&db, &kh, 1002).await.unwrap();
+        assert_eq!(current_count(&db, &kh, 1002).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn period_rollover_resets_count() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-k3").await;
+        increment(&db, &kh, 1000).await.unwrap();
+        increment(&db, &kh, 1001).await.unwrap();
         let after_period = 1000 + PERIOD_SECS + 1;
-        m.increment("k1", after_period);
-        assert_eq!(m.current_count("k1", after_period), 1);
+        increment(&db, &kh, after_period).await.unwrap();
+        assert_eq!(current_count(&db, &kh, after_period).await.unwrap(), 1);
     }
 
-    #[test]
-    fn get_unknown_key_returns_zero() {
-        let m = Metering::new();
-        assert_eq!(m.current_count("unknown", 5000), 0);
+    #[tokio::test]
+    #[serial]
+    async fn get_unknown_key_returns_zero() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        assert_eq!(current_count(&db, "unknown", 5000).await.unwrap(), 0);
     }
 
-    #[test]
-    fn period_boundary_exact() {
-        let m = Metering::new();
-        m.increment("k1", 0);
+    #[tokio::test]
+    #[serial]
+    async fn period_boundary_exact() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-k4").await;
+        increment(&db, &kh, 0).await.unwrap();
         let exactly_at = PERIOD_SECS;
-        m.increment("k1", exactly_at);
-        assert_eq!(m.current_count("k1", exactly_at), 1);
+        increment(&db, &kh, exactly_at).await.unwrap();
+        assert_eq!(current_count(&db, &kh, exactly_at).await.unwrap(), 1);
     }
 
-    #[test]
-    fn period_boundary_one_before() {
-        let m = Metering::new();
-        m.increment("k1", 0);
+    #[tokio::test]
+    #[serial]
+    async fn period_boundary_one_before() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-k5").await;
+        increment(&db, &kh, 0).await.unwrap();
         let just_before = PERIOD_SECS - 1;
-        m.increment("k1", just_before);
-        assert_eq!(m.current_count("k1", just_before), 2);
+        increment(&db, &kh, just_before).await.unwrap();
+        assert_eq!(current_count(&db, &kh, just_before).await.unwrap(), 2);
     }
 
-    #[test]
-    fn get_returns_fresh_record_after_period() {
-        let m = Metering::new();
-        m.increment("k1", 0);
-        m.increment("k1", 1);
+    #[tokio::test]
+    #[serial]
+    async fn get_returns_fresh_record_after_period() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-k6").await;
+        increment(&db, &kh, 0).await.unwrap();
+        increment(&db, &kh, 1).await.unwrap();
         let after = PERIOD_SECS + 100;
-        let rec = m.get("k1", after);
+        let rec = get(&db, &kh, after).await.unwrap();
         assert_eq!(rec.request_count, 0);
         assert_eq!(rec.period_start, after);
     }
 
-    #[test]
-    fn last_request_updated() {
-        let m = Metering::new();
-        m.increment("k1", 100);
-        m.increment("k1", 200);
-        let rec = m.get("k1", 200);
+    #[tokio::test]
+    #[serial]
+    async fn last_request_updated() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-k7").await;
+        increment(&db, &kh, 100).await.unwrap();
+        increment(&db, &kh, 200).await.unwrap();
+        let rec = get(&db, &kh, 200).await.unwrap();
         assert_eq!(rec.last_request, 200);
     }
 
@@ -212,77 +266,74 @@ mod tests {
         assert_eq!(PERIOD_SECS, 30 * 24 * 60 * 60);
     }
 
-    #[test]
-    fn subtraction_not_addition_in_period_check() {
-        let m = Metering::new();
-        let start = PERIOD_SECS / 2;
-        m.increment("k1", start);
-        let now = start + 1;
-        m.increment("k1", now);
-        assert_eq!(m.current_count("k1", now), 2, "should accumulate, not reset");
-    }
-
-    #[test]
-    fn daily_history_empty_for_unknown_key() {
-        let m = Metering::new();
-        let h = m.daily_history("nope", DAY_SECS * 100, 7);
+    #[tokio::test]
+    #[serial]
+    async fn daily_history_empty_for_unknown_key() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let h = daily_history(&db, "nope", DAY_SECS * 100, 7).await.unwrap();
         assert_eq!(h.len(), 7);
         assert!(h.iter().all(|d| d.count == 0));
     }
 
-    #[test]
-    fn daily_history_zero_days_returns_empty() {
-        let m = Metering::new();
-        assert!(m.daily_history("k", 0, 0).is_empty());
+    #[tokio::test]
+    #[serial]
+    async fn daily_history_zero_days_returns_empty() {
+        let db = test_db().await;
+        assert!(daily_history(&db, "k", 0, 0).await.unwrap().is_empty());
     }
 
-    #[test]
-    fn daily_history_groups_same_day() {
-        let m = Metering::new();
-        let now = DAY_SECS * 100 + 42; // arbitrary day, mid-day
-        m.increment("k", now);
-        m.increment("k", now + 10);
-        m.increment("k", now + 999);
-        let h = m.daily_history("k", now, 1);
+    #[tokio::test]
+    #[serial]
+    async fn daily_history_groups_same_day() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-daily1").await;
+        let now = DAY_SECS * 100 + 42;
+        increment(&db, &kh, now).await.unwrap();
+        increment(&db, &kh, now + 10).await.unwrap();
+        increment(&db, &kh, now + 999).await.unwrap();
+        let h = daily_history(&db, &kh, now, 1).await.unwrap();
         assert_eq!(h.len(), 1);
         assert_eq!(h[0].count, 3);
     }
 
-    #[test]
-    fn daily_history_separates_consecutive_days() {
-        let m = Metering::new();
+    #[tokio::test]
+    #[serial]
+    async fn daily_history_separates_consecutive_days() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-daily2").await;
         let day0 = DAY_SECS * 200;
-        m.increment("k", day0);
-        m.increment("k", day0 + DAY_SECS); // next day
-        m.increment("k", day0 + DAY_SECS); // same as above
-        let h = m.daily_history("k", day0 + DAY_SECS, 2);
-        // Oldest first.
+        increment(&db, &kh, day0).await.unwrap();
+        increment(&db, &kh, day0 + DAY_SECS).await.unwrap();
+        increment(&db, &kh, day0 + DAY_SECS).await.unwrap();
+        let h = daily_history(&db, &kh, day0 + DAY_SECS, 2).await.unwrap();
         assert_eq!(h[0].count, 1);
         assert_eq!(h[1].count, 2);
     }
 
-    #[test]
-    fn daily_history_zero_fills_gaps() {
-        let m = Metering::new();
+    #[tokio::test]
+    #[serial]
+    async fn daily_history_zero_fills_gaps() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-daily3").await;
         let day0 = DAY_SECS * 300;
-        m.increment("k", day0);
-        let h = m.daily_history("k", day0 + 3 * DAY_SECS, 5);
+        increment(&db, &kh, day0).await.unwrap();
+        let h = daily_history(&db, &kh, day0 + 3 * DAY_SECS, 5).await.unwrap();
         assert_eq!(h.len(), 5);
-        // day0 - 1, day0, day0+1, day0+2, day0+3 all relative to "now=day0+3"
-        // → "now=day0+3" gets count=0, day0+2 →0, day0+1 →0, day0 →1, day0-1 →0
         let counts: Vec<u64> = h.iter().map(|d| d.count).collect();
         assert_eq!(counts, vec![0, 1, 0, 0, 0]);
     }
 
-    #[test]
-    fn daily_history_dates_are_iso() {
-        let m = Metering::new();
-        // 1970-01-01 00:00:00 UTC = 0
-        let h = m.daily_history("k", 0, 1);
+    #[tokio::test]
+    #[serial]
+    async fn daily_history_dates_are_iso() {
+        let db = test_db().await;
+        let h = daily_history(&db, "k", 0, 1).await.unwrap();
         assert_eq!(h[0].date, "1970-01-01");
-
-        // 2026-04-25 00:00:00 UTC = unix 1_777_075_200
-        let h = m.daily_history("k", 1_777_075_200, 1);
+        let h = daily_history(&db, "k", 1_777_075_200, 1).await.unwrap();
         assert_eq!(h[0].date, "2026-04-25");
     }
 
@@ -293,46 +344,34 @@ mod tests {
         assert_eq!(day_start(DAY_SECS), DAY_SECS);
     }
 
-    #[test]
-    fn pruning_caps_stored_buckets() {
-        let m = Metering::new();
-        // Insert MAX_DAILY_BUCKETS + 5 distinct days.
-        for i in 0..(MAX_DAILY_BUCKETS as u64 + 5) {
-            m.increment("k", i * DAY_SECS);
+    #[tokio::test]
+    #[serial]
+    async fn pruning_caps_stored_buckets() {
+        let db = test_db().await;
+        test_cleanup(&db).await;
+        let kh = seed_key(&db, "meter-prune").await;
+        for i in 0..(MAX_DAILY_BUCKETS + 5) {
+            increment(&db, &kh, i * DAY_SECS).await.unwrap();
         }
-        let stored = m.daily.get("k").unwrap().len();
+        let stored = daily_usage::Entity::find()
+            .filter(daily_usage::Column::KeyHash.eq(kh.as_str()))
+            .count(&db)
+            .await
+            .unwrap();
         assert_eq!(stored, MAX_DAILY_BUCKETS);
     }
 
     #[test]
     fn civil_from_days_known_dates() {
-        // Days since 1970-01-01.
         assert_eq!(civil_from_days(0), (1970, 1, 1));
         assert_eq!(civil_from_days(31), (1970, 2, 1));
         assert_eq!(civil_from_days(365), (1971, 1, 1));
         assert_eq!(civil_from_days(20_454), (2026, 1, 1));
         assert_eq!(civil_from_days(20_568), (2026, 4, 25));
-
-        // Century boundaries — exercise doe/36524 and doe/146096 corrections (line 126).
-        assert_eq!(civil_from_days(47_541), (2100, 3, 1)); // doe/36524=1
-        assert_eq!(civil_from_days(-25_508), (1900, 3, 1)); // doe/36524=2
-        assert_eq!(civil_from_days(11_016), (2000, 2, 29)); // doe/146096=1 (400-yr leap)
-
-        // Negative era — exercise else branch on line 124.
+        assert_eq!(civil_from_days(47_541), (2100, 3, 1));
+        assert_eq!(civil_from_days(-25_508), (1900, 3, 1));
+        assert_eq!(civil_from_days(11_016), (2000, 2, 29));
         assert_eq!(civil_from_days(-719_468), (0, 3, 1));
         assert_eq!(civil_from_days(-719_469), (0, 2, 29));
-    }
-
-    #[test]
-    fn remove_clears_usage_and_daily() {
-        let m = Metering::new();
-        m.increment("k", 1000);
-        m.increment("k", 1001);
-        assert_eq!(m.current_count("k", 1001), 2);
-        assert!(m.daily.get("k").is_some());
-
-        m.remove("k");
-        assert_eq!(m.current_count("k", 1001), 0);
-        assert!(m.daily.get("k").is_none());
     }
 }

--- a/backend/crates/api-gateway/src/proxy.rs
+++ b/backend/crates/api-gateway/src/proxy.rs
@@ -8,6 +8,7 @@ use axum::response::{IntoResponse, Response};
 
 use crate::auth::AuthenticatedKey;
 use crate::error::GatewayError;
+use crate::metering;
 use crate::upstream::UpstreamRequest;
 use crate::AppState;
 
@@ -28,8 +29,6 @@ fn is_hop_by_hop(name: &str) -> bool {
     HOP_BY_HOP.iter().any(|h| h.eq_ignore_ascii_case(name))
 }
 
-/// Route `/events` and `/events/{id}` to `GATEWAY_INDEXER_URL` when configured.
-/// Everything else goes to `GATEWAY_UPSTREAM_URL` (issuer-service).
 fn pick_upstream<'a>(path_after_v1: &str, config: &'a crate::config::Config) -> &'a str {
     if path_after_v1 == "/events"
         || path_after_v1.starts_with("/events/")
@@ -63,7 +62,7 @@ pub async fn proxy_to_upstream(
         .unwrap()
         .as_secs();
 
-    let current = state.metering.current_count(&record.key_hash, now);
+    let current = metering::current_count(&state.db, &record.key_hash, now).await?;
     if current >= record.tier.monthly_limit() {
         return Err(GatewayError::QuotaExhausted);
     }
@@ -98,7 +97,7 @@ pub async fn proxy_to_upstream(
     let upstream_resp = state.upstream.send(upstream_req).await?;
 
     if upstream_resp.status.is_success() || upstream_resp.status.is_redirection() {
-        state.metering.increment(&record.key_hash, now);
+        metering::increment(&state.db, &record.key_hash, now).await?;
     }
 
     let status = upstream_resp.status;
@@ -110,50 +109,32 @@ pub async fn proxy_to_upstream(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn hop_by_hop_matches_all_entries() {
-        for &h in HOP_BY_HOP {
-            assert!(is_hop_by_hop(h), "{h} should be hop-by-hop");
-        }
-    }
-
-    #[test]
-    fn hop_by_hop_case_insensitive() {
-        assert!(is_hop_by_hop("Connection"));
-        assert!(is_hop_by_hop("TRANSFER-ENCODING"));
-        assert!(is_hop_by_hop("Keep-Alive"));
-    }
-
-    #[test]
-    fn not_hop_by_hop() {
-        assert!(!is_hop_by_hop("content-type"));
-        assert!(!is_hop_by_hop("accept"));
-        assert!(!is_hop_by_hop("x-custom-header"));
-    }
-
-    use axum::body::Body;
-    use axum::http::{Method, StatusCode};
-    use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    use axum::http::{Method, StatusCode};
     use zksettle_types::gateway::{ApiKeyRecord, Tier};
 
     use crate::config::Config;
-    use crate::key_store::{hash_key, KeyStore};
-    use crate::metering::Metering;
+    use crate::key_store;
     use crate::rate_limit::RateLimitStore;
     use crate::upstream::{MockHttpUpstream, UpstreamResponse};
+    use serial_test::serial;
 
-    fn record() -> ApiKeyRecord {
+    fn record(tier: Tier) -> ApiKeyRecord {
         ApiKeyRecord {
-            key_hash: hash_key("zks_test"),
-            tier: Tier::Developer,
+            key_hash: key_store::hash_key("zks_test"),
+            tier,
             owner: "alice".into(),
             created_at: 0,
         }
     }
 
-    fn state(mock: Arc<MockHttpUpstream>) -> Arc<AppState> {
+    async fn state_with_mock(mock: Arc<MockHttpUpstream>) -> Arc<AppState> {
+        let db = crate::test_db().await;
+        crate::test_cleanup(&db).await;
+        key_store::insert(&db, "zks_test", "alice".into(), Tier::Developer, 0)
+            .await
+            .unwrap();
         Arc::new(AppState {
             config: Config {
                 port: 4000,
@@ -163,9 +144,9 @@ mod tests {
                 allow_open_keys: true,
                 cors_allowed_origins: vec![],
                 indexer_url: None,
+                database_url: String::new(),
             },
-            keys: KeyStore::new(),
-            metering: Metering::new(),
+            db,
             rate_limiter: RateLimitStore::new(),
             upstream: mock,
         })
@@ -188,8 +169,9 @@ mod tests {
             .as_secs()
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn happy_path_forwards_request_and_increments_metering() {
+    #[tokio::test]
+    #[serial]
+    async fn happy_path_forwards_and_increments_metering() {
         let mock = Arc::new(MockHttpUpstream::new());
         let mut headers = HeaderMap::new();
         headers.insert("x-upstream", "value".parse().unwrap());
@@ -198,8 +180,8 @@ mod tests {
             headers,
             body: axum::body::Bytes::from_static(b"hello"),
         });
-        let state = state(mock.clone());
-        let rec = record();
+        let state = state_with_mock(mock.clone()).await;
+        let rec = record(Tier::Developer);
 
         let resp = proxy_to_upstream(
             State(state.clone()),
@@ -210,32 +192,31 @@ mod tests {
         .unwrap();
 
         assert_eq!(resp.status(), StatusCode::OK);
-        // handler uses SystemTime::now() internally; query with the same clock
-        assert_eq!(state.metering.current_count(&rec.key_hash, now_secs()), 1);
+        assert_eq!(
+            metering::current_count(&state.db, &rec.key_hash, now_secs())
+                .await
+                .unwrap(),
+            1
+        );
 
         let sent = mock.last_sent().expect("mock recorded send");
         assert_eq!(sent.method, Method::GET);
         assert_eq!(sent.url, "http://upstream.example/issuers/foo?x=1");
-        assert!(
-            sent.headers.contains_key("x-keep"),
-            "non-hop-by-hop headers must reach upstream"
-        );
-        assert!(
-            !sent.headers.contains_key("connection"),
-            "hop-by-hop headers must be stripped"
-        );
+        assert!(sent.headers.contains_key("x-keep"));
+        assert!(!sent.headers.contains_key("connection"));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn upstream_5xx_is_propagated_and_metering_does_not_increment() {
+    #[tokio::test]
+    #[serial]
+    async fn upstream_5xx_does_not_increment_metering() {
         let mock = Arc::new(MockHttpUpstream::new());
         mock.queue_response(UpstreamResponse {
             status: StatusCode::BAD_GATEWAY,
             headers: HeaderMap::new(),
             body: axum::body::Bytes::new(),
         });
-        let state = state(mock.clone());
-        let rec = record();
+        let state = state_with_mock(mock.clone()).await;
+        let rec = record(Tier::Developer);
 
         let resp = proxy_to_upstream(
             State(state.clone()),
@@ -247,51 +228,59 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
         assert_eq!(
-            state.metering.current_count(&rec.key_hash, now_secs()),
-            0,
-            "non-success upstream response must not consume quota"
+            metering::current_count(&state.db, &rec.key_hash, now_secs())
+                .await
+                .unwrap(),
+            0
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn quota_exhausted_short_circuits_before_upstream_call() {
+    #[tokio::test]
+    #[serial]
+    async fn quota_exhausted_returns_error() {
         let mock = Arc::new(MockHttpUpstream::new());
-        let state = state(mock.clone());
-        let rec = record();
-        // pre-fill the metering counter with the same wall clock the handler
-        // will read so the period-rollover branch doesn't reset us to zero
+        let state = state_with_mock(mock.clone()).await;
+        let rec = record(Tier::Developer);
         let now = now_secs();
-        for _ in 0..rec.tier.monthly_limit() {
-            state.metering.increment(&rec.key_hash, now);
+
+        for _ in 0..Tier::Developer.monthly_limit() {
+            metering::increment(&state.db, &rec.key_hash, now)
+                .await
+                .unwrap();
         }
 
-        let err = proxy_to_upstream(State(state.clone()), AuthenticatedKey(rec), build_request())
-            .await
-            .unwrap_err();
-
-        assert!(matches!(err, GatewayError::QuotaExhausted));
-        assert_eq!(
-            mock.sent_count(),
-            0,
-            "must not call upstream after quota check"
-        );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn upstream_transport_error_propagates_as_upstream_variant() {
-        let mock = Arc::new(MockHttpUpstream::new());
-        mock.queue_error(GatewayError::Upstream("network down".into()));
-        let state = state(mock.clone());
-
+        mock.queue_ok();
         let err = proxy_to_upstream(
             State(state.clone()),
-            AuthenticatedKey(record()),
+            AuthenticatedKey(rec),
             build_request(),
         )
         .await
         .unwrap_err();
 
-        assert!(matches!(err, GatewayError::Upstream(_)));
+        assert!(matches!(err, GatewayError::QuotaExhausted));
+        assert_eq!(mock.sent_count(), 0);
+    }
+
+    #[test]
+    fn hop_by_hop_matches_all_entries() {
+        for &h in HOP_BY_HOP {
+            assert!(is_hop_by_hop(h), "{h} should be hop-by-hop");
+        }
+    }
+
+    #[test]
+    fn hop_by_hop_case_insensitive() {
+        assert!(is_hop_by_hop("Connection"));
+        assert!(is_hop_by_hop("TRANSFER-ENCODING"));
+        assert!(is_hop_by_hop("Keep-Alive"));
+    }
+
+    #[test]
+    fn not_hop_by_hop() {
+        assert!(!is_hop_by_hop("content-type"));
+        assert!(!is_hop_by_hop("accept"));
+        assert!(!is_hop_by_hop("x-custom-header"));
     }
 
     #[test]
@@ -320,6 +309,7 @@ mod tests {
             admin_key: None,
             allow_open_keys: true,
             cors_allowed_origins: vec![],
+            database_url: String::new(),
         }
     }
 

--- a/backend/crates/api-gateway/src/routes/keys.rs
+++ b/backend/crates/api-gateway/src/routes/keys.rs
@@ -10,7 +10,7 @@ use zksettle_types::gateway::Tier;
 
 use crate::config::Config;
 use crate::error::GatewayError;
-use crate::key_store::generate_key;
+use crate::key_store;
 use crate::AppState;
 
 #[derive(Deserialize)]
@@ -51,10 +51,6 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
     a_hash.ct_eq(&b_hash).into()
 }
 
-/// Admin-auth gate shared by `POST /api-keys`, `GET /api-keys`, and `DELETE /api-keys/{hash}`.
-/// - `admin_key` set → require matching `Authorization: Bearer <admin_key>`.
-/// - `allow_open_keys` true → accept anonymous calls.
-/// - Otherwise → 500 Config (admin operations are disabled by deployment).
 fn verify_admin(config: &Config, headers: &HeaderMap) -> Result<(), GatewayError> {
     if let Some(ref admin_key) = config.admin_key {
         let provided = headers
@@ -84,15 +80,13 @@ pub async fn create_key(
 ) -> Result<Json<CreateKeyResponse>, GatewayError> {
     verify_admin(&state.config, &headers)?;
 
-    let raw_key = generate_key();
+    let raw_key = key_store::generate_key();
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
 
-    state
-        .keys
-        .insert(&raw_key, body.owner.clone(), Tier::Developer, now);
+    key_store::insert(&state.db, &raw_key, body.owner.clone(), Tier::Developer, now).await?;
 
     Ok(Json(CreateKeyResponse {
         api_key: raw_key,
@@ -107,9 +101,8 @@ pub async fn list_keys(
 ) -> Result<Json<ListKeysResponse>, GatewayError> {
     verify_admin(&state.config, &headers)?;
 
-    let mut keys: Vec<ListedKey> = state
-        .keys
-        .list()
+    let mut keys: Vec<ListedKey> = key_store::list(&state.db)
+        .await?
         .into_iter()
         .map(|r| ListedKey {
             key_hash: r.key_hash,
@@ -130,11 +123,11 @@ pub async fn delete_key(
 ) -> Result<Json<DeleteKeyResponse>, GatewayError> {
     verify_admin(&state.config, &headers)?;
 
-    let removed = state.keys.remove_by_hash(&key_hash);
+    let removed = key_store::remove_by_hash(&state.db, &key_hash).await?;
     if !removed {
         return Err(GatewayError::NotFound);
     }
-    state.metering.remove(&key_hash);
+    // CASCADE handles usage_records + daily_usage cleanup
     Ok(Json(DeleteKeyResponse {
         key_hash,
         deleted: true,
@@ -150,14 +143,14 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::config::Config;
-    use crate::key_store::{hash_key, KeyStore};
-    use crate::metering::Metering;
     use crate::rate_limit::RateLimitStore;
-    use crate::{build_router, test_app, AppState};
+    use crate::{build_router, test_app, test_cleanup, test_db, AppState};
+    use serial_test::serial;
 
     #[tokio::test]
+    #[serial]
     async fn create_key_no_admin_key_configured_allows_open() {
-        let app = test_app();
+        let app = test_app().await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -178,7 +171,9 @@ mod tests {
         assert_eq!(body.owner, "alice");
     }
 
-    fn app_with_admin_key() -> (axum::Router, Arc<AppState>) {
+    async fn app_with_admin_key() -> (axum::Router, Arc<AppState>) {
+        let db = test_db().await;
+        test_cleanup(&db).await;
         let config = Config {
             port: 4000,
             upstream_url: "http://localhost:0".into(),
@@ -187,18 +182,20 @@ mod tests {
             allow_open_keys: false,
             cors_allowed_origins: vec![],
             indexer_url: None,
+            database_url: String::new(),
         };
         let state = Arc::new(AppState {
             config,
-            keys: KeyStore::new(),
-            metering: Metering::new(),
+            db,
             rate_limiter: RateLimitStore::new(),
             upstream: Arc::new(crate::upstream::ReqwestUpstream::new(reqwest::Client::new())),
         });
         (build_router(state.clone()), state)
     }
 
-    fn app_with_provisioning_disabled() -> axum::Router {
+    async fn app_with_provisioning_disabled() -> axum::Router {
+        let db = test_db().await;
+        test_cleanup(&db).await;
         let config = Config {
             port: 4000,
             upstream_url: "http://localhost:0".into(),
@@ -207,11 +204,11 @@ mod tests {
             allow_open_keys: false,
             cors_allowed_origins: vec![],
             indexer_url: None,
+            database_url: String::new(),
         };
         let state = Arc::new(AppState {
             config,
-            keys: KeyStore::new(),
-            metering: Metering::new(),
+            db,
             rate_limiter: RateLimitStore::new(),
             upstream: Arc::new(crate::upstream::ReqwestUpstream::new(reqwest::Client::new())),
         });
@@ -219,8 +216,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn create_key_rejects_without_admin_auth() {
-        let (app, _) = app_with_admin_key();
+        let (app, _) = app_with_admin_key().await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -237,8 +235,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn create_key_rejects_wrong_admin_key() {
-        let (app, _) = app_with_admin_key();
+        let (app, _) = app_with_admin_key().await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -256,8 +255,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn create_key_accepts_correct_admin_key() {
-        let (app, _) = app_with_admin_key();
+        let (app, _) = app_with_admin_key().await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -278,8 +278,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn list_keys_requires_admin_auth() {
-        let (app, _) = app_with_admin_key();
+        let (app, _) = app_with_admin_key().await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -293,14 +294,15 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn list_keys_returns_provisioned_records() {
-        let (app, state) = app_with_admin_key();
-        state
-            .keys
-            .insert("zks_a", "alice".into(), Tier::Developer, 100);
-        state
-            .keys
-            .insert("zks_b", "bob".into(), Tier::Startup, 200);
+        let (app, state) = app_with_admin_key().await;
+        key_store::insert(&state.db, "zks_a", "alice".into(), Tier::Developer, 100)
+            .await
+            .unwrap();
+        key_store::insert(&state.db, "zks_b", "bob".into(), Tier::Startup, 200)
+            .await
+            .unwrap();
 
         let resp = app
             .oneshot(
@@ -316,14 +318,14 @@ mod tests {
         let bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let body: ListKeysResponse = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(body.keys.len(), 2);
-        // Sorted by created_at desc → bob first.
         assert_eq!(body.keys[0].owner, "bob");
         assert_eq!(body.keys[1].owner, "alice");
     }
 
     #[tokio::test]
+    #[serial]
     async fn list_keys_open_when_provisioning_open() {
-        let app = test_app(); // admin_key=None, allow_open_keys=true
+        let app = test_app().await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -337,8 +339,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn list_keys_500_when_provisioning_disabled() {
-        let app = app_with_provisioning_disabled();
+        let app = app_with_provisioning_disabled().await;
         let resp = app
             .oneshot(
                 Request::builder()
@@ -352,9 +355,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn delete_key_requires_admin_auth() {
-        let (app, _) = app_with_admin_key();
-        let hash = hash_key("zks_x");
+        let (app, _) = app_with_admin_key().await;
+        let hash = key_store::hash_key("zks_x");
         let resp = app
             .oneshot(
                 Request::builder()
@@ -369,8 +373,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn delete_key_404_for_unknown_hash() {
-        let (app, _) = app_with_admin_key();
+        let (app, _) = app_with_admin_key().await;
         let unknown = "0".repeat(64);
         let resp = app
             .oneshot(
@@ -387,15 +392,15 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn delete_key_evicts_and_invalidates_subsequent_auth() {
-        let (app, state) = app_with_admin_key();
+        let (app, state) = app_with_admin_key().await;
         let raw = "zks_to_delete";
-        state
-            .keys
-            .insert(raw, "carol".into(), Tier::Developer, 300);
-        let hash = hash_key(raw);
+        key_store::insert(&state.db, raw, "carol".into(), Tier::Developer, 300)
+            .await
+            .unwrap();
+        let hash = key_store::hash_key(raw);
 
-        // Confirm the key works for /usage initially.
         let resp = app
             .clone()
             .oneshot(
@@ -409,7 +414,6 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), 200);
 
-        // Delete it.
         let resp = app
             .clone()
             .oneshot(
@@ -428,7 +432,6 @@ mod tests {
         assert_eq!(body.key_hash, hash);
         assert!(body.deleted);
 
-        // Now /usage with that key is 401.
         let resp = app
             .oneshot(
                 Request::builder()

--- a/backend/crates/api-gateway/src/routes/usage.rs
+++ b/backend/crates/api-gateway/src/routes/usage.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use zksettle_types::gateway::{DailyUsage, Tier, UsageRecord};
 
 use crate::auth::AuthenticatedKey;
+use crate::error::GatewayError;
+use crate::metering;
 use crate::AppState;
 
 const DEFAULT_HISTORY_DAYS: u32 = 30;
@@ -34,25 +36,25 @@ pub struct UsageHistoryResponse {
 pub async fn get_usage(
     State(state): State<Arc<AppState>>,
     AuthenticatedKey(record): AuthenticatedKey,
-) -> Json<UsageResponse> {
+) -> Result<Json<UsageResponse>, GatewayError> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    let usage = state.metering.get(&record.key_hash, now);
+    let usage = metering::get(&state.db, &record.key_hash, now).await?;
 
-    Json(UsageResponse {
+    Ok(Json(UsageResponse {
         tier: record.tier,
         monthly_limit: record.tier.monthly_limit(),
         usage,
-    })
+    }))
 }
 
 pub async fn get_usage_history(
     State(state): State<Arc<AppState>>,
     AuthenticatedKey(record): AuthenticatedKey,
     Query(q): Query<HistoryQuery>,
-) -> Json<UsageHistoryResponse> {
+) -> Result<Json<UsageHistoryResponse>, GatewayError> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -61,13 +63,13 @@ pub async fn get_usage_history(
         .days
         .unwrap_or(DEFAULT_HISTORY_DAYS)
         .clamp(1, MAX_HISTORY_DAYS);
-    let history = state.metering.daily_history(&record.key_hash, now, days);
+    let history = metering::daily_history(&state.db, &record.key_hash, now, days).await?;
 
-    Json(UsageHistoryResponse {
+    Ok(Json(UsageHistoryResponse {
         tier: record.tier,
         monthly_limit: record.tier.monthly_limit(),
         history,
-    })
+    }))
 }
 
 #[cfg(test)]
@@ -78,11 +80,20 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    use crate::{build_router, test_state};
+    use crate::{build_router, key_store, test_cleanup, test_state};
+    use serial_test::serial;
+
+    async fn cleanup_and_seed(state: &Arc<crate::AppState>, raw_key: &str, owner: &str) {
+        test_cleanup(&state.db).await;
+        key_store::insert(&state.db, raw_key, owner.into(), Tier::Developer, 1000)
+            .await
+            .unwrap();
+    }
 
     #[tokio::test]
+    #[serial]
     async fn usage_requires_auth() {
-        let state = test_state();
+        let state = test_state().await;
         let app = build_router(state);
         let resp = app
             .oneshot(
@@ -97,14 +108,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn usage_returns_zero_for_new_key() {
-        let state = test_state();
-
-        // Insert key directly via state
+        let state = test_state().await;
         let raw_key = "test-key-for-usage";
-        state
-            .keys
-            .insert(raw_key, "bob".into(), Tier::Developer, 1000);
+        cleanup_and_seed(&state, raw_key, "bob").await;
 
         let app = build_router(state);
         let resp = app
@@ -126,8 +134,9 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn usage_history_requires_auth() {
-        let state = test_state();
+        let state = test_state().await;
         let app = build_router(state);
         let resp = app
             .oneshot(
@@ -142,12 +151,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn usage_history_defaults_to_30_days() {
-        let state = test_state();
+        let state = test_state().await;
         let raw_key = "key-history";
-        state
-            .keys
-            .insert(raw_key, "carol".into(), Tier::Developer, 1000);
+        cleanup_and_seed(&state, raw_key, "carol").await;
 
         let app = build_router(state);
         let resp = app
@@ -171,12 +179,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn usage_history_respects_days_param() {
-        let state = test_state();
+        let state = test_state().await;
         let raw_key = "key-history-7";
-        state
-            .keys
-            .insert(raw_key, "dave".into(), Tier::Developer, 1000);
+        cleanup_and_seed(&state, raw_key, "dave").await;
 
         let app = build_router(state);
         let resp = app
@@ -197,12 +204,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn usage_history_clamps_max_days() {
-        let state = test_state();
+        let state = test_state().await;
         let raw_key = "key-history-cap";
-        state
-            .keys
-            .insert(raw_key, "eve".into(), Tier::Developer, 1000);
+        cleanup_and_seed(&state, raw_key, "eve").await;
 
         let app = build_router(state);
         let resp = app
@@ -222,12 +228,11 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn usage_history_clamps_zero_to_one_day() {
-        let state = test_state();
+        let state = test_state().await;
         let raw_key = "key-history-zero";
-        state
-            .keys
-            .insert(raw_key, "frank".into(), Tier::Developer, 1000);
+        cleanup_and_seed(&state, raw_key, "frank").await;
 
         let app = build_router(state);
         let resp = app

--- a/backend/crates/zksettle-types/src/gateway.rs
+++ b/backend/crates/zksettle-types/src/gateway.rs
@@ -42,6 +42,20 @@ impl std::fmt::Display for Tier {
     }
 }
 
+impl std::str::FromStr for Tier {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "developer" => Ok(Self::Developer),
+            "startup" => Ok(Self::Startup),
+            "growth" => Ok(Self::Growth),
+            "enterprise" => Ok(Self::Enterprise),
+            other => Err(format!("unknown tier: {other}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ApiKeyRecord {
@@ -110,6 +124,28 @@ mod tests {
         assert_eq!(Tier::Startup.to_string(), "startup");
         assert_eq!(Tier::Growth.to_string(), "growth");
         assert_eq!(Tier::Enterprise.to_string(), "enterprise");
+    }
+
+    #[test]
+    fn tier_from_str_valid() {
+        assert_eq!("developer".parse::<Tier>().unwrap(), Tier::Developer);
+        assert_eq!("startup".parse::<Tier>().unwrap(), Tier::Startup);
+        assert_eq!("growth".parse::<Tier>().unwrap(), Tier::Growth);
+        assert_eq!("enterprise".parse::<Tier>().unwrap(), Tier::Enterprise);
+    }
+
+    #[test]
+    fn tier_from_str_roundtrips_with_display() {
+        for tier in [Tier::Developer, Tier::Startup, Tier::Growth, Tier::Enterprise] {
+            assert_eq!(tier.to_string().parse::<Tier>().unwrap(), tier);
+        }
+    }
+
+    #[test]
+    fn tier_from_str_rejects_unknown() {
+        assert!("unknown".parse::<Tier>().is_err());
+        assert!("DEVELOPER".parse::<Tier>().is_err());
+        assert!("".parse::<Tier>().is_err());
     }
 
     #[test]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: zksettle
+      POSTGRES_PASSWORD: zksettle_dev
+      POSTGRES_DB: zksettle_gateway
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U zksettle"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  api-gateway:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: api-gateway
+    ports:
+      - "4000:4000"
+    environment:
+      GATEWAY_PORT: "4000"
+      GATEWAY_UPSTREAM_URL: "http://issuer-service:3000"
+      GATEWAY_INDEXER_URL: "http://indexer:3001"
+      GATEWAY_DATABASE_URL: "postgres://zksettle:zksettle_dev@postgres:5432/zksettle_gateway"
+      GATEWAY_ALLOW_OPEN_KEYS: "true"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  issuer-service:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: issuer-service
+    ports:
+      - "3000:3000"
+
+  indexer:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      target: indexer
+    ports:
+      - "3001:3001"
+    volumes:
+      - indexer_data:/data
+
+volumes:
+  pgdata:
+  indexer_data:


### PR DESCRIPTION
Migrate KeyStore and Metering from DashMap-based in-memory storage to PostgreSQL, giving the api-gateway durable state that survives restarts.

- Add SeaORM entities for api_keys, usage_records, and daily_usage tables
- Add sea-orm-migration crate with schema, foreign keys (CASCADE), and indexes
- Rewrite key_store and metering as free-fn modules backed by DB queries
- Use atomic ON CONFLICT DO UPDATE (UPSERT) in metering::increment to prevent race conditions under concurrent requests
- Add date-range filter to daily_history query and efficient time-based pruning
- Implement Tier::FromStr with error on unknown values (replaces silent default)
- Restore proxy integration tests (happy path, 5xx, quota) against DB state
- Centralize test_db() and test_cleanup() in lib.rs, use serial_test for isolation
- Split config.rs into config/ module with db.rs for connection + migration logic
- Add Dockerfile (multi-stage), docker-compose.yml, and .env.example