### PR TITLE
fix(landing): fix mobile layout — visible hero, engine, market cards,…

### DIFF
--- a/frontend/src/components/landing/acts/act-three-engine.tsx
+++ b/frontend/src/components/landing/acts/act-three-engine.tsx
@@ -172,7 +172,7 @@ export function ActThreeEngine() {
       <div
         ref={curtainRef}
         aria-hidden
-        className="pointer-events-none absolute inset-0 z-20 bg-canvas"
+        className="pointer-events-none absolute inset-0 z-20 bg-canvas opacity-0 md:opacity-100"
       />
 
       <div className="relative mx-auto flex min-h-screen max-w-6xl flex-col justify-center gap-8 px-6 py-16 md:px-8 lg:gap-7 lg:py-12">

--- a/frontend/src/components/landing/acts/act-two-paradox.tsx
+++ b/frontend/src/components/landing/acts/act-two-paradox.tsx
@@ -194,7 +194,7 @@ export function ActTwoParadox() {
       </div>
 
       {/* ── Mobile: simple stacked layout ── */}
-      <div className="flex flex-col items-center gap-20 bg-canvas px-6 py-28 text-center md:hidden">
+      <div className="flex flex-col items-center gap-10 bg-canvas px-6 py-16 text-center md:hidden">
         <h2 className="font-display text-[2rem] font-normal leading-tight tracking-tight text-ink">
           $9 trillion moves in the open.
         </h2>

--- a/frontend/src/components/landing/acts/market-cell.tsx
+++ b/frontend/src/components/landing/acts/market-cell.tsx
@@ -83,13 +83,13 @@ export function MarketCell({
             Inner div has overflow-hidden so content clips during animation.
           */}
           <div
-            className="mt-2 grid grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:grid-rows-[1fr] group-hover:opacity-100"
+            className="mt-2 grid grid-rows-[1fr] opacity-100 transition-[grid-template-rows,opacity] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] md:grid-rows-[0fr] md:opacity-0 md:group-hover:grid-rows-[1fr] md:group-hover:opacity-100"
             style={{ transitionDelay: "110ms" }}
           >
-            <div className="translate-y-1 overflow-hidden transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:translate-y-0">
+            <div className="translate-y-0 overflow-hidden transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] md:translate-y-1 md:group-hover:translate-y-0">
               <div
                 aria-hidden
-                className="mb-2 h-px w-full origin-left scale-x-75 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:scale-x-100"
+                className="mb-2 h-px w-full origin-left scale-x-100 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] md:scale-x-75 md:group-hover:scale-x-100"
                 style={{
                   backgroundImage:
                     "repeating-linear-gradient(to right, color-mix(in srgb, var(--color-forest) 36%, transparent) 0 4px, transparent 4px 8px)",

--- a/frontend/src/components/landing/hero/hero-copy.tsx
+++ b/frontend/src/components/landing/hero/hero-copy.tsx
@@ -156,9 +156,9 @@ export function HeroCopy() {
       id="hero"
       aria-labelledby="hero-heading"
       ref={heroRef}
-      className="relative isolate"
+      className="relative isolate bg-ink md:bg-transparent"
     >
-      <div className="relative mx-auto flex min-h-[calc(100vh-56px)] w-full max-w-7xl flex-col items-center justify-center px-5 py-24 md:px-8">
+      <div className="relative mx-auto flex min-h-[calc(100dvh-56px)] w-full max-w-7xl flex-col items-center justify-center px-5 py-24 md:px-8">
         <p
           data-hero-eyebrow
           className="mb-8 font-mono text-xs leading-none uppercase tracking-[0.18em] text-white/60 md:mb-10"

--- a/frontend/src/components/landing/hero/hero-copy.tsx
+++ b/frontend/src/components/landing/hero/hero-copy.tsx
@@ -3,7 +3,7 @@
 import { useGSAP } from "@gsap/react";
 import { gsap } from "gsap";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { buttonVariants } from "@/components/ui/button";
 import { COPY } from "@/content/copy";
@@ -104,12 +104,17 @@ export function HeroCopy() {
 
   const { overrides, scrambleWord } = useWordScramble(headline);
 
+  const canHover = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia("(hover: hover)").matches;
+  }, []);
+
   const onWordHover = useCallback(
     (word: { start: number; end: number }) => {
-      if (!cipher.done || reduceMotion) return;
+      if (!canHover || !cipher.done || reduceMotion) return;
       scrambleWord(word.start, word.end);
     },
-    [cipher.done, reduceMotion, scrambleWord],
+    [canHover, cipher.done, reduceMotion, scrambleWord],
   );
 
   useGSAP(
@@ -193,7 +198,7 @@ export function HeroCopy() {
                   <span
                     key={i}
                     className={cn(
-                      "inline-block transition-all duration-300",
+                      "inline-block transition-[color,filter,opacity] duration-300",
                       !isDecoded && !isHoverScrambled && "font-mono text-white/40",
                       !isDecoded && isHoverScrambled && "text-white/40",
                       isDecoded && isLastWord && !cipher.done && "text-cyan-300",

--- a/frontend/src/components/landing/mobile-nav-drawer.tsx
+++ b/frontend/src/components/landing/mobile-nav-drawer.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Link from "next/link";
+import { Menu, Xmark } from "iconoir-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+const LINKS: ReadonlyArray<{ label: string; href: string }> = [
+  { label: "Demo", href: "#demo" },
+  { label: "SDK", href: "#developers" },
+  { label: "GitHub", href: "https://github.com/zksettle" },
+];
+
+export function MobileNavDrawer({ scrolled }: { scrolled: boolean }) {
+  const [open, setOpen] = useState(false);
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const mainRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const main = document.querySelector("main");
+    if (main) {
+      main.setAttribute("inert", "");
+      mainRef.current = main;
+    }
+    return () => {
+      if (mainRef.current) {
+        mainRef.current.removeAttribute("inert");
+        mainRef.current = null;
+      }
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+        return;
+      }
+      if (event.key === "Tab") {
+        const drawer = drawerRef.current;
+        if (!drawer) return;
+        const focusable = drawer.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled])',
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0]!;
+        const last = focusable[focusable.length - 1]!;
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const first = drawerRef.current?.querySelector<HTMLElement>(
+      'a[href], button:not([disabled])',
+    );
+    first?.focus();
+  }, [open]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-expanded={open}
+        aria-controls="landing-mobile-nav"
+        aria-label="Open navigation"
+        className={cn(
+          "inline-flex size-9 items-center justify-center rounded-[2px] transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest md:hidden",
+          scrolled
+            ? "text-quill hover:text-ink"
+            : "text-white/70 hover:text-white",
+        )}
+      >
+        <Menu className="size-5" aria-hidden="true" strokeWidth={1.5} />
+      </button>
+
+      {open ? (
+        <div
+          id="landing-mobile-nav"
+          ref={drawerRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Site navigation"
+          className="fixed inset-0 z-[60] flex flex-col bg-ink md:hidden"
+        >
+          <div className="flex items-center justify-end px-5 pt-4">
+            <button
+              type="button"
+              onClick={close}
+              aria-label="Close navigation"
+              className="inline-flex size-9 items-center justify-center rounded-[2px] text-white/60 hover:text-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+            >
+              <Xmark className="size-5" aria-hidden="true" strokeWidth={1.5} />
+            </button>
+          </div>
+
+          <nav className="flex flex-1 flex-col items-center justify-center gap-8">
+            {LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={close}
+                className="font-display text-2xl text-white/80 transition-colors hover:text-white focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-forest"
+              >
+                {link.label}
+              </Link>
+            ))}
+            <Link
+              href="#demo"
+              onClick={close}
+              className={cn(
+                buttonVariants({ variant: "primary", size: "lg" }),
+                "mt-4",
+              )}
+            >
+              Try demo
+            </Link>
+          </nav>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/landing/nav.tsx
+++ b/frontend/src/components/landing/nav.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 
 import { Logo } from "@/components/icons/logo";
 import { buttonVariants } from "@/components/ui/button";
+import { MobileNavDrawer } from "@/components/landing/mobile-nav-drawer";
 import { cn } from "@/lib/cn";
 
 const LINKS: ReadonlyArray<{ label: string; href: string }> = [
@@ -44,6 +45,7 @@ export function Nav() {
           <Logo size={28} variant={scrolled ? "canvas-ink" : "forest-surface"} />
         </Link>
         <div className="flex items-center gap-1 md:gap-4">
+          <MobileNavDrawer scrolled={scrolled} />
           <ul className="hidden items-center gap-1 md:flex">
             {LINKS.map((link) => (
               <li key={link.href}>


### PR DESCRIPTION
… and nav drawer

Mobile was broken: hero text invisible (white on transparent — no WebGL canvas), engine section hidden behind opaque curtain, market descriptors requiring hover, excessive paradox spacing, and no mobile navigation menu.

- Add bg-ink mobile background to hero (canvas only renders on desktop)
- Show engine curtain only on md+ where GSAP animates it away
- Make market card descriptors visible by default, hover-reveal on md+
- Reduce paradox mobile gap/padding for proportional spacing
- Switch hero height to 100dvh for mobile browser address bar
- Add mobile nav drawer with fullscreen overlay and a11y support