### PR TITLE
fix(landing): fix mobile layout and add nav drawer

### DIFF
--- a/frontend/src/components/landing/hero/hero-copy.tsx
+++ b/frontend/src/components/landing/hero/hero-copy.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { buttonVariants } from "@/components/ui/button";
+import { useCanvasStage } from "@/components/landing/canvas/use-canvas-stage";
 import { COPY } from "@/content/copy";
 import { useReducedMotion } from "@/hooks/use-reduced-motion";
 import { cn } from "@/lib/cn";
@@ -88,6 +89,7 @@ function useWordScramble(text: string) {
 export function HeroCopy() {
   const { eyebrow, headline, sub, ctas } = COPY.hero;
   const heroRef = useRef<HTMLDivElement>(null);
+  const { enabled: canvasEnabled } = useCanvasStage();
   const reduceMotion = useReducedMotion();
   const [cipherActive, setCipherActive] = useState(false);
 
@@ -161,7 +163,7 @@ export function HeroCopy() {
       id="hero"
       aria-labelledby="hero-heading"
       ref={heroRef}
-      className="relative isolate bg-ink md:bg-transparent"
+      className={cn("relative isolate", canvasEnabled ? "bg-transparent" : "bg-ink")}
     >
       <div className="relative mx-auto flex min-h-[calc(100dvh-56px)] w-full max-w-7xl flex-col items-center justify-center px-5 py-24 md:px-8">
         <p


### PR DESCRIPTION
## Summary
- Fix invisible hero text on mobile (white text, no WebGL canvas background)
- Fix engine section hidden behind opaque curtain on mobile (GSAP only runs on desktop)
- Show market card descriptors by default on mobile (no hover on touch)
- Reduce excessive paradox section spacing on mobile
- Switch hero height to `100dvh` for mobile browser address bar
- Add mobile nav drawer with fullscreen overlay and a11y support
- Disable hero word scramble on touch devices (`hover: hover` media query)
- Use canvas context for hero fallback background (fixes Opera/no-WebGL desktop too)

## Test plan
- [ ] Mobile viewport (390x844): hero visible, engine cards visible, market descriptors shown, nav drawer opens/closes
- [ ] Desktop viewport (1440x900): canvas WebGL renders, no hamburger icon, hover effects work
- [ ] Desktop without WebGL: hero shows dark fallback background
- [ ] Touch devices: no scramble effect on headline hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)