### PR TITLE
Prevent DB error leaking and fix Docker Compose service configs

### DIFF
--- a/backend/crates/api-gateway/src/error.rs
+++ b/backend/crates/api-gateway/src/error.rs
@@ -3,6 +3,7 @@ use axum::response::{IntoResponse, Response};
 use sea_orm::DbErr;
 use serde::Serialize;
 use thiserror::Error;
+use tracing::error;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -50,9 +51,18 @@ impl IntoResponse for GatewayError {
             Self::Upstream(_) => StatusCode::BAD_GATEWAY,
             Self::Config(_) | Self::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        let body = ErrorBody {
-            error: self.to_string(),
+        let message = match &self {
+            Self::Database(detail) => {
+                error!(error = %detail, "database error");
+                "internal server error".to_owned()
+            }
+            Self::Config(detail) => {
+                error!(error = %detail, "configuration error");
+                "internal server error".to_owned()
+            }
+            other => other.to_string(),
         };
+        let body = ErrorBody { error: message };
         (status, axum::Json(body)).into_response()
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,13 @@ services:
       target: issuer-service
     ports:
       - "3000:3000"
+    environment:
+      LISTEN_ADDR: "0.0.0.0:3000"
+      PROGRAM_ID: "${PROGRAM_ID:?set PROGRAM_ID}"
+      KEYPAIR_PATH: "/keys/id.json"
+      RPC_URL: "${RPC_URL:-http://127.0.0.1:8899}"
+    volumes:
+      - ${KEYPAIR_FILE:-~/.config/solana/id.json}:/keys/id.json:ro
 
   indexer:
     build:
@@ -47,6 +54,10 @@ services:
       target: indexer
     ports:
       - "3001:3001"
+    environment:
+      INDEXER_PORT: "3001"
+      INDEXER_HELIUS_AUTH_TOKEN: "${INDEXER_HELIUS_AUTH_TOKEN:?set INDEXER_HELIUS_AUTH_TOKEN}"
+      INDEXER_PROGRAM_ID: "${INDEXER_PROGRAM_ID:?set INDEXER_PROGRAM_ID}"
     volumes:
       - indexer_data:/data
 


### PR DESCRIPTION
Stop exposing raw SeaORM/SQLx error details in HTTP responses by logging internals server-side and returning a generic message for Database and Config error variants. Add missing environment variables and volume mounts for issuer-service and indexer in docker-compose.yml.