### PR TITLE
Add GET /events endpoint with cursor pagination and PostgreSQL storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ INDEXER_LOG_LEVEL=info
 INDEXER_DEDUP_PATH=./data/dedup
 INDEXER_DEDUP_CAPACITY=1000000
 INDEXER_DEDUP_TTL_SECS=86400
+INDEXER_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway
 
 # ── Issuer Service ───────────────────────────────────────────
 RPC_URL=http://127.0.0.1:8899
@@ -31,6 +32,7 @@ ALLOW_UNAUTHENTICATED=false
 
 # ── Testing ───────────────────────────────────────────────────
 TEST_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway_test
+INDEXER_TEST_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_indexer_test
 
 # ── Build ────────────────────────────────────────────────────
 VK_PATH=default.vk

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3215,12 +3215,16 @@ dependencies = [
  "bs58",
  "ed25519-dalek 2.2.0",
  "hex",
+ "http-body-util",
+ "indexer-migration",
  "moka",
  "mutants",
  "reqwest 0.12.28",
  "rocksdb",
+ "sea-orm",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
@@ -3230,6 +3234,14 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zksettle-types",
+]
+
+[[package]]
+name = "indexer-migration"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "sea-orm-migration",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "programs/*",
     "crates/*",
     "crates/api-gateway/migration",
+    "crates/indexer/migration",
 ]
 resolver = "2"
 

--- a/backend/crates/indexer/Cargo.toml
+++ b/backend/crates/indexer/Cargo.toml
@@ -36,8 +36,12 @@ moka = { version = "0.12", features = ["sync"] }
 rocksdb = "0.24"
 sha2 = "0.10"
 mutants = "0.0.3"
+sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
+indexer-migration = { path = "migration" }
 
 [dev-dependencies]
 axum-test = "16"
+http-body-util = "0.1"
+serial_test = "3"
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/backend/crates/indexer/migration/Cargo.toml
+++ b/backend/crates/indexer/migration/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "indexer-migration"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = "0.1"
+sea-orm-migration = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }

--- a/backend/crates/indexer/migration/src/lib.rs
+++ b/backend/crates/indexer/migration/src/lib.rs
@@ -1,0 +1,12 @@
+pub use sea_orm_migration::prelude::*;
+
+mod m20260430_001_create_events_table;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m20260430_001_create_events_table::Migration)]
+    }
+}

--- a/backend/crates/indexer/migration/src/lib.rs
+++ b/backend/crates/indexer/migration/src/lib.rs
@@ -1,12 +1,16 @@
 pub use sea_orm_migration::prelude::*;
 
 mod m20260430_001_create_events_table;
+mod m20260430_002_add_slot_id_index;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20260430_001_create_events_table::Migration)]
+        vec![
+            Box::new(m20260430_001_create_events_table::Migration),
+            Box::new(m20260430_002_add_slot_id_index::Migration),
+        ]
     }
 }

--- a/backend/crates/indexer/migration/src/m20260430_001_create_events_table.rs
+++ b/backend/crates/indexer/migration/src/m20260430_001_create_events_table.rs
@@ -1,0 +1,110 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Events::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Events::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Events::Signature).text().not_null())
+                    .col(ColumnDef::new(Events::Slot).big_integer().not_null())
+                    .col(ColumnDef::new(Events::Timestamp).big_integer().not_null())
+                    .col(ColumnDef::new(Events::Issuer).text().not_null())
+                    .col(
+                        ColumnDef::new(Events::NullifierHash)
+                            .text()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Events::MerkleRoot).text().not_null())
+                    .col(ColumnDef::new(Events::SanctionsRoot).text().not_null())
+                    .col(ColumnDef::new(Events::JurisdictionRoot).text().not_null())
+                    .col(ColumnDef::new(Events::Mint).text().not_null())
+                    .col(ColumnDef::new(Events::Recipient).text().not_null())
+                    .col(ColumnDef::new(Events::Payer).text().not_null())
+                    .col(ColumnDef::new(Events::Amount).big_integer().not_null())
+                    .col(ColumnDef::new(Events::Epoch).big_integer().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_events_slot")
+                    .table(Events::Table)
+                    .col((Events::Slot, IndexOrder::Desc))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_events_timestamp")
+                    .table(Events::Table)
+                    .col(Events::Timestamp)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_events_issuer")
+                    .table(Events::Table)
+                    .col(Events::Issuer)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_events_recipient")
+                    .table(Events::Table)
+                    .col(Events::Recipient)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(Events::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Events {
+    Table,
+    Id,
+    Signature,
+    Slot,
+    Timestamp,
+    Issuer,
+    NullifierHash,
+    MerkleRoot,
+    SanctionsRoot,
+    JurisdictionRoot,
+    Mint,
+    Recipient,
+    Payer,
+    Amount,
+    Epoch,
+}

--- a/backend/crates/indexer/migration/src/m20260430_002_add_slot_id_index.rs
+++ b/backend/crates/indexer/migration/src/m20260430_002_add_slot_id_index.rs
@@ -1,0 +1,47 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(Index::drop().name("idx_events_slot").to_owned())
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_events_slot_id")
+                    .table(Events::Table)
+                    .col((Events::Slot, IndexOrder::Desc))
+                    .col((Events::Id, IndexOrder::Desc))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(Index::drop().name("idx_events_slot_id").to_owned())
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_events_slot")
+                    .table(Events::Table)
+                    .col((Events::Slot, IndexOrder::Desc))
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Events {
+    Table,
+    Slot,
+    Id,
+}

--- a/backend/crates/indexer/src/config/db.rs
+++ b/backend/crates/indexer/src/config/db.rs
@@ -1,0 +1,21 @@
+use indexer_migration::{Migrator, MigratorTrait};
+use sea_orm::{ConnectOptions, Database, DatabaseConnection};
+
+use crate::error::IndexerError;
+
+pub async fn connect_and_migrate(database_url: &str) -> Result<DatabaseConnection, IndexerError> {
+    let mut opts = ConnectOptions::new(database_url);
+    opts.max_connections(20)
+        .min_connections(2)
+        .sqlx_logging(false);
+
+    let db = Database::connect(opts)
+        .await
+        .map_err(|e| IndexerError::Database(e.to_string()))?;
+
+    Migrator::up(&db, None)
+        .await
+        .map_err(|e| IndexerError::Database(format!("migration failed: {e}")))?;
+
+    Ok(db)
+}

--- a/backend/crates/indexer/src/config/mod.rs
+++ b/backend/crates/indexer/src/config/mod.rs
@@ -1,0 +1,4 @@
+mod settings;
+pub mod db;
+
+pub use settings::Config;

--- a/backend/crates/indexer/src/config/settings.rs
+++ b/backend/crates/indexer/src/config/settings.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub dedup_path: String,
     pub dedup_capacity: u64,
     pub dedup_ttl_secs: u64,
+    pub database_url: String,
 }
 
 impl std::fmt::Debug for Config {
@@ -25,6 +26,7 @@ impl std::fmt::Debug for Config {
             .field("dedup_path", &self.dedup_path)
             .field("dedup_capacity", &self.dedup_capacity)
             .field("dedup_ttl_secs", &self.dedup_ttl_secs)
+            .field("database_url", &"[REDACTED]")
             .finish()
     }
 }
@@ -52,6 +54,7 @@ impl Config {
                 .unwrap_or_else(|_| "86400".into())
                 .parse()
                 .map_err(|_| IndexerError::Config("INDEXER_DEDUP_TTL_SECS must be a valid u64".into()))?,
+            database_url: read_var("INDEXER_DATABASE_URL")?,
         })
     }
 
@@ -90,6 +93,7 @@ mod tests {
             dedup_path: "./data/dedup".into(),
             dedup_capacity: 1_000_000,
             dedup_ttl_secs: 86400,
+            database_url: String::new(),
         };
         assert!(cfg.is_dry_run());
     }
@@ -106,6 +110,7 @@ mod tests {
             dedup_path: "./data/dedup".into(),
             dedup_capacity: 1_000_000,
             dedup_ttl_secs: 86400,
+            database_url: String::new(),
         };
         assert!(!cfg.is_dry_run());
     }
@@ -122,6 +127,7 @@ mod tests {
             dedup_path: "./data/dedup".into(),
             dedup_capacity: 1_000_000,
             dedup_ttl_secs: 86400,
+            database_url: String::new(),
         };
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains("super_secret_token"));

--- a/backend/crates/indexer/src/entity/event.rs
+++ b/backend/crates/indexer/src/entity/event.rs
@@ -1,0 +1,26 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, serde::Serialize, serde::Deserialize)]
+#[sea_orm(table_name = "events")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub signature: String,
+    pub slot: i64,
+    pub timestamp: i64,
+    pub issuer: String,
+    pub nullifier_hash: String,
+    pub merkle_root: String,
+    pub sanctions_root: String,
+    pub jurisdiction_root: String,
+    pub mint: String,
+    pub recipient: String,
+    pub payer: String,
+    pub amount: i64,
+    pub epoch: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/backend/crates/indexer/src/entity/mod.rs
+++ b/backend/crates/indexer/src/entity/mod.rs
@@ -1,0 +1,1 @@
+pub mod event;

--- a/backend/crates/indexer/src/error.rs
+++ b/backend/crates/indexer/src/error.rs
@@ -32,6 +32,12 @@ pub enum IndexerError {
     #[error("configuration error: {0}")]
     Config(String),
 
+    #[error("database error: {0}")]
+    Database(String),
+
+    #[error("invalid cursor")]
+    InvalidCursor,
+
     #[error("unauthorized")]
     Unauthorized,
 }
@@ -40,7 +46,10 @@ impl IntoResponse for IndexerError {
     fn into_response(self) -> Response {
         let status = match &self {
             Self::Unauthorized => StatusCode::UNAUTHORIZED,
-            Self::Config(_) | Self::DedupWrite(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Config(_) | Self::DedupWrite(_) | Self::Database(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Self::InvalidCursor => StatusCode::BAD_REQUEST,
             Self::IrysUpload(_) => StatusCode::BAD_GATEWAY,
             Self::Base64Decode(_)
             | Self::BorshDeserialize(_)
@@ -72,5 +81,7 @@ mod tests {
         assert_eq!(status_of(IndexerError::DiscriminatorMismatch), StatusCode::BAD_REQUEST);
         assert_eq!(status_of(IndexerError::NoProofSettledEvent), StatusCode::OK);
         assert_eq!(status_of(IndexerError::DuplicateNullifier), StatusCode::OK);
+        assert_eq!(status_of(IndexerError::Database("x".into())), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(status_of(IndexerError::InvalidCursor), StatusCode::BAD_REQUEST);
     }
 }

--- a/backend/crates/indexer/src/error.rs
+++ b/backend/crates/indexer/src/error.rs
@@ -1,6 +1,7 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use thiserror::Error;
+use tracing::error;
 
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -57,7 +58,22 @@ impl IntoResponse for IndexerError {
             | Self::MissingEvents => StatusCode::BAD_REQUEST,
             Self::NoProofSettledEvent | Self::DuplicateNullifier => StatusCode::OK,
         };
-        (status, self.to_string()).into_response()
+        let message = match &self {
+            Self::Database(detail) => {
+                error!(error = %detail, "database error");
+                "internal server error".to_owned()
+            }
+            Self::Config(detail) => {
+                error!(error = %detail, "configuration error");
+                "internal server error".to_owned()
+            }
+            Self::DedupWrite(detail) => {
+                error!(error = %detail, "dedup write error");
+                "internal server error".to_owned()
+            }
+            other => other.to_string(),
+        };
+        (status, message).into_response()
     }
 }
 

--- a/backend/crates/indexer/src/lib.rs
+++ b/backend/crates/indexer/src/lib.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use axum::routing::{get, post};
 use axum::Router;
+use sea_orm::DatabaseConnection;
 use tower_http::trace::TraceLayer;
 
 pub mod config;
 pub mod dedup;
+pub mod entity;
 pub mod error;
 pub mod helius;
 pub mod irys;
@@ -19,12 +21,19 @@ pub struct AppState {
     pub config: Config,
     pub irys: Arc<dyn IrysUploader>,
     pub dedup: NullifierStore,
+    pub db: Option<DatabaseConnection>,
 }
 
 pub fn build_router(state: Arc<AppState>) -> Router {
-    Router::new()
+    let mut router = Router::new()
         .route("/health", get(routes::health::health))
-        .route("/webhook/helius", post(routes::webhook::handle_webhook))
+        .route("/webhook/helius", post(routes::webhook::handle_webhook));
+
+    if state.db.is_some() {
+        router = router.route("/events", get(routes::events::list_events));
+    }
+
+    router
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
@@ -42,6 +51,7 @@ pub fn test_app() -> (Router, tempfile::TempDir) {
         dedup_path: tmp.path().to_string_lossy().into_owned(),
         dedup_capacity: 1_000_000,
         dedup_ttl_secs: 86400,
+        database_url: String::new(),
     };
     let http = reqwest::Client::new();
     let irys: Arc<dyn IrysUploader> =
@@ -52,6 +62,103 @@ pub fn test_app() -> (Router, tempfile::TempDir) {
         config,
         irys,
         dedup,
+        db: None,
     });
     (build_router(state), tmp)
+}
+
+#[cfg(test)]
+fn test_config(tmp: &tempfile::TempDir) -> Config {
+    Config {
+        port: 3000,
+        helius_auth_token: "test-token".into(),
+        irys_node_url: "http://localhost:0".into(),
+        irys_wallet_key: None,
+        program_id: "11111111111111111111111111111111".into(),
+        log_level: "error".into(),
+        dedup_path: tmp.path().to_string_lossy().into_owned(),
+        dedup_capacity: 1_000_000,
+        dedup_ttl_secs: 86400,
+        database_url: String::new(),
+    }
+}
+
+#[cfg(test)]
+pub async fn test_db() -> DatabaseConnection {
+    let url = std::env::var("INDEXER_TEST_DATABASE_URL").unwrap_or_else(|_| {
+        "postgres://zksettle:zksettle_dev@localhost:5432/zksettle_indexer_test".into()
+    });
+    config::db::connect_and_migrate(&url)
+        .await
+        .expect("failed to connect to test database")
+}
+
+#[cfg(test)]
+pub async fn test_cleanup(db: &DatabaseConnection) {
+    use sea_orm::EntityTrait;
+    entity::event::Entity::delete_many()
+        .exec(db)
+        .await
+        .expect("failed to clean up test events");
+}
+
+#[cfg(test)]
+pub async fn test_app_with_db() -> (Router, tempfile::TempDir, Arc<AppState>) {
+    let db = test_db().await;
+    test_cleanup(&db).await;
+
+    let tmp = tempfile::tempdir().expect("failed to create tempdir for test dedup store");
+    let config = test_config(&tmp);
+    let irys: Arc<dyn IrysUploader> = Arc::new(irys::MockIrysUploader::new());
+    let dedup = NullifierStore::open(tmp.path(), 1_000_000, std::time::Duration::from_secs(86400))
+        .expect("failed to open test dedup store");
+    let state = Arc::new(AppState {
+        config,
+        irys,
+        dedup,
+        db: Some(db),
+    });
+    let router = build_router(state.clone());
+    (router, tmp, state)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn events_route_registered_when_db_present() {
+        let (app, _tmp, _state) = test_app_with_db().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    async fn events_route_not_registered_when_db_absent() {
+        let (app, _tmp) = test_app();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 404);
+    }
 }

--- a/backend/crates/indexer/src/main.rs
+++ b/backend/crates/indexer/src/main.rs
@@ -43,10 +43,16 @@ async fn main() -> anyhow::Result<()> {
     )
     .context("opening dedup store")?;
 
+    info!("connecting to database and running migrations");
+    let db = indexer::config::db::connect_and_migrate(&config.database_url)
+        .await
+        .context("database setup")?;
+
     let state = Arc::new(AppState {
         config: config.clone(),
         irys,
         dedup,
+        db: Some(db),
     });
 
     let addr = format!("0.0.0.0:{}", config.port);

--- a/backend/crates/indexer/src/routes/events.rs
+++ b/backend/crates/indexer/src/routes/events.rs
@@ -4,7 +4,7 @@ use axum::extract::{Query, State};
 use axum::Json;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
 use serde::{Deserialize, Serialize};
 
 use crate::entity::event::{Column, Entity as EventEntity, Model as EventModel};
@@ -27,18 +27,23 @@ pub struct ListEventsResponse {
     pub next_cursor: Option<String>,
 }
 
-fn encode_cursor(id: i32) -> String {
-    URL_SAFE_NO_PAD.encode(id.to_le_bytes())
+fn encode_cursor(slot: i64, id: i32) -> String {
+    let mut buf = [0u8; 12];
+    buf[..8].copy_from_slice(&slot.to_le_bytes());
+    buf[8..].copy_from_slice(&id.to_le_bytes());
+    URL_SAFE_NO_PAD.encode(buf)
 }
 
-fn decode_cursor(cursor: &str) -> Result<i32, IndexerError> {
+fn decode_cursor(cursor: &str) -> Result<(i64, i32), IndexerError> {
     let bytes = URL_SAFE_NO_PAD
         .decode(cursor)
         .map_err(|_| IndexerError::InvalidCursor)?;
-    let arr: [u8; 4] = bytes
-        .try_into()
-        .map_err(|_| IndexerError::InvalidCursor)?;
-    Ok(i32::from_le_bytes(arr))
+    if bytes.len() != 12 {
+        return Err(IndexerError::InvalidCursor);
+    }
+    let slot = i64::from_le_bytes(bytes[..8].try_into().unwrap());
+    let id = i32::from_le_bytes(bytes[8..].try_into().unwrap());
+    Ok((slot, id))
 }
 
 pub async fn list_events(
@@ -47,11 +52,21 @@ pub async fn list_events(
 ) -> Result<Json<ListEventsResponse>, IndexerError> {
     let limit = params.limit.unwrap_or(50).clamp(1, 200);
 
-    let mut query = EventEntity::find().order_by_desc(Column::Id);
+    let mut query = EventEntity::find()
+        .order_by_desc(Column::Slot)
+        .order_by_desc(Column::Id);
 
     if let Some(ref cursor) = params.cursor {
-        let cursor_id = decode_cursor(cursor)?;
-        query = query.filter(Column::Id.lt(cursor_id));
+        let (cursor_slot, cursor_id) = decode_cursor(cursor)?;
+        query = query.filter(
+            Condition::any()
+                .add(Column::Slot.lt(cursor_slot))
+                .add(
+                    Condition::all()
+                        .add(Column::Slot.eq(cursor_slot))
+                        .add(Column::Id.lt(cursor_id)),
+                ),
+        );
     }
     if let Some(from_ts) = params.from_ts {
         query = query.filter(Column::Timestamp.gte(from_ts));
@@ -77,7 +92,7 @@ pub async fn list_events(
 
     let next_cursor = if rows.len() > limit as usize {
         let last = rows.pop().unwrap();
-        Some(encode_cursor(last.id))
+        Some(encode_cursor(last.slot, last.id))
     } else {
         None
     };
@@ -94,10 +109,10 @@ mod tests {
 
     #[test]
     fn cursor_roundtrip() {
-        let id = 42;
-        let encoded = encode_cursor(id);
-        let decoded = decode_cursor(&encoded).unwrap();
-        assert_eq!(decoded, id);
+        let encoded = encode_cursor(500, 42);
+        let (slot, id) = decode_cursor(&encoded).unwrap();
+        assert_eq!(slot, 500);
+        assert_eq!(id, 42);
     }
 
     #[test]
@@ -106,10 +121,18 @@ mod tests {
     }
 
     #[test]
+    fn cursor_wrong_length_returns_error() {
+        let short = URL_SAFE_NO_PAD.encode([0u8; 4]);
+        assert!(decode_cursor(&short).is_err());
+    }
+
+    #[test]
     fn cursor_roundtrip_edge_values() {
-        for id in [0, 1, i32::MAX, -1] {
-            let encoded = encode_cursor(id);
-            assert_eq!(decode_cursor(&encoded).unwrap(), id);
+        for (slot, id) in [(0, 0), (1, 1), (i64::MAX, i32::MAX), (-1, -1)] {
+            let encoded = encode_cursor(slot, id);
+            let (s, i) = decode_cursor(&encoded).unwrap();
+            assert_eq!(s, slot);
+            assert_eq!(i, id);
         }
     }
 }
@@ -201,8 +224,8 @@ mod integration_tests {
             .unwrap();
         let body: ListEventsResponse = parse_body(resp).await;
         assert_eq!(body.events.len(), 3);
-        assert!(body.events[0].id > body.events[1].id);
-        assert!(body.events[1].id > body.events[2].id);
+        assert!(body.events[0].slot >= body.events[1].slot);
+        assert!(body.events[1].slot >= body.events[2].slot);
     }
 
     #[tokio::test]

--- a/backend/crates/indexer/src/routes/events.rs
+++ b/backend/crates/indexer/src/routes/events.rs
@@ -1,0 +1,385 @@
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::Json;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryOrder, QuerySelect};
+use serde::{Deserialize, Serialize};
+
+use crate::entity::event::{Column, Entity as EventEntity, Model as EventModel};
+use crate::error::IndexerError;
+use crate::AppState;
+
+#[derive(Deserialize)]
+pub struct ListEventsQuery {
+    pub cursor: Option<String>,
+    pub limit: Option<u64>,
+    pub from_ts: Option<i64>,
+    pub to_ts: Option<i64>,
+    pub issuer: Option<String>,
+    pub recipient: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ListEventsResponse {
+    pub events: Vec<EventModel>,
+    pub next_cursor: Option<String>,
+}
+
+fn encode_cursor(id: i32) -> String {
+    URL_SAFE_NO_PAD.encode(id.to_le_bytes())
+}
+
+fn decode_cursor(cursor: &str) -> Result<i32, IndexerError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| IndexerError::InvalidCursor)?;
+    let arr: [u8; 4] = bytes
+        .try_into()
+        .map_err(|_| IndexerError::InvalidCursor)?;
+    Ok(i32::from_le_bytes(arr))
+}
+
+pub async fn list_events(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<ListEventsQuery>,
+) -> Result<Json<ListEventsResponse>, IndexerError> {
+    let limit = params.limit.unwrap_or(50).clamp(1, 200);
+
+    let mut query = EventEntity::find().order_by_desc(Column::Id);
+
+    if let Some(ref cursor) = params.cursor {
+        let cursor_id = decode_cursor(cursor)?;
+        query = query.filter(Column::Id.lt(cursor_id));
+    }
+    if let Some(from_ts) = params.from_ts {
+        query = query.filter(Column::Timestamp.gte(from_ts));
+    }
+    if let Some(to_ts) = params.to_ts {
+        query = query.filter(Column::Timestamp.lte(to_ts));
+    }
+    if let Some(ref issuer) = params.issuer {
+        query = query.filter(Column::Issuer.eq(issuer));
+    }
+    if let Some(ref recipient) = params.recipient {
+        query = query.filter(Column::Recipient.eq(recipient));
+    }
+
+    // Route only registered when db is Some (see build_router)
+    let db = state.db.as_ref().unwrap();
+
+    let mut rows = query
+        .limit(limit + 1)
+        .all(db)
+        .await
+        .map_err(|e| IndexerError::Database(e.to_string()))?;
+
+    let next_cursor = if rows.len() > limit as usize {
+        let last = rows.pop().unwrap();
+        Some(encode_cursor(last.id))
+    } else {
+        None
+    };
+
+    Ok(Json(ListEventsResponse {
+        events: rows,
+        next_cursor,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_roundtrip() {
+        let id = 42;
+        let encoded = encode_cursor(id);
+        let decoded = decode_cursor(&encoded).unwrap();
+        assert_eq!(decoded, id);
+    }
+
+    #[test]
+    fn invalid_cursor_returns_error() {
+        assert!(decode_cursor("not-valid!!!").is_err());
+    }
+
+    #[test]
+    fn cursor_roundtrip_edge_values() {
+        for id in [0, 1, i32::MAX, -1] {
+            let encoded = encode_cursor(id);
+            assert_eq!(decode_cursor(&encoded).unwrap(), id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use axum::body::Body;
+    use axum::http::Request;
+    use http_body_util::BodyExt;
+    use sea_orm::{EntityTrait, Set};
+    use serial_test::serial;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::entity::event;
+    use crate::test_app_with_db;
+
+    async fn parse_body<T: serde::de::DeserializeOwned>(
+        resp: axum::http::Response<Body>,
+    ) -> T {
+        let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn insert_test_event(
+        db: &sea_orm::DatabaseConnection,
+        index: i64,
+        timestamp: i64,
+        issuer: &str,
+        recipient: &str,
+        nullifier_hash: &str,
+    ) {
+        let active = event::ActiveModel {
+            id: Default::default(),
+            signature: Set(format!("sig_{index}")),
+            slot: Set(100 + index),
+            timestamp: Set(timestamp),
+            issuer: Set(issuer.to_string()),
+            nullifier_hash: Set(nullifier_hash.to_string()),
+            merkle_root: Set(format!("mr_{index}")),
+            sanctions_root: Set(format!("sr_{index}")),
+            jurisdiction_root: Set(format!("jr_{index}")),
+            mint: Set("mint_a".to_string()),
+            recipient: Set(recipient.to_string()),
+            payer: Set("payer_a".to_string()),
+            amount: Set(1_000_000),
+            epoch: Set(1),
+        };
+        event::Entity::insert(active).exec(db).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_empty_db() {
+        let (app, _tmp, _state) = test_app_with_db().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let body: ListEventsResponse = parse_body(resp).await;
+        assert!(body.events.is_empty());
+        assert!(body.next_cursor.is_none());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_returns_newest_first() {
+        let (app, _tmp, state) = test_app_with_db().await;
+        let db = state.db.as_ref().unwrap();
+
+        for i in 0..3 {
+            insert_test_event(db, i, 1_700_000_000 + i, "issuerA", "recipA", &format!("nh_{i}")).await;
+        }
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(body.events.len(), 3);
+        assert!(body.events[0].id > body.events[1].id);
+        assert!(body.events[1].id > body.events[2].id);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_cursor_pagination() {
+        let (app, _tmp, state) = test_app_with_db().await;
+        let db = state.db.as_ref().unwrap();
+
+        for i in 0..5 {
+            insert_test_event(db, i, 1_700_000_000, "issuerA", "recipA", &format!("nh_{i}")).await;
+        }
+
+        // Page 1: limit=3
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/events?limit=3")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let page1: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(page1.events.len(), 3);
+        assert!(page1.next_cursor.is_some());
+
+        // Page 2: use cursor
+        let cursor = page1.next_cursor.unwrap();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(&format!("/events?limit=3&cursor={cursor}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let page2: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(page2.events.len(), 2);
+        assert!(page2.next_cursor.is_none());
+
+        // No overlap
+        let page1_ids: Vec<i32> = page1.events.iter().map(|e| e.id).collect();
+        for e in &page2.events {
+            assert!(!page1_ids.contains(&e.id));
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_limit_clamped() {
+        let (app, _tmp, _state) = test_app_with_db().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/events?limit=999")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_timestamp_filters() {
+        let (app, _tmp, state) = test_app_with_db().await;
+        let db = state.db.as_ref().unwrap();
+
+        insert_test_event(db, 0, 100, "issA", "recA", "nh_t0").await;
+        insert_test_event(db, 1, 200, "issA", "recA", "nh_t1").await;
+        insert_test_event(db, 2, 300, "issA", "recA", "nh_t2").await;
+
+        // from_ts only
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/events?from_ts=200")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(body.events.len(), 2);
+
+        // to_ts only
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/events?to_ts=200")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(body.events.len(), 2);
+
+        // combined
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/events?from_ts=200&to_ts=200")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(body.events.len(), 1);
+        assert_eq!(body.events[0].timestamp, 200);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_issuer_filter() {
+        let (app, _tmp, state) = test_app_with_db().await;
+        let db = state.db.as_ref().unwrap();
+
+        insert_test_event(db, 0, 100, "alice", "bob", "nh_i0").await;
+        insert_test_event(db, 1, 200, "carol", "bob", "nh_i1").await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/events?issuer=alice")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(body.events.len(), 1);
+        assert_eq!(body.events[0].issuer, "alice");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_recipient_filter() {
+        let (app, _tmp, state) = test_app_with_db().await;
+        let db = state.db.as_ref().unwrap();
+
+        insert_test_event(db, 0, 100, "alice", "bob", "nh_r0").await;
+        insert_test_event(db, 1, 200, "alice", "carol", "nh_r1").await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/events?recipient=carol")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body: ListEventsResponse = parse_body(resp).await;
+        assert_eq!(body.events.len(), 1);
+        assert_eq!(body.events[0].recipient, "carol");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_events_invalid_cursor_returns_400() {
+        let (app, _tmp, _state) = test_app_with_db().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/events?cursor=garbage!!!")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 400);
+    }
+}

--- a/backend/crates/indexer/src/routes/mod.rs
+++ b/backend/crates/indexer/src/routes/mod.rs
@@ -1,2 +1,3 @@
+pub mod events;
 pub mod health;
 pub mod webhook;

--- a/backend/crates/indexer/src/routes/webhook.rs
+++ b/backend/crates/indexer/src/routes/webhook.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
+use sea_orm::{EntityTrait, Set, sea_query::OnConflict};
 use tracing::{error, info, warn};
 
+use crate::entity::event;
 use crate::helius::parse::extract_proof_settled;
 use crate::helius::payload::HeliusTransaction;
 use crate::AppState;
@@ -42,9 +44,41 @@ pub async fn handle_webhook(
 
             match state.irys.upload(event).await {
                 Ok(_) => {
-                    // Upload succeeded but if dedup write fails, this nullifier won't
-                    // be deduplicated on restart — may cause a duplicate Irys upload.
-                    // Acceptable: Irys uploads are idempotent by content hash.
+                    if let Some(db) = &state.db {
+                        let active = event::ActiveModel {
+                            id: Default::default(),
+                            signature: Set(tx.signature.clone()),
+                            slot: Set(tx.slot as i64),
+                            timestamp: Set(tx.timestamp),
+                            issuer: Set(bs58::encode(event.issuer).into_string()),
+                            nullifier_hash: Set(hex::encode(event.nullifier_hash)),
+                            merkle_root: Set(hex::encode(event.merkle_root)),
+                            sanctions_root: Set(hex::encode(event.sanctions_root)),
+                            jurisdiction_root: Set(hex::encode(event.jurisdiction_root)),
+                            mint: Set(bs58::encode(event.mint).into_string()),
+                            recipient: Set(bs58::encode(event.recipient).into_string()),
+                            payer: Set(bs58::encode(event.payer).into_string()),
+                            amount: Set(event.amount as i64),
+                            epoch: Set(event.epoch as i64),
+                        };
+                        if let Err(e) = event::Entity::insert(active)
+                            .on_conflict(
+                                OnConflict::column(event::Column::NullifierHash)
+                                    .do_nothing()
+                                    .to_owned(),
+                            )
+                            .do_nothing()
+                            .exec(db)
+                            .await
+                        {
+                            error!(
+                                nullifier = hex::encode(event.nullifier_hash),
+                                error = %e,
+                                "failed to store event in database"
+                            );
+                        }
+                    }
+
                     if let Err(e) = state.dedup.mark_uploaded(&event.nullifier_hash) {
                         error!(
                             nullifier = hex::encode(event.nullifier_hash),
@@ -249,5 +283,152 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), 200);
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use axum::body::Body;
+    use axum::http::Request;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+    use serial_test::serial;
+    use tower::ServiceExt;
+
+    use crate::entity::event;
+    use crate::test_app_with_db;
+
+    fn make_webhook_payload(
+        event: &zksettle_types::ProofSettled,
+        signature: &str,
+        slot: u64,
+        timestamp: i64,
+    ) -> String {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        use sha2::{Digest, Sha256};
+
+        let disc = {
+            let hash = Sha256::digest(b"event:ProofSettled");
+            let mut d = [0u8; 8];
+            d.copy_from_slice(&hash[..8]);
+            d
+        };
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&disc);
+        buf.extend_from_slice(&borsh::to_vec(event).unwrap());
+        let b64 = STANDARD.encode(&buf);
+
+        serde_json::to_string(&serde_json::json!([{
+            "signature": signature,
+            "slot": slot,
+            "timestamp": timestamp,
+            "logMessages": [format!("Program data: {b64}")]
+        }]))
+        .unwrap()
+    }
+
+    fn test_event() -> zksettle_types::ProofSettled {
+        zksettle_types::ProofSettled {
+            issuer: [1u8; 32],
+            nullifier_hash: [9u8; 32],
+            merkle_root: [3u8; 32],
+            sanctions_root: [4u8; 32],
+            jurisdiction_root: [5u8; 32],
+            mint: [6u8; 32],
+            recipient: [7u8; 32],
+            amount: 1_000_000,
+            epoch: 3,
+            timestamp: 1_700_000_000,
+            slot: 500,
+            payer: [8u8; 32],
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn webhook_stores_event_in_db() {
+        let (app, _tmp, state) = test_app_with_db().await;
+        let db = state.db.as_ref().unwrap();
+        let ev = test_event();
+        let body = make_webhook_payload(&ev, "txSig1", 500, 1_700_000_000);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhook/helius")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let nh = hex::encode(ev.nullifier_hash);
+        let row = event::Entity::find()
+            .filter(event::Column::NullifierHash.eq(&nh))
+            .one(db)
+            .await
+            .unwrap()
+            .expect("event should be stored in DB");
+
+        assert_eq!(row.signature, "txSig1");
+        assert_eq!(row.slot, 500);
+        assert_eq!(row.issuer, bs58::encode(ev.issuer).into_string());
+        assert_eq!(row.recipient, bs58::encode(ev.recipient).into_string());
+        assert_eq!(row.nullifier_hash, nh);
+        assert_eq!(row.merkle_root, hex::encode(ev.merkle_root));
+        assert_eq!(row.amount, 1_000_000);
+        assert_eq!(row.epoch, 3);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn webhook_duplicate_nullifier_no_db_insert() {
+        let (app, _tmp, state) = test_app_with_db().await;
+        let db = state.db.as_ref().unwrap();
+        let ev = test_event();
+        let body = make_webhook_payload(&ev, "txDup1", 500, 1_700_000_000);
+
+        // First
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhook/helius")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(body.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        // Duplicate
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhook/helius")
+                    .header("content-type", "application/json")
+                    .header("authorization", "Bearer test-token")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let nh = hex::encode(ev.nullifier_hash);
+        let rows = event::Entity::find()
+            .filter(event::Column::NullifierHash.eq(&nh))
+            .all(db)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "dedup should block second insert");
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./scripts/init-test-dbs.sql:/docker-entrypoint-initdb.d/10-test-dbs.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U zksettle"]
       interval: 5s
@@ -58,6 +59,10 @@ services:
       INDEXER_PORT: "3001"
       INDEXER_HELIUS_AUTH_TOKEN: "${INDEXER_HELIUS_AUTH_TOKEN:?set INDEXER_HELIUS_AUTH_TOKEN}"
       INDEXER_PROGRAM_ID: "${INDEXER_PROGRAM_ID:?set INDEXER_PROGRAM_ID}"
+      INDEXER_DATABASE_URL: "postgres://zksettle:zksettle_dev@postgres:5432/zksettle_gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
     volumes:
       - indexer_data:/data
 

--- a/scripts/init-test-dbs.sql
+++ b/scripts/init-test-dbs.sql
@@ -1,0 +1,4 @@
+-- Auto-created by docker-compose on first postgres boot.
+-- Creates the test databases used by `cargo test`.
+CREATE DATABASE zksettle_gateway_test;
+CREATE DATABASE zksettle_indexer_test;


### PR DESCRIPTION
Split config.rs into config/ module with db.rs for SeaORM connection and migration logic. Add events table via sea-orm-migration, entity model, and a cursor-paginated GET /events route with filtering by timestamp, issuer, and recipient. Store parsed ProofSettled events in the database during webhook processing with ON CONFLICT dedup. Wire indexer to postgres in docker-compose and add test database init script.

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Added `/events` endpoint with queryable filtering by issuer, recipient, and timestamp range
- Implemented cursor-based pagination for event retrieval with configurable result limits (1–200 results)
- Indexer now persists webhook events to the database for historical tracking
- Established database connectivity and migration system for reliable data management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->