### PR TITLE
chore: document CORS env var and complete .env.example for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ zksettle/
 
 ## Getting started
 
-> **Note:** Full development setup is published alongside the SDK release. The steps below are placeholders pending the Week 1 build.
+> **Note:** Full development setup is published alongside the SDK release. The steps below cover environment configuration and the minimum build pipeline; service-specific runbooks land with each milestone.
 
 ### Prerequisites
 
@@ -233,6 +233,32 @@ zksettle/
 - Node.js 20+ with pnpm
 - Noir (via `noirup`) + Sunspot compiler
 - Docker (for local PostgreSQL and Redis)
+
+### Local development setup
+
+ZKSettle ships per-package `.env.example` files that document every variable the services read at startup. Copy them before running anything:
+
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env.local
+```
+
+A combined `.env.example` at the repo root is also provided as a single-file overview of every service variable (gateway, indexer, issuer service, sanctions updater, testing).
+
+#### CORS — required for the browser to talk to the gateway
+
+The api-gateway enforces CORS via `GATEWAY_CORS_ALLOWED_ORIGINS` (see `backend/crates/api-gateway/src/lib.rs`). When this variable is unset or empty:
+
+- The gateway logs a warning at startup
+- Every browser request from the frontend is **silently blocked** — the network tab shows the request, but the response never reaches the JS code
+
+For local development the frontend runs at `http://localhost:3000` (or `:3001` if `:3000` is taken by the issuer service). Set the variable to include both:
+
+```env
+GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
+```
+
+The frontend's `NEXT_PUBLIC_API_BASE_URL` must point at the gateway (default `http://localhost:4000`), and that gateway origin must be reachable — opening the gateway URL in a browser tab is a quick smoke test.
 
 ### Clone and build
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,17 @@
+# API Gateway — required for `cargo run --bin api-gateway`.
+#
+# `GATEWAY_DATABASE_URL` and `GATEWAY_UPSTREAM_URL` are mandatory; everything else
+# has sensible defaults (see `backend/crates/api-gateway/src/config/settings.rs`).
+#
+# `GATEWAY_CORS_ALLOWED_ORIGINS` MUST list every browser origin that calls the
+# gateway. When empty, the gateway logs a warning and the browser silently blocks
+# all cross-origin requests, including from the local frontend.
+
+GATEWAY_PORT=4000
+GATEWAY_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway
+GATEWAY_UPSTREAM_URL=http://localhost:3000
+GATEWAY_INDEXER_URL=http://localhost:3001
+GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
+GATEWAY_ADMIN_KEY=
+GATEWAY_ALLOW_OPEN_KEYS=true
+GATEWAY_LOG_LEVEL=info

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,9 +2,18 @@
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # zksettle api-gateway base URL (no trailing slash).
+# The gateway must include this origin in `GATEWAY_CORS_ALLOWED_ORIGINS`,
+# otherwise the browser will block every request.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
 
 # Provisioned via POST /api-keys. NOTE: NEXT_PUBLIC_* is shipped in the bundle —
 # this env is acceptable for local dev only. Production must inject the key
 # server-side via a Route Handler proxy or HttpOnly cookie.
 NEXT_PUBLIC_API_KEY=
+
+# Solana RPC endpoint used by the wallet adapter and on-chain reads.
+# Use the public devnet URL for local dev or a Helius/Triton URL for higher rate limits.
+NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
+
+# Solana cluster — `devnet`, `testnet`, or `mainnet-beta`.
+NEXT_PUBLIC_SOLANA_NETWORK=devnet


### PR DESCRIPTION
Add `backend/.env.example` with every api-gateway variable, expand `frontend/.env.example` with the Solana variables the wallet adapter will need, and add a "Local development setup" section to the README that explains the CORS requirement.

The gateway already enforces CORS via `GATEWAY_CORS_ALLOWED_ORIGINS` (`backend/crates/api-gateway/src/lib.rs:35`), but a new contributor has no way to discover this — when the variable is unset, the gateway only logs a warning and the browser silently blocks every cross-origin request from the frontend at `localhost:3000`. The new env files and README section make this explicit.

### Notes on two intentional deviations from the issue body

- **`GATEWAY_INDEXER_URL`** is set to `http://localhost:3001` (matching the existing root `.env.example` and `INDEXER_PORT`), not `:5000` as suggested in the issue — there is no service on `:5000`.
- **`GATEWAY_DATABASE_URL`** is included; it is required by `backend/crates/api-gateway/src/config/settings.rs:51` and the gateway will not start without it.

### Acceptance criteria

- [x] `backend/.env.example` exists with all api-gateway vars
- [x] `frontend/.env.example` updated with Solana vars
- [x] `README.md` has a "Local development setup" section with CORS steps
- [x] A new developer can run frontend + gateway locally following the README

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Getting Started section with environment configuration and build pipeline information.
  * Added Local Development Setup guide covering `.env` file configuration and CORS requirements.
  * Added Solana network environment variables for RPC endpoint and network selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->