### PR TITLE
feat(frontend): implement CSV/JSON export in audit log

### DIFF
--- a/frontend/src/components/dashboard/audit-log-table.tsx
+++ b/frontend/src/components/dashboard/audit-log-table.tsx
@@ -10,6 +10,7 @@ import { useEvents, type EventsFilters } from "@/hooks/use-events";
 import { ApiError } from "@/lib/api/client";
 import type { EventDto } from "@/lib/api/schemas";
 import { cn } from "@/lib/cn";
+import { exportToCsv, exportToJson } from "@/lib/export";
 import { fmtAmount, fmtCompact, truncateWallet } from "@/lib/format";
 import { isValidWalletHex, normalizeWalletHex } from "@/lib/wallet";
 
@@ -112,9 +113,9 @@ export function AuditLogTable() {
     setRange("30d");
   };
 
-  const exportToast = useCallback((label: string) => {
+  const showToast = useCallback((message: string) => {
     if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    setToast(`${label} not yet wired · backend exposes JSON via GET /v1/events`);
+    setToast(message);
     toastTimerRef.current = setTimeout(() => {
       setToast(null);
       toastTimerRef.current = null;
@@ -158,10 +159,26 @@ export function AuditLogTable() {
               <Refresh aria-hidden="true" className="size-4" />
               Refresh
             </Button>
-            <Button variant="ghost" size="sm" onClick={() => exportToast("CSV export")}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                events.length
+                  ? exportToCsv(events, "zksettle-audit-log.csv")
+                  : showToast("No events to export")
+              }
+            >
               Export CSV
             </Button>
-            <Button variant="ghost" size="sm" onClick={() => exportToast("JSON export")}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                events.length
+                  ? exportToJson(events, "zksettle-audit-log.json")
+                  : showToast("No events to export")
+              }
+            >
               Export JSON
             </Button>
           </div>

--- a/frontend/src/lib/export.test.ts
+++ b/frontend/src/lib/export.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { EventDto } from "@/lib/api/schemas";
+import { buildCsvContent, buildJsonContent } from "./export";
+
+const SAMPLE_EVENT: EventDto = {
+  signature: "abc123",
+  slot: 42,
+  timestamp: 1713456000,
+  issuer: "issuer_addr",
+  nullifier_hash: "nullhash",
+  merkle_root: "mroot",
+  sanctions_root: "sroot",
+  jurisdiction_root: "jroot",
+  mint: "mint_addr",
+  recipient: "recipient_addr",
+  payer: "payer_addr",
+  amount: 50_000_000,
+  epoch: 10,
+};
+
+describe("buildCsvContent", () => {
+  it("produces a header row with 13 columns", () => {
+    const csv = buildCsvContent([]);
+    const header = csv.split("\n")[0];
+    expect(header.split(",")).toHaveLength(13);
+    expect(header).toBe(
+      "signature,slot,timestamp,issuer,nullifier_hash,merkle_root,sanctions_root,jurisdiction_root,mint,recipient,payer,amount,epoch",
+    );
+  });
+
+  it("converts timestamp to ISO 8601", () => {
+    const csv = buildCsvContent([SAMPLE_EVENT]);
+    const row = csv.split("\n")[1];
+    expect(row).toContain("2024-04-18T");
+  });
+
+  it("converts amount from micro-units to units", () => {
+    const csv = buildCsvContent([SAMPLE_EVENT]);
+    const row = csv.split("\n")[1];
+    const fields = row.split(",");
+    // amount is the 12th column (index 11)
+    expect(fields[11]).toBe("50");
+  });
+
+  it("escapes fields containing commas", () => {
+    const event: EventDto = { ...SAMPLE_EVENT, issuer: "addr,with,commas" };
+    const csv = buildCsvContent([event]);
+    const row = csv.split("\n")[1];
+    expect(row).toContain('"addr,with,commas"');
+  });
+
+  it("escapes fields containing double quotes", () => {
+    const event: EventDto = { ...SAMPLE_EVENT, issuer: 'addr"quoted' };
+    const csv = buildCsvContent([event]);
+    const row = csv.split("\n")[1];
+    expect(row).toContain('"addr""quoted"');
+  });
+
+  it("returns only the header for an empty array", () => {
+    const csv = buildCsvContent([]);
+    expect(csv.split("\n")).toHaveLength(1);
+  });
+});
+
+describe("buildJsonContent", () => {
+  it("produces valid JSON that round-trips", () => {
+    const events = [SAMPLE_EVENT];
+    const json = buildJsonContent(events);
+    expect(JSON.parse(json)).toEqual(events);
+  });
+
+  it("returns an empty array for no events", () => {
+    const json = buildJsonContent([]);
+    expect(JSON.parse(json)).toEqual([]);
+  });
+});

--- a/frontend/src/lib/export.ts
+++ b/frontend/src/lib/export.ts
@@ -1,0 +1,61 @@
+import type { EventDto } from "@/lib/api/schemas";
+
+const CSV_COLUMNS: (keyof EventDto)[] = [
+  "signature",
+  "slot",
+  "timestamp",
+  "issuer",
+  "nullifier_hash",
+  "merkle_root",
+  "sanctions_root",
+  "jurisdiction_root",
+  "mint",
+  "recipient",
+  "payer",
+  "amount",
+  "epoch",
+];
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function formatCsvValue(key: keyof EventDto, value: string | number): string {
+  if (key === "timestamp") return new Date((value as number) * 1000).toISOString();
+  if (key === "amount") return String((value as number) / 1_000_000);
+  return String(value);
+}
+
+export function buildCsvContent(events: EventDto[]): string {
+  const header = CSV_COLUMNS.join(",");
+  const rows = events.map((e) =>
+    CSV_COLUMNS.map((col) => escapeCsvField(formatCsvValue(col, e[col]))).join(","),
+  );
+  return [header, ...rows].join("\n");
+}
+
+export function buildJsonContent(events: EventDto[]): string {
+  return JSON.stringify(events, null, 2);
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function exportToCsv(events: EventDto[], filename: string): void {
+  const content = buildCsvContent(events);
+  triggerDownload(new Blob([content], { type: "text/csv;charset=utf-8" }), filename);
+}
+
+export function exportToJson(events: EventDto[], filename: string): void {
+  const content = buildJsonContent(events);
+  triggerDownload(new Blob([content], { type: "application/json" }), filename);
+}


### PR DESCRIPTION
## Summary
- Wire up Export CSV and Export JSON buttons in audit log with client-side download using data already loaded via React Query
- CSV follows RFC 4180 escaping, ISO 8601 timestamps, and USDC decimal conversion (÷1,000,000)
- Shows "No events to export" toast when event list is empty

Closes #96

## Test plan
- [ ] Click "Export CSV" with events loaded → downloads `.csv` with 13-column header and correct data
- [ ] Click "Export JSON" with events loaded → downloads `.json` with pretty-printed array
- [ ] Click either button with no events → toast "No events to export"
- [ ] Verify CSV escaping: fields with commas/quotes are properly wrapped
- [ ] `pnpm test` — 8 new unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audit log export functionality is now fully operational. Users can download audit logs in both CSV and JSON formats from the audit log dashboard. The system provides helpful feedback when no events are available for export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->