### PR TITLE
feat(frontend): add wallet registration UI

### DIFF
--- a/frontend/src/components/dashboard/wallets-credentials-panel.tsx
+++ b/frontend/src/components/dashboard/wallets-credentials-panel.tsx
@@ -80,6 +80,7 @@ export function WalletsCredentialsPanel() {
     try {
       await register.mutateAsync(normalized);
       recordWallet(normalized);
+      setRegisterInput("");
     } catch {
       // error surfaced via register.error
     }
@@ -182,13 +183,12 @@ export function WalletsCredentialsPanel() {
         )}
 
         {register.isSuccess ? (
-          <p
-            role="status"
+          <output
             className="mt-3 flex items-start gap-2 font-mono text-xs text-forest"
           >
             <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
             Wallet registered — {register.data.message}
-          </p>
+          </output>
         ) : null}
 
         {register.isError ? (
@@ -343,7 +343,7 @@ function CredentialCard({
   revokePending,
   issueError,
   revokeError,
-}: CredentialCardProps) {
+}: Readonly<CredentialCardProps>) {
   const { data: credential, isLoading, isError, error } = query;
   const errorInfo = isError ? describeError(error) : null;
 
@@ -468,13 +468,13 @@ function CredentialStatus({
   credential,
   authError,
   otherError,
-}: {
+}: Readonly<{
   loading: boolean;
   notFound: boolean;
   credential: Credential | null;
   authError: boolean;
   otherError: boolean;
-}) {
+}>) {
   if (loading) return <StatusPill kind="info" label="Loading" />;
   if (notFound) return <StatusPill kind="warning" label="Not found" />;
   if (authError) return <StatusPill kind="warning" label="Unauthorized" />;
@@ -484,7 +484,7 @@ function CredentialStatus({
   return null;
 }
 
-function CredentialDetails({ credential }: { credential: Credential }) {
+function CredentialDetails({ credential }: Readonly<{ credential: Credential }>) {
   const walletHex = bytesToHex(credential.wallet);
   return (
     <dl className="mt-5 grid gap-y-3 sm:grid-cols-[140px_1fr]">

--- a/frontend/src/components/dashboard/wallets-credentials-panel.tsx
+++ b/frontend/src/components/dashboard/wallets-credentials-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Search, Trash, WarningTriangle, Xmark } from "iconoir-react";
+import { Check, Plus, Search, Trash, WarningTriangle, Xmark } from "iconoir-react";
 import { useState, type FormEvent } from "react";
 
 import { StatusPill } from "@/components/dashboard/status-pill";
@@ -16,6 +16,7 @@ import {
   useRecentWallets,
   useRecordWallet,
 } from "@/hooks/use-recent-wallets";
+import { useRegisterWallet } from "@/hooks/use-register-wallet";
 import { ApiError } from "@/lib/api/client";
 import type { Credential } from "@/lib/api/schemas";
 import { truncateWallet } from "@/lib/format";
@@ -43,19 +44,46 @@ function describeError(err: unknown): { kind: "not-found" | "auth" | "conflict" 
   return { kind: "other", message: err instanceof Error ? err.message : "Unknown error" };
 }
 
+function describeRegisterError(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 409) return "Wallet is already registered in the membership tree.";
+    if (err.status === 400) return "Invalid wallet hex (need exactly 64 hex characters).";
+    if (err.status === 401 || err.status === 403)
+      return "Not authorized. Check NEXT_PUBLIC_API_KEY.";
+    return err.message;
+  }
+  return err instanceof Error ? err.message : "Unknown error";
+}
+
 export function WalletsCredentialsPanel() {
   const [walletInput, setWalletInput] = useState("");
   const [activeWallet, setActiveWallet] = useState<string | null>(null);
   const [issueJurisdiction, setIssueJurisdiction] = useState("US");
+  const [registerInput, setRegisterInput] = useState("");
 
   const credentialQuery = useCredential(activeWallet);
   const issue = useIssueCredential();
   const revoke = useRevokeCredential();
+  const register = useRegisterWallet();
   const { data: recent = [] } = useRecentWallets();
   const recordWallet = useRecordWallet();
   const forgetWallet = useForgetWallet();
+  const registerInputValid = isValidWalletHex(registerInput);
 
   const inputValid = isValidWalletHex(walletInput);
+
+  const onRegister = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!registerInputValid) return;
+    const normalized = normalizeWalletHex(registerInput);
+    register.reset();
+    try {
+      await register.mutateAsync(normalized);
+      recordWallet(normalized);
+    } catch {
+      // error surfaced via register.error
+    }
+  };
 
   const lookup = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -99,6 +127,84 @@ export function WalletsCredentialsPanel() {
 
   return (
     <div className="flex flex-col gap-6">
+      <section
+        aria-labelledby="register-heading"
+        className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
+      >
+        <span
+          id="register-heading"
+          className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
+        >
+          Register wallet
+        </span>
+        <p className="mt-1 text-sm text-stone">
+          Add a wallet to the membership tree. Paste a 32-byte pubkey as 64 hex
+          chars (with or without <span className="font-mono">0x</span>).
+        </p>
+
+        <form
+          onSubmit={onRegister}
+          className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center"
+        >
+          <Input
+            value={registerInput}
+            onChange={(e) => {
+              setRegisterInput(e.target.value);
+              register.reset();
+            }}
+            placeholder="0x… (64 hex chars)"
+            spellCheck={false}
+            autoComplete="off"
+            aria-invalid={registerInput.length > 0 && !registerInputValid}
+            aria-describedby="register-help"
+            className="font-mono"
+            disabled={register.isPending}
+          />
+          <Button
+            type="submit"
+            variant="primary"
+            size="md"
+            disabled={!registerInputValid || register.isPending}
+          >
+            <Plus aria-hidden="true" className="size-4" />
+            {register.isPending ? "Registering…" : "Register"}
+          </Button>
+        </form>
+
+        {registerInput.length > 0 && !registerInputValid ? (
+          <p id="register-help" className="mt-2 font-mono text-xs text-rust">
+            Wallet must be 64 hex characters.
+          </p>
+        ) : (
+          <p id="register-help" className="mt-2 font-mono text-xs text-muted">
+            Calls <span className="text-quill">POST /v1/wallets</span>.
+          </p>
+        )}
+
+        {register.isSuccess ? (
+          <p
+            role="status"
+            className="mt-3 flex items-start gap-2 font-mono text-xs text-forest"
+          >
+            <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+            Wallet registered — {register.data.message}
+          </p>
+        ) : null}
+
+        {register.isError ? (
+          <p
+            role="alert"
+            className="mt-3 flex items-start gap-2 font-mono text-xs text-rust"
+          >
+            <WarningTriangle
+              aria-hidden="true"
+              className="mt-0.5 size-4 shrink-0"
+            />
+            {describeRegisterError(register.error)}
+          </p>
+        ) : null}
+      </section>
+
       <section
         aria-labelledby="lookup-heading"
         className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"

--- a/frontend/src/hooks/use-register-wallet.ts
+++ b/frontend/src/hooks/use-register-wallet.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { registerWallet } from "@/lib/api/endpoints";
+import { credentialQueryKey } from "@/hooks/use-credential";
+import { rootsQueryKey } from "@/hooks/use-roots";
+
+export function useRegisterWallet() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (wallet: string) => registerWallet(wallet),
+    onSuccess: (_data, wallet) => {
+      queryClient.invalidateQueries({ queryKey: credentialQueryKey(wallet) });
+      queryClient.invalidateQueries({ queryKey: rootsQueryKey });
+    },
+  });
+}

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -7,6 +7,7 @@ import {
   ListEventsResponseSchema,
   ListKeysResponseSchema,
   MembershipProofSchema,
+  RegisterWalletResponseSchema,
   RootsSchema,
   SanctionsProofSchema,
   UsageHistorySchema,
@@ -18,6 +19,7 @@ import {
   type ListEventsResponse,
   type ListKeysResponse,
   type MembershipProof,
+  type RegisterWalletResponse,
   type Roots,
   type SanctionsProof,
   type Usage,
@@ -44,6 +46,14 @@ export const getMembershipProof = async (wallet: string): Promise<MembershipProo
 
 export const getSanctionsProof = async (wallet: string): Promise<SanctionsProof> =>
   SanctionsProofSchema.parse(await apiFetch(`/v1/proofs/sanctions/${wallet}`));
+
+export const registerWallet = async (wallet: string): Promise<RegisterWalletResponse> =>
+  RegisterWalletResponseSchema.parse(
+    await apiFetch("/v1/wallets", {
+      method: "POST",
+      body: JSON.stringify({ wallet }),
+    }),
+  );
 
 export const issueCredential = (body: { wallet: string; jurisdiction?: string }) =>
   apiFetch<{ wallet: string; leaf_index: number; jurisdiction: string }>("/v1/credentials", {

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -105,7 +105,6 @@ export const listEvents = async (
   if (params.issuer) search.set("issuer", params.issuer);
   if (params.recipient) search.set("recipient", params.recipient);
   const query = search.toString();
-  return ListEventsResponseSchema.parse(
-    await apiFetch(`/v1/events${query ? `?${query}` : ""}`),
-  );
+  const path = query ? `/v1/events?${query}` : "/v1/events";
+  return ListEventsResponseSchema.parse(await apiFetch(path));
 };

--- a/frontend/src/lib/api/schemas.ts
+++ b/frontend/src/lib/api/schemas.ts
@@ -45,6 +45,12 @@ export const CredentialSchema = z.object({
 });
 export type Credential = z.infer<typeof CredentialSchema>;
 
+export const RegisterWalletResponseSchema = z.object({
+  wallet: z.string(),
+  message: z.string(),
+});
+export type RegisterWalletResponse = z.infer<typeof RegisterWalletResponseSchema>;
+
 export const MembershipProofSchema = z.object({
   wallet: z.string(),
   leaf_index: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary
- Adds "Register wallet" form section to the Wallets & Credentials dashboard panel
- New `POST /v1/wallets` endpoint function with Zod-validated response schema
- New `useRegisterWallet` React Query mutation hook with credential + roots cache invalidation
- Success/error feedback inline (handles 400, 401/403, 409 gracefully)

Closes #118

## Test plan
- [ ] `pnpm build` passes with no type errors
- [ ] Navigate to dashboard → Wallets & Credentials page
- [ ] Paste valid 64-hex wallet → click Register → see success message
- [ ] Register same wallet again → see "already registered" error (409)
- [ ] Type partial/invalid hex → button disabled, validation hint shows
- [ ] After successful registration, wallet appears in "Recent lookups"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet registration to the dashboard. Users can now register wallet addresses with built-in validation and immediate status feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->