### PR TITLE
feat(events): add version byte to ProofSettled and AttestationChecked

### DIFF
--- a/backend/crates/indexer/src/helius/parse.rs
+++ b/backend/crates/indexer/src/helius/parse.rs
@@ -52,6 +52,7 @@ mod tests {
 
     fn make_test_event() -> ProofSettled {
         ProofSettled {
+            version: 1,
             issuer: [9u8; 32],
             nullifier_hash: [8u8; 32],
             merkle_root: [7u8; 32],

--- a/backend/crates/indexer/src/irys/client.rs
+++ b/backend/crates/indexer/src/irys/client.rs
@@ -93,6 +93,7 @@ mod tests {
 
     fn fixture_event() -> ProofSettled {
         ProofSettled {
+            version: 1,
             issuer: [1u8; 32],
             nullifier_hash: [2u8; 32],
             merkle_root: [3u8; 32],

--- a/backend/crates/indexer/src/irys/mod.rs
+++ b/backend/crates/indexer/src/irys/mod.rs
@@ -86,6 +86,7 @@ mod tests {
 
     fn fixture_event() -> ProofSettled {
         ProofSettled {
+            version: 1,
             issuer: [1u8; 32],
             nullifier_hash: [2u8; 32],
             merkle_root: [3u8; 32],

--- a/backend/crates/indexer/src/irys/types.rs
+++ b/backend/crates/indexer/src/irys/types.rs
@@ -79,6 +79,7 @@ mod tests {
 
     fn test_event() -> ProofSettled {
         ProofSettled {
+            version: 1,
             issuer: [1u8; 32],
             nullifier_hash: [2u8; 32],
             merkle_root: [3u8; 32],

--- a/backend/crates/indexer/src/routes/webhook.rs
+++ b/backend/crates/indexer/src/routes/webhook.rs
@@ -218,6 +218,7 @@ mod tests {
         use zksettle_types::ProofSettled;
 
         let event = ProofSettled {
+            version: 1,
             issuer: [1u8; 32],
             nullifier_hash: [2u8; 32],
             merkle_root: [3u8; 32],
@@ -328,6 +329,7 @@ mod integration_tests {
 
     fn test_event() -> zksettle_types::ProofSettled {
         zksettle_types::ProofSettled {
+            version: 1,
             issuer: [1u8; 32],
             nullifier_hash: [9u8; 32],
             merkle_root: [3u8; 32],

--- a/backend/crates/zksettle-types/src/events.rs
+++ b/backend/crates/zksettle-types/src/events.rs
@@ -12,6 +12,7 @@ use crate::{Hash32, Pubkey};
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ProofSettled {
+    pub version: u8,
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,
     pub merkle_root: Hash32,
@@ -27,13 +28,14 @@ pub struct ProofSettled {
 }
 
 impl ProofSettled {
-    pub const LEN: usize = 32 * 8 + 8 * 4;
+    pub const LEN: usize = 1 + 32 * 8 + 8 * 4;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "borsh", derive(BorshSerialize, BorshDeserialize))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AttestationChecked {
+    pub version: u8,
     pub issuer: Pubkey,
     pub nullifier_hash: Hash32,
     pub slot: u64,
@@ -44,12 +46,13 @@ mod tests {
     use super::*;
 
     const PROOF_SETTLED_PAYLOAD_LEN: usize = ProofSettled::LEN;
-    const ATTESTATION_CHECKED_PAYLOAD_LEN: usize = 32 + 32 + 8;
+    const ATTESTATION_CHECKED_PAYLOAD_LEN: usize = 1 + 32 + 32 + 8;
 
     #[cfg(feature = "borsh")]
     #[test]
     fn proof_settled_borsh_roundtrip() {
         let original = ProofSettled {
+            version: 1,
             issuer: [9u8; 32],
             nullifier_hash: [8u8; 32],
             merkle_root: [7u8; 32],
@@ -73,6 +76,7 @@ mod tests {
     #[test]
     fn attestation_checked_borsh_roundtrip() {
         let original = AttestationChecked {
+            version: 1,
             issuer: [1u8; 32],
             nullifier_hash: [2u8; 32],
             slot: 999,

--- a/backend/crates/zksettle-types/src/lib.rs
+++ b/backend/crates/zksettle-types/src/lib.rs
@@ -69,6 +69,6 @@ mod tests {
     fn struct_sizes_available_without_serde_or_borsh() {
         assert_eq!(Issuer::LEN, 137);
         assert_eq!(CompressedAttestation::LEN, 288);
-        assert_eq!(ProofSettled::LEN, 288);
+        assert_eq!(ProofSettled::LEN, 289);
     }
 }

--- a/backend/programs/zksettle/src/instructions/check_attestation.rs
+++ b/backend/programs/zksettle/src/instructions/check_attestation.rs
@@ -26,6 +26,7 @@ pub struct CheckAttestation<'info> {
 
 #[event]
 pub struct AttestationChecked {
+    pub version: u8,
     pub issuer: Pubkey,
     pub nullifier_hash: [u8; 32],
     pub slot: u64,
@@ -87,6 +88,7 @@ pub fn check_handler<'info>(
         .map_err(crate::map_light_err!("Light CPI invoke failed", ZkSettleError::LightInvokeFailed))?;
 
     emit!(AttestationChecked {
+        version: 1,
         issuer: ctx.accounts.issuer.key(),
         nullifier_hash,
         slot,

--- a/backend/programs/zksettle/src/instructions/settle_core.rs
+++ b/backend/programs/zksettle/src/instructions/settle_core.rs
@@ -118,6 +118,7 @@ pub(crate) fn settle_core(params: SettlementParams<'_, '_>) -> Result<()> {
         ))?;
 
     emit!(ProofSettled {
+        version: 1,
         issuer: params.issuer_key,
         nullifier_hash: params.nullifier_hash,
         merkle_root: params.merkle_root,

--- a/backend/programs/zksettle/src/instructions/verify_proof/handler.rs
+++ b/backend/programs/zksettle/src/instructions/verify_proof/handler.rs
@@ -11,6 +11,7 @@ use super::VerifyProof;
 
 #[event]
 pub struct ProofSettled {
+    pub version: u8,
     pub issuer: Pubkey,
     pub nullifier_hash: [u8; 32],
     pub merkle_root: [u8; 32],


### PR DESCRIPTION
1-byte version field (set to 1) as the first field in both on-chain event structs. Allows the indexer to handle schema evolution without breaking existing event parsing. Must land before mainnet.

Relates to #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated event payloads to include a version field.
  * Updated event emission code and test fixtures to align with the new event structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->