### PR TITLE
refactor: replace hardcoded API key with HttpOnly cookie (closes #154)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,10 @@
+# ── Postgres (shared by gateway + indexer) ──────────────────
+# Required: any non-empty string for local dev; rotate to a real secret in prod.
+# Don't commit a real production password — keep prod values in your secret manager.
+POSTGRES_USER=zksettle
+POSTGRES_PASSWORD=zksettle_dev
+POSTGRES_DB=zksettle_gateway
+
 # ── API Gateway ──────────────────────────────────────────────
 GATEWAY_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway
 GATEWAY_PORT=4000

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ GATEWAY_ADMIN_KEY=
 GATEWAY_ALLOW_OPEN_KEYS=true
 GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:3000
 GATEWAY_LOG_LEVEL=info
+# Signs SIWS session JWTs. Any random non-empty string for local dev; rotate
+# to a 32+ byte cryptographically random secret in prod (e.g. `openssl rand -base64 48`).
+GATEWAY_JWT_SECRET=
+# Domain the gateway expects in the SIWS-signed message (must match the browser host).
+# Local dev default is localhost:3000; in prod set to the deployed app domain.
+GATEWAY_SIWS_DOMAIN=localhost:3000
 
 # ── Indexer ──────────────────────────────────────────────────
 INDEXER_PORT=3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       GATEWAY_INDEXER_URL: "http://indexer:3001"
       GATEWAY_DATABASE_URL: "postgres://zksettle:zksettle_dev@postgres:5432/zksettle_gateway"
       GATEWAY_ALLOW_OPEN_KEYS: "true"
+      GATEWAY_JWT_SECRET: "${GATEWAY_JWT_SECRET:?set GATEWAY_JWT_SECRET}"
+      GATEWAY_SIWS_DOMAIN: "${GATEWAY_SIWS_DOMAIN:-localhost:3000}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   postgres:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: zksettle
-      POSTGRES_PASSWORD: zksettle_dev
-      POSTGRES_DB: zksettle_gateway
+      POSTGRES_USER: "${POSTGRES_USER:-zksettle}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD (any non-empty string for local dev; rotate in prod)}"
+      POSTGRES_DB: "${POSTGRES_DB:-zksettle_gateway}"
     ports:
       - "5432:5432"
     volumes:
@@ -27,7 +27,7 @@ services:
       GATEWAY_PORT: "4000"
       GATEWAY_UPSTREAM_URL: "http://issuer-service:3000"
       GATEWAY_INDEXER_URL: "http://indexer:3001"
-      GATEWAY_DATABASE_URL: "postgres://zksettle:zksettle_dev@postgres:5432/zksettle_gateway"
+      GATEWAY_DATABASE_URL: "postgres://${POSTGRES_USER:-zksettle}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-zksettle_gateway}"
       GATEWAY_ALLOW_OPEN_KEYS: "true"
       GATEWAY_JWT_SECRET: "${GATEWAY_JWT_SECRET:?set GATEWAY_JWT_SECRET}"
       GATEWAY_SIWS_DOMAIN: "${GATEWAY_SIWS_DOMAIN:-localhost:3000}"
@@ -61,7 +61,7 @@ services:
       INDEXER_PORT: "3001"
       INDEXER_HELIUS_AUTH_TOKEN: "${INDEXER_HELIUS_AUTH_TOKEN:?set INDEXER_HELIUS_AUTH_TOKEN}"
       INDEXER_PROGRAM_ID: "${INDEXER_PROGRAM_ID:?set INDEXER_PROGRAM_ID}"
-      INDEXER_DATABASE_URL: "postgres://zksettle:zksettle_dev@postgres:5432/zksettle_gateway"
+      INDEXER_DATABASE_URL: "postgres://${POSTGRES_USER:-zksettle}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-zksettle_gateway}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,16 +1,17 @@
 # Public site URL - used as metadataBase for OG/Twitter tags.
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
-# zksettle api-gateway base URL (no trailing slash).
-# The gateway must include this origin in `GATEWAY_CORS_ALLOWED_ORIGINS`,
-# otherwise the browser will block every request.
+# zksettle api-gateway base URL (no trailing slash). Used server-side by the
+# Next.js proxy at /api/proxy/[...path] — browser code never calls the gateway
+# directly, so this no longer needs to be in `GATEWAY_CORS_ALLOWED_ORIGINS`.
+GATEWAY_BASE_URL=http://localhost:4000
+# Legacy/public alias — kept for backward compatibility with code that still
+# reads NEXT_PUBLIC_API_BASE_URL. Safe to remove once nothing references it.
 NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
 
 # Solana RPC endpoint and cluster used by wallet adapter.
 NEXT_PUBLIC_SOLANA_RPC_URL=https://api.devnet.solana.com
 NEXT_PUBLIC_SOLANA_NETWORK=devnet
 
-# Provisioned via POST /api-keys. NOTE: NEXT_PUBLIC_* is shipped in the bundle -
-# this env is acceptable for local dev only. Production must inject the key
-# server-side via a Route Handler proxy or HttpOnly cookie.
-NEXT_PUBLIC_API_KEY=
+# Active API keys are now selected at runtime in the dashboard and stored as
+# an HttpOnly cookie (`zks_active_key`). No NEXT_PUBLIC_API_KEY required.

--- a/frontend/INTEGRATION.md
+++ b/frontend/INTEGRATION.md
@@ -95,7 +95,7 @@ NEXT_PUBLIC_API_BASE_URL=http://localhost:4000
 ```
 
 Notas:
-- ~~`NEXT_PUBLIC_API_KEY`~~ foi removido. A API key agora é selecionada pelo usuário na dashboard e armazenada em `localStorage` (`zks.active_api_key`). O `apiFetch` lê a key ativa via `getActiveApiKey()` e injeta `Authorization: Bearer` automaticamente. Ver §4.2.
+- ~~`NEXT_PUBLIC_API_KEY`~~ foi removido. A API key ativa é selecionada pelo usuário na dashboard e armazenada como **cookie HttpOnly** (`zks_active_key`) — JS no browser não consegue ler. Todas as chamadas ao gateway passam pelo proxy server-side `/api/proxy/[...path]`, que lê o cookie e injeta `Authorization: Bearer` antes de encaminhar. Ver §4.2.
 - Backend roda em `:4000` por padrão (`GATEWAY_PORT`). O issuer-service em `:3000` é interno — **não chamar direto**.
 
 ### 3.3 ✅ CORS (implementado)
@@ -113,16 +113,16 @@ export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:4000";
 ```
 
-`API_KEY` foi removido — a key ativa vem de `localStorage` via `src/lib/api/active-key.ts`.
+`API_KEY` foi removido — a key ativa é gerenciada server-side via cookie HttpOnly e o frontend nunca a manipula diretamente.
 
 ### 4.2 `src/lib/api/client.ts`
 
-Wrapper `fetch` com auth + error parsing. Sem retry (deixa pro react-query). No browser, injeta `Authorization: Bearer` a partir da key ativa em `localStorage`. Para rotas wallet-scoped (`/credentials/`, `/proofs/membership/`, `/proofs/sanctions/`, `/proofs/jurisdiction/`), injeta `x-wallet-signature` e `x-wallet-timestamp` via `wallet-auth.ts`.
+Wrapper `fetch` com error parsing. Sem retry (deixa pro react-query). Não envia mais `Authorization` direto — chamadas vão para `/api/proxy/[...path]` (mesma origem), e o Route Handler server-side lê o cookie HttpOnly `zks_active_key` e injeta `Authorization: Bearer` antes de encaminhar ao gateway. Para rotas wallet-scoped (`/credentials/`, `/proofs/membership/`, `/proofs/sanctions/`, `/proofs/jurisdiction/`), o browser ainda injeta `x-wallet-signature` e `x-wallet-timestamp` (a assinatura precisa da wallet) — o proxy os encaminha sem alteração.
 
 ```ts
-import { API_BASE_URL } from "../config";
-import { getActiveApiKey } from "./active-key";
 import { getWalletAuthHeaders, isWalletScopedPath } from "./wallet-auth";
+
+const PROXY_BASE = "/api/proxy";
 
 export class ApiError extends Error {
   constructor(public status: number, public body: unknown, message: string) {
@@ -136,21 +136,15 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
     ...(init.headers as Record<string, string>),
   };
 
-  const isBrowser = globalThis.window !== undefined;
-  if (isBrowser && !headers.Authorization) {
-    const activeKey = getActiveApiKey();
-    if (activeKey) {
-      headers.Authorization = `Bearer ${activeKey}`;
-    }
-  }
   if (isWalletScopedPath(path)) {
     const walletHeaders = await getWalletAuthHeaders();
     Object.assign(headers, walletHeaders);
   }
 
-  const res = await fetch(`${API_BASE_URL}${path}`, {
+  const res = await fetch(`${PROXY_BASE}${path}`, {
     ...init,
     headers,
+    credentials: "same-origin",
   });
 
   if (!res.ok) {
@@ -383,13 +377,14 @@ Pré-requisitos para fechar a dashboard:
 
 A dashboard usa dois mecanismos de auth complementares:
 
-### 7.1 API key — seleção pelo usuário
+### 7.1 API key — seleção pelo usuário (HttpOnly cookie)
 
 1. Usuário provisiona keys via `/dashboard/api-keys` (`POST /api-keys`).
-2. Seleciona a key ativa no `ApiKeySelector` (sidebar/drawer).
-3. Key armazenada em `localStorage` (`zks.active_api_key`) via `src/lib/api/active-key.ts`.
-4. `apiFetch` lê a key ativa e injeta `Authorization: Bearer` em todas as chamadas browser-side.
-5. `NoKeyGuard` no layout + `RequireApiKey` por página impedem uso sem key selecionada.
+2. Ao criar uma key (ou colá-la na gate), o frontend faz `POST /api/active-key` no Next.js server.
+3. O Route Handler valida o formato e seta um cookie **HttpOnly + SameSite=Lax + Secure (prod)** chamado `zks_active_key`. JS no browser nunca lê o valor.
+4. Todas as chamadas ao gateway são feitas para `/api/proxy/[...path]` (mesma origem). O proxy server-side lê o cookie e injeta `Authorization: Bearer` antes de encaminhar.
+5. `RequireApiKey` por página chama `GET /api/active-key/status` (que retorna apenas `{ hasKey, prefix }`) e mostra a gate enquanto não houver key ativa.
+6. `DELETE /api/active-key` limpa o cookie. Na revoke de uma key que está ativa, o panel chama esse endpoint automaticamente para evitar bearer "morto".
 
 ### 7.2 Wallet auth — endpoints per-wallet
 
@@ -400,9 +395,11 @@ Rotas de credential/proof (`/v1/credentials/{wallet}`, `/v1/proofs/*/{wallet}`) 
 3. `apiFetch` detecta rotas wallet-scoped e injeta `x-wallet-signature` + `x-wallet-timestamp` automaticamente.
 4. Signature cacheada por 240s (refresh antes da janela de 300s do servidor).
 
-### 7.3 Futuro (produção)
+### 7.3 CSRF & próximos passos
 
-Para produção, migrar a API key de `localStorage` para cookie HttpOnly via Route Handler — elimina exposição no DevTools. O mecanismo wallet auth já é seguro (signature efêmera, não armazena segredos).
+- `SameSite=Lax` bloqueia que outros sites disparem `POST`/`DELETE` cross-site carregando o cookie. Suficiente para v1. Se um dia houver embed cross-site, adicionar token CSRF no header.
+- Cookie tem `Max-Age` de 7 dias. Para idle-timeout mais agressivo, renovar o cookie em cada request server-side.
+- Wallet auth (signature efêmera) continua igual — sem segredos persistidos.
 
 ---
 
@@ -414,6 +411,6 @@ Para produção, migrar a API key de `localStorage` para cookie HttpOnly via Rou
 4. ✅ Pivot `/dashboard/counterparties` → "Issuer Status" usando `useRoots()`.
 5. ✅ Pivot `/dashboard/transactions` → "Wallets & Credentials".
 6. ✅ Wire `/dashboard/audit-log` em `useEvents(limit, filters)` — cursor pagination + filtros server-side (range, issuer, recipient).
-7. ✅ Active API key (localStorage) + wallet auth + `NoKeyGuard` + `RequireApiKey` — substitui `NEXT_PUBLIC_API_KEY`.
+7. ✅ Active API key (HttpOnly cookie) + wallet auth + `RequireApiKey` — substitui `NEXT_PUBLIC_API_KEY` e elimina exposição via XSS/localStorage.
 8. ✅ `/dashboard/prove` — flow E2E com proof generation in-browser + on-chain submission via SDK `wrap()`.
 9. Aguardando §6.3 (invoices) — único bloqueio é decisão de produto.

--- a/frontend/src/app/api/active-key/route.ts
+++ b/frontend/src/app/api/active-key/route.ts
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import {
+  ACTIVE_KEY_COOKIE,
+  KEY_FORMAT,
+  clearActiveKeyCookie,
+  setActiveKeyCookie,
+} from "@/lib/server/active-key-cookie";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const key = (body as { key?: unknown })?.key;
+  if (typeof key !== "string" || !KEY_FORMAT.test(key)) {
+    return NextResponse.json({ error: "invalid_key_format" }, { status: 400 });
+  }
+
+  const res = NextResponse.json({ ok: true });
+  setActiveKeyCookie(res, key);
+  return res;
+}
+
+export async function DELETE() {
+  const store = await cookies();
+  if (!store.get(ACTIVE_KEY_COOKIE)) {
+    return NextResponse.json({ ok: true, cleared: false });
+  }
+  const res = NextResponse.json({ ok: true, cleared: true });
+  clearActiveKeyCookie(res);
+  return res;
+}

--- a/frontend/src/app/api/active-key/status/route.ts
+++ b/frontend/src/app/api/active-key/status/route.ts
@@ -1,0 +1,21 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { ACTIVE_KEY_COOKIE, keyPrefix } from "@/lib/server/active-key-cookie";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const store = await cookies();
+  const key = store.get(ACTIVE_KEY_COOKIE)?.value;
+  if (!key) {
+    return NextResponse.json(
+      { hasKey: false },
+      { headers: { "cache-control": "no-store" } },
+    );
+  }
+  return NextResponse.json(
+    { hasKey: true, prefix: keyPrefix(key) },
+    { headers: { "cache-control": "no-store" } },
+  );
+}

--- a/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/frontend/src/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,92 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { ACTIVE_KEY_COOKIE } from "@/lib/server/active-key-cookie";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const GATEWAY_BASE_URL =
+  process.env.GATEWAY_BASE_URL ??
+  process.env.NEXT_PUBLIC_API_BASE_URL ??
+  "http://localhost:4000";
+
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "cookie",
+  "content-length",
+]);
+
+interface RouteContext {
+  params: Promise<{ path: string[] }>;
+}
+
+async function forward(request: Request, context: RouteContext): Promise<Response> {
+  const { path } = await context.params;
+  const search = new URL(request.url).search;
+  const targetPath = `/${(path ?? []).join("/")}${search}`;
+  const targetUrl = `${GATEWAY_BASE_URL}${targetPath}`;
+
+  const headers = new Headers();
+  request.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) {
+      headers.set(key, value);
+    }
+  });
+
+  const cookieStore = await cookies();
+  const apiKey = cookieStore.get(ACTIVE_KEY_COOKIE)?.value;
+  if (apiKey && !headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${apiKey}`);
+  }
+
+  const method = request.method.toUpperCase();
+  const hasBody = method !== "GET" && method !== "HEAD";
+
+  const init: RequestInit = {
+    method,
+    headers,
+    redirect: "manual",
+  };
+  if (hasBody) {
+    init.body = await request.arrayBuffer();
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(targetUrl, init);
+  } catch (err) {
+    return NextResponse.json(
+      { error: "upstream_unreachable", message: (err as Error).message },
+      { status: 502 },
+    );
+  }
+
+  const responseHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase()) && key.toLowerCase() !== "set-cookie") {
+      responseHeaders.set(key, value);
+    }
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: responseHeaders,
+  });
+}
+
+export const GET = forward;
+export const POST = forward;
+export const PUT = forward;
+export const PATCH = forward;
+export const DELETE = forward;
+export const OPTIONS = forward;

--- a/frontend/src/app/api/proxy/[...path]/route.ts
+++ b/frontend/src/app/api/proxy/[...path]/route.ts
@@ -11,6 +11,8 @@ const GATEWAY_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ??
   "http://localhost:4000";
 
+// Headers we never forward in either direction. Cookie/Set-Cookie are
+// rewritten below to strip our own active-key cookie.
 const HOP_BY_HOP = new Set([
   "connection",
   "keep-alive",
@@ -21,12 +23,20 @@ const HOP_BY_HOP = new Set([
   "transfer-encoding",
   "upgrade",
   "host",
-  "cookie",
   "content-length",
 ]);
 
 interface RouteContext {
   params: Promise<{ path: string[] }>;
+}
+
+function stripActiveKeyCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) return null;
+  const kept = cookieHeader
+    .split(/;\s*/)
+    .filter((pair) => !pair.startsWith(`${ACTIVE_KEY_COOKIE}=`))
+    .join("; ");
+  return kept.length > 0 ? kept : null;
 }
 
 async function forward(request: Request, context: RouteContext): Promise<Response> {
@@ -37,11 +47,17 @@ async function forward(request: Request, context: RouteContext): Promise<Respons
 
   const headers = new Headers();
   request.headers.forEach((value, key) => {
-    if (!HOP_BY_HOP.has(key.toLowerCase())) {
-      headers.set(key, value);
-    }
+    const lower = key.toLowerCase();
+    if (HOP_BY_HOP.has(lower)) return;
+    if (lower === "cookie") return; // handled below
+    headers.set(key, value);
   });
 
+  // Forward all cookies EXCEPT our active-key cookie (server-only secret).
+  const forwardedCookies = stripActiveKeyCookie(request.headers.get("cookie"));
+  if (forwardedCookies) headers.set("cookie", forwardedCookies);
+
+  // Inject the bearer token from the active-key cookie.
   const cookieStore = await cookies();
   const apiKey = cookieStore.get(ACTIVE_KEY_COOKIE)?.value;
   if (apiKey && !headers.has("authorization")) {
@@ -72,9 +88,13 @@ async function forward(request: Request, context: RouteContext): Promise<Respons
 
   const responseHeaders = new Headers();
   upstream.headers.forEach((value, key) => {
-    if (!HOP_BY_HOP.has(key.toLowerCase()) && key.toLowerCase() !== "set-cookie") {
-      responseHeaders.set(key, value);
+    if (HOP_BY_HOP.has(key.toLowerCase())) return;
+    // Set-Cookie can repeat — Headers#set would collapse it. Use append.
+    if (key.toLowerCase() === "set-cookie") {
+      responseHeaders.append("set-cookie", value);
+      return;
     }
+    responseHeaders.set(key, value);
   });
 
   return new Response(upstream.body, {

--- a/frontend/src/components/dashboard/api-keys-panel.tsx
+++ b/frontend/src/components/dashboard/api-keys-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Copy, Trash, WarningTriangle } from "iconoir-react";
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type SyntheticEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,7 +56,7 @@ function describeError(err: unknown): string {
 }
 
 function displayPrefix(keyHash: string): string {
-  const cached = typeof window === "undefined" ? null : lookupKeyPrefix(keyHash);
+  const cached = globalThis.window === undefined ? null : lookupKeyPrefix(keyHash);
   if (cached) return cached;
   return `hash ${keyHash.slice(0, 8)}…${keyHash.slice(-4)}`;
 }
@@ -87,10 +87,7 @@ export function ApiKeysPanel() {
     };
   }, []);
 
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const trimmed = owner.trim();
-    if (!trimmed || createKey.isPending) return;
+  const runCreate = async (trimmed: string): Promise<void> => {
     try {
       const created = await createKey.mutateAsync(trimmed);
       setRevealed(created);
@@ -99,6 +96,13 @@ export function ApiKeysPanel() {
     } catch {
       // surfaced via createKey.error
     }
+  };
+
+  const submit = (event: SyntheticEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = owner.trim();
+    if (!trimmed || createKey.isPending) return;
+    void runCreate(trimmed);
   };
 
   const dismissReveal = async () => {
@@ -339,7 +343,7 @@ interface RevealKeyDialogProps {
   onDismiss: () => void;
 }
 
-function RevealKeyDialog({ created, copied, onCopy, onDismiss }: RevealKeyDialogProps) {
+function RevealKeyDialog({ created, copied, onCopy, onDismiss }: Readonly<RevealKeyDialogProps>) {
   const ref = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
@@ -380,7 +384,8 @@ function RevealKeyDialog({ created, copied, onCopy, onDismiss }: RevealKeyDialog
             </h2>
             <p className="text-sm text-stone">
               We won&apos;t show it again. Store it in your secret manager before closing
-              this dialog. The key is also set as your active key (HttpOnly cookie).
+              this dialog. After you close this dialog, it will be set as your
+              active key (stored as an HttpOnly cookie, never visible to JS).
             </p>
           </div>
         </div>
@@ -416,7 +421,7 @@ interface RevokeConfirmDialogProps {
   onConfirm: () => void;
 }
 
-function RevokeConfirmDialog({ target, onCancel, onConfirm }: RevokeConfirmDialogProps) {
+function RevokeConfirmDialog({ target, onCancel, onConfirm }: Readonly<RevokeConfirmDialogProps>) {
   const ref = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {

--- a/frontend/src/components/dashboard/api-keys-panel.tsx
+++ b/frontend/src/components/dashboard/api-keys-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Copy, Trash, WarningTriangle } from "iconoir-react";
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,6 +13,13 @@ import {
   type CreatedKey,
 } from "@/hooks/use-api-keys";
 import { ApiError } from "@/lib/api/client";
+import {
+  clearActiveApiKey,
+  fetchActiveKeyStatus,
+  onActiveKeyChanged,
+  setActiveApiKey,
+  type ActiveKeyStatus,
+} from "@/lib/api/active-key";
 import type { ListedKey, Tier } from "@/lib/api/schemas";
 
 const TIER_LABEL: Record<Tier, string> = {
@@ -35,7 +42,7 @@ function formatDate(unixSeconds: number): string {
 function describeError(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.status === 401 || err.status === 403) {
-      return "Not authorized. Set NEXT_PUBLIC_API_KEY to your admin key, or set GATEWAY_ALLOW_OPEN_KEYS=true on the gateway.";
+      return "Not authorized. Select an active API key in the sidebar, or set GATEWAY_ALLOW_OPEN_KEYS=true on the gateway.";
     }
     if (err.status === 500) {
       return "Key administration is disabled on the gateway. Set GATEWAY_ADMIN_KEY or GATEWAY_ALLOW_OPEN_KEYS=true.";
@@ -62,6 +69,23 @@ export function ApiKeysPanel() {
   const [owner, setOwner] = useState("");
   const [revealed, setRevealed] = useState<CreatedKey | null>(null);
   const [copied, setCopied] = useState(false);
+  const [pendingRevoke, setPendingRevoke] = useState<ListedKey | null>(null);
+  const [activePrefix, setActivePrefix] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async () => {
+      const fallback: ActiveKeyStatus = { hasKey: false };
+      const status = await fetchActiveKeyStatus().catch(() => fallback);
+      if (!cancelled) setActivePrefix(status.hasKey ? status.prefix ?? null : null);
+    };
+    void refresh();
+    const off = onActiveKeyChanged(() => void refresh());
+    return () => {
+      cancelled = true;
+      off();
+    };
+  }, []);
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -72,6 +96,12 @@ export function ApiKeysPanel() {
       setRevealed(created);
       setOwner("");
       setCopied(false);
+      // Auto-activate the freshly created key as the active one.
+      try {
+        await setActiveApiKey(created.api_key);
+      } catch {
+        // surfaced via subsequent UI checks; not fatal here.
+      }
     } catch {
       // surfaced via createKey.error
     }
@@ -88,14 +118,21 @@ export function ApiKeysPanel() {
     }
   };
 
-  const onRevoke = async (key: ListedKey) => {
-    const confirmed = window.confirm(
-      `Revoke key "${displayPrefix(key.key_hash)}" owned by "${key.owner}"? This cannot be undone.`,
-    );
-    if (!confirmed) return;
+  const requestRevoke = (key: ListedKey) => {
     deleteKey.reset();
+    setPendingRevoke(key);
+  };
+
+  const confirmRevoke = async () => {
+    if (!pendingRevoke) return;
+    const target = pendingRevoke;
+    const targetPrefix = lookupKeyPrefix(target.key_hash);
+    setPendingRevoke(null);
     try {
-      await deleteKey.mutateAsync(key.key_hash);
+      await deleteKey.mutateAsync(target.key_hash);
+      if (targetPrefix && activePrefix && targetPrefix === activePrefix) {
+        await clearActiveApiKey();
+      }
     } catch {
       // surfaced via deleteKey.error
     }
@@ -222,37 +259,47 @@ export function ApiKeysPanel() {
               </tr>
             </thead>
             <tbody>
-              {keys.map((key) => (
-                <tr
-                  key={key.key_hash}
-                  className="border-b border-border-subtle text-quill last:border-b-0"
-                >
-                  <td className="py-3 pr-3 font-mono text-ink">
-                    {displayPrefix(key.key_hash)}
-                  </td>
-                  <td className="py-3 pr-3">{key.owner}</td>
-                  <td className="py-3 pr-3 font-mono text-stone">{TIER_LABEL[key.tier]}</td>
-                  <td className="py-3 pr-3 font-mono text-xs text-stone">
-                    {formatDate(key.created_at)}
-                  </td>
-                  <td className="py-3 text-right">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      aria-label={`Revoke key ${displayPrefix(key.key_hash)}`}
-                      disabled={
-                        deleteKey.isPending && deleteKey.variables === key.key_hash
-                      }
-                      onClick={() => onRevoke(key)}
-                    >
-                      <Trash aria-hidden="true" className="size-4" />
-                      {deleteKey.isPending && deleteKey.variables === key.key_hash
-                        ? "Revoking…"
-                        : "Revoke"}
-                    </Button>
-                  </td>
-                </tr>
-              ))}
+              {keys.map((key) => {
+                const prefix = displayPrefix(key.key_hash);
+                const isActive =
+                  activePrefix !== null && lookupKeyPrefix(key.key_hash) === activePrefix;
+                return (
+                  <tr
+                    key={key.key_hash}
+                    className="border-b border-border-subtle text-quill last:border-b-0"
+                  >
+                    <td className="py-3 pr-3 font-mono text-ink">
+                      {prefix}
+                      {isActive ? (
+                        <span className="ml-2 rounded-full border border-emerald/40 bg-emerald/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-emerald">
+                          active
+                        </span>
+                      ) : null}
+                    </td>
+                    <td className="py-3 pr-3">{key.owner}</td>
+                    <td className="py-3 pr-3 font-mono text-stone">{TIER_LABEL[key.tier]}</td>
+                    <td className="py-3 pr-3 font-mono text-xs text-stone">
+                      {formatDate(key.created_at)}
+                    </td>
+                    <td className="py-3 text-right">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label={`Revoke key ${prefix}`}
+                        disabled={
+                          deleteKey.isPending && deleteKey.variables === key.key_hash
+                        }
+                        onClick={() => requestRevoke(key)}
+                      >
+                        <Trash aria-hidden="true" className="size-4" />
+                        {deleteKey.isPending && deleteKey.variables === key.key_hash
+                          ? "Revoking…"
+                          : "Revoke"}
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         ) : null}
@@ -264,6 +311,14 @@ export function ApiKeysPanel() {
           copied={copied}
           onCopy={copyKey}
           onDismiss={() => setRevealed(null)}
+        />
+      ) : null}
+
+      {pendingRevoke ? (
+        <RevokeConfirmDialog
+          target={pendingRevoke}
+          onCancel={() => setPendingRevoke(null)}
+          onConfirm={confirmRevoke}
         />
       ) : null}
     </div>
@@ -278,14 +333,29 @@ interface RevealKeyDialogProps {
 }
 
 function RevealKeyDialog({ created, copied, onCopy, onDismiss }: RevealKeyDialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (!dialog.open) dialog.showModal();
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
+    <dialog
+      ref={ref}
       aria-labelledby="reveal-key-heading"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
+      onCancel={(event) => {
+        event.preventDefault();
+        onDismiss();
+      }}
+      onClose={onDismiss}
+      className="m-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-lg backdrop:bg-ink/40"
     >
-      <div className="w-full max-w-lg rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-lg">
+      <div className="w-full max-w-lg">
         <div className="flex items-start gap-3">
           <WarningTriangle aria-hidden="true" className="mt-1 size-5 shrink-0 text-rust" />
           <div className="flex flex-col gap-1">
@@ -297,7 +367,7 @@ function RevealKeyDialog({ created, copied, onCopy, onDismiss }: RevealKeyDialog
             </h2>
             <p className="text-sm text-stone">
               We won&apos;t show it again. Store it in your secret manager before closing
-              this dialog.
+              this dialog. The key is also set as your active key (HttpOnly cookie).
             </p>
           </div>
         </div>
@@ -323,6 +393,58 @@ function RevealKeyDialog({ created, copied, onCopy, onDismiss }: RevealKeyDialog
           </Button>
         </div>
       </div>
-    </div>
+    </dialog>
+  );
+}
+
+interface RevokeConfirmDialogProps {
+  target: ListedKey;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function RevokeConfirmDialog({ target, onCancel, onConfirm }: RevokeConfirmDialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (!dialog.open) dialog.showModal();
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  return (
+    <dialog
+      ref={ref}
+      aria-labelledby="revoke-key-heading"
+      onCancel={(event) => {
+        event.preventDefault();
+        onCancel();
+      }}
+      onClose={onCancel}
+      className="m-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-lg backdrop:bg-ink/40"
+    >
+      <div className="w-full max-w-md">
+        <h2 id="revoke-key-heading" className="font-display text-xl text-ink">
+          Revoke API key?
+        </h2>
+        <p className="mt-2 text-sm text-stone">
+          This will permanently revoke{" "}
+          <span className="font-mono text-ink">{displayPrefix(target.key_hash)}</span>{" "}
+          owned by <span className="font-mono text-ink">{target.owner}</span>. This
+          cannot be undone.
+        </p>
+        <div className="mt-6 flex justify-end gap-2">
+          <Button variant="ghost" size="md" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="md" onClick={onConfirm}>
+            Revoke key
+          </Button>
+        </div>
+      </div>
+    </dialog>
   );
 }

--- a/frontend/src/components/dashboard/api-keys-panel.tsx
+++ b/frontend/src/components/dashboard/api-keys-panel.tsx
@@ -96,14 +96,21 @@ export function ApiKeysPanel() {
       setRevealed(created);
       setOwner("");
       setCopied(false);
-      // Auto-activate the freshly created key as the active one.
-      try {
-        await setActiveApiKey(created.api_key);
-      } catch {
-        // surfaced via subsequent UI checks; not fatal here.
-      }
     } catch {
       // surfaced via createKey.error
+    }
+  };
+
+  const dismissReveal = async () => {
+    const created = revealed;
+    setRevealed(null);
+    if (!created) return;
+    // Activate the new key as the cookie *after* the user dismisses the
+    // reveal — avoids a re-render cascade clobbering the dialog mid-display.
+    try {
+      await setActiveApiKey(created.api_key);
+    } catch {
+      // non-fatal: user can re-paste from their secret manager
     }
   };
 
@@ -310,7 +317,7 @@ export function ApiKeysPanel() {
           created={revealed}
           copied={copied}
           onCopy={copyKey}
-          onDismiss={() => setRevealed(null)}
+          onDismiss={dismissReveal}
         />
       ) : null}
 

--- a/frontend/src/components/dashboard/api-keys-panel.tsx
+++ b/frontend/src/components/dashboard/api-keys-panel.tsx
@@ -356,10 +356,16 @@ function RevealKeyDialog({ created, copied, onCopy, onDismiss }: RevealKeyDialog
       ref={ref}
       aria-labelledby="reveal-key-heading"
       onCancel={(event) => {
+        // Esc was pressed. preventDefault stops the browser's native close so
+        // we can dismiss through React state — otherwise the close event would
+        // race with our unmount-driven cleanup.
         event.preventDefault();
         onDismiss();
       }}
-      onClose={onDismiss}
+      // No onClose handler: the DOM "close" event also fires from the cleanup
+      // function below (which runs in dev under React Strict Mode's
+      // mount→cleanup→mount cycle). Wiring onClose to onDismiss would set
+      // revealed=null mid-mount and the user would never see the dialog.
       className="m-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-lg backdrop:bg-ink/40"
     >
       <div className="w-full max-w-lg">
@@ -430,7 +436,8 @@ function RevokeConfirmDialog({ target, onCancel, onConfirm }: RevokeConfirmDialo
         event.preventDefault();
         onCancel();
       }}
-      onClose={onCancel}
+      // See note in RevealKeyDialog: no onClose handler to avoid React Strict
+      // Mode's cleanup-triggered close event clobbering the dialog mid-mount.
       className="m-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-lg backdrop:bg-ink/40"
     >
       <div className="w-full max-w-md">

--- a/frontend/src/components/dashboard/attestation-explorer-panel.tsx
+++ b/frontend/src/components/dashboard/attestation-explorer-panel.tsx
@@ -60,7 +60,7 @@ function describeProofError(err: unknown): { kind: "not-found" | "auth" | "other
   if (err instanceof ApiError) {
     if (err.status === 404) return { kind: "not-found", message: "No proof found for this wallet." };
     if (err.status === 401 || err.status === 403)
-      return { kind: "auth", message: "Not authorized. Check NEXT_PUBLIC_API_KEY." };
+      return { kind: "auth", message: "Not authorized. Select an active API key in the sidebar." };
     return { kind: "other", message: err.message };
   }
   return { kind: "other", message: err instanceof Error ? err.message : "Unknown error" };

--- a/frontend/src/components/dashboard/audit-log-table.tsx
+++ b/frontend/src/components/dashboard/audit-log-table.tsx
@@ -53,7 +53,7 @@ function pluralizeEvents(count: number): string {
 function describeError(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.status === 401 || err.status === 403) {
-      return "Not authorized. Set NEXT_PUBLIC_API_KEY.";
+      return "Not authorized. Select an active API key in the sidebar.";
     }
     if (err.status === 502) {
       return "Indexer is unreachable from the gateway.";

--- a/frontend/src/components/dashboard/issuer-status-panel.tsx
+++ b/frontend/src/components/dashboard/issuer-status-panel.tsx
@@ -53,7 +53,7 @@ function rootDisplayValue(isLoading: boolean, value: string | undefined): string
 function describeError(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.status === 401 || err.status === 403) {
-      return "Not authorized. Check NEXT_PUBLIC_API_KEY.";
+      return "Not authorized. Select an active API key in the sidebar.";
     }
     if (err.status === 502) {
       return "Upstream issuer-service is unreachable.";

--- a/frontend/src/components/dashboard/require-api-key.tsx
+++ b/frontend/src/components/dashboard/require-api-key.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useId, useState, type ReactNode } from "react";
-import { Key } from "iconoir-react";
+import { Copy, Key, WarningTriangle } from "iconoir-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -62,6 +62,8 @@ function ApiKeyGate() {
   const [pasteMode, setPasteMode] = useState(false);
   const [pastedKey, setPastedKey] = useState("");
   const [activateError, setActivateError] = useState<string | null>(null);
+  const [revealedKey, setRevealedKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
   const pasteInputId = useId();
   const ownerInputId = useId();
 
@@ -71,11 +73,35 @@ function ApiKeyGate() {
     setActivateError(null);
     try {
       const result = await createKey.mutateAsync(owner || "dashboard");
-      await setActiveApiKey(result.api_key);
+      // Reveal the key first; activation happens on user confirmation so they
+      // have a chance to copy the secret before the gate closes.
+      setRevealedKey(result.api_key);
+      setCopied(false);
+    } catch (err) {
+      setActivateError(err instanceof Error ? err.message : "Failed to create key");
+    }
+  }, [createKey, owner]);
+
+  const handleConfirmReveal = useCallback(async () => {
+    if (!revealedKey) return;
+    setActivateError(null);
+    try {
+      await setActiveApiKey(revealedKey);
     } catch (err) {
       setActivateError(err instanceof Error ? err.message : "Failed to activate key");
     }
-  }, [createKey, owner]);
+  }, [revealedKey]);
+
+  const copyRevealedKey = useCallback(async () => {
+    if (!revealedKey) return;
+    try {
+      await navigator.clipboard.writeText(revealedKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }, [revealedKey]);
 
   const isPasteValid = KEY_FORMAT.test(pastedKey);
 
@@ -88,6 +114,53 @@ function ApiKeyGate() {
       setActivateError(err instanceof Error ? err.message : "Failed to activate key");
     }
   }, [pastedKey, isPasteValid]);
+
+  if (revealedKey) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center px-4">
+        <div className="w-full max-w-lg rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6">
+          <div className="flex items-start gap-3">
+            <WarningTriangle aria-hidden="true" className="mt-1 size-5 shrink-0 text-rust" />
+            <div className="flex flex-col gap-1">
+              <h2 className="font-display text-xl text-ink">Copy this key now</h2>
+              <p className="text-sm text-stone">
+                We won&apos;t show it again. Store it in your secret manager before
+                continuing — you&apos;ll need it for any non-dashboard usage (SDK, curl,
+                CI). The key will also be set as your active key in an HttpOnly cookie.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-5 flex items-center gap-2 rounded-[var(--radius-3)] border border-border-subtle bg-canvas p-3">
+            <code className="flex-1 break-all font-mono text-sm text-ink">
+              {revealedKey}
+            </code>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={copyRevealedKey}
+              aria-label="Copy API key"
+            >
+              <Copy aria-hidden="true" className="size-4" />
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+
+          {activateError && (
+            <p role="alert" className="mt-3 text-xs text-red-600">
+              {activateError}
+            </p>
+          )}
+
+          <div className="mt-6 flex justify-end">
+            <Button variant="primary" size="md" onClick={handleConfirmReveal}>
+              I saved it — continue
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-[40vh] items-center justify-center px-4">

--- a/frontend/src/components/dashboard/require-api-key.tsx
+++ b/frontend/src/components/dashboard/require-api-key.tsx
@@ -5,49 +5,89 @@ import { Key } from "iconoir-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { getActiveApiKey, setActiveApiKey } from "@/lib/api/active-key";
+import {
+  fetchActiveKeyStatus,
+  onActiveKeyChanged,
+  setActiveApiKey,
+  type ActiveKeyStatus,
+} from "@/lib/api/active-key";
 import { useApiKeys, useCreateApiKey, lookupKeyPrefix } from "@/hooks/use-api-keys";
 
+const KEY_FORMAT = /^zks_[A-Za-z0-9_-]{32,}$/;
+
 export function RequireApiKey({ children }: Readonly<{ children: ReactNode }>) {
-  const [hasKey, setHasKey] = useState<boolean | null>(null);
+  const [status, setStatus] = useState<ActiveKeyStatus | null>(null);
 
   useEffect(() => {
-    setHasKey(!!getActiveApiKey());
-
-    const handler = () => setHasKey(!!getActiveApiKey());
-    globalThis.addEventListener("zks:active-key-changed", handler);
-    return () => globalThis.removeEventListener("zks:active-key-changed", handler);
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const next = await fetchActiveKeyStatus();
+        if (!cancelled) setStatus(next);
+      } catch {
+        if (!cancelled) setStatus({ hasKey: false });
+      }
+    };
+    void refresh();
+    const off = onActiveKeyChanged(() => void refresh());
+    return () => {
+      cancelled = true;
+      off();
+    };
   }, []);
 
-  if (hasKey === null) return null;
-  if (hasKey) return <>{children}</>;
+  if (status === null) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        className="flex min-h-[40vh] items-center justify-center px-4"
+      >
+        <div className="h-32 w-full max-w-md animate-pulse rounded-[var(--radius-6)] border border-border-subtle bg-surface" />
+        <span className="sr-only">Checking active API key…</span>
+      </div>
+    );
+  }
 
-  return <ApiKeyGate onSelected={() => setHasKey(true)} />;
+  if (status.hasKey) return <>{children}</>;
+
+  return <ApiKeyGate />;
 }
 
-function ApiKeyGate({ onSelected }: Readonly<{ onSelected: () => void }>) {
+function ApiKeyGate() {
   const { data, isLoading, isError, refetch } = useApiKeys();
   const createKey = useCreateApiKey();
   const [owner, setOwner] = useState("");
+  const [pasteMode, setPasteMode] = useState(false);
+  const [pastedKey, setPastedKey] = useState("");
+  const [activateError, setActivateError] = useState<string | null>(null);
   const pasteInputId = useId();
   const ownerInputId = useId();
 
   const keys = data?.keys ?? [];
 
   const handleCreate = useCallback(async () => {
-    const result = await createKey.mutateAsync(owner || "dashboard");
-    setActiveApiKey(result.api_key);
-    onSelected();
-  }, [createKey, owner, onSelected]);
+    setActivateError(null);
+    try {
+      const result = await createKey.mutateAsync(owner || "dashboard");
+      await setActiveApiKey(result.api_key);
+    } catch (err) {
+      setActivateError(err instanceof Error ? err.message : "Failed to activate key");
+    }
+  }, [createKey, owner]);
 
-  const [pasteMode, setPasteMode] = useState(false);
-  const [pastedKey, setPastedKey] = useState("");
+  const isPasteValid = KEY_FORMAT.test(pastedKey);
 
-  const handlePaste = useCallback(() => {
-    if (!pastedKey.startsWith("zks_")) return;
-    setActiveApiKey(pastedKey);
-    onSelected();
-  }, [pastedKey, onSelected]);
+  const handlePaste = useCallback(async () => {
+    setActivateError(null);
+    if (!isPasteValid) return;
+    try {
+      await setActiveApiKey(pastedKey);
+    } catch (err) {
+      setActivateError(err instanceof Error ? err.message : "Failed to activate key");
+    }
+  }, [pastedKey, isPasteValid]);
 
   return (
     <div className="flex min-h-[40vh] items-center justify-center px-4">
@@ -57,8 +97,8 @@ function ApiKeyGate({ onSelected }: Readonly<{ onSelected: () => void }>) {
           <h2 className="text-sm font-medium">API key required</h2>
         </div>
         <p className="mt-2 text-xs leading-relaxed text-stone">
-          This page makes requests through the gateway proxy. Select an existing
-          API key or create a new one to continue.
+          Select an existing API key or create a new one to continue. The key is stored
+          server-side as an HttpOnly cookie — never exposed to JavaScript.
         </p>
 
         {isLoading && (
@@ -104,19 +144,23 @@ function ApiKeyGate({ onSelected }: Readonly<{ onSelected: () => void }>) {
               placeholder="zks_…"
               className="font-mono text-xs"
             />
+            {pastedKey && !isPasteValid && (
+              <p className="text-xs text-red-600">
+                Invalid format. Keys must match <code>zks_</code> followed by 32+ characters.
+              </p>
+            )}
             <div className="flex gap-2">
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={() => setPasteMode(false)}
+                onClick={() => {
+                  setPasteMode(false);
+                  setPastedKey("");
+                }}
               >
                 Back
               </Button>
-              <Button
-                size="sm"
-                onClick={handlePaste}
-                disabled={!pastedKey.startsWith("zks_")}
-              >
+              <Button size="sm" onClick={handlePaste} disabled={!isPasteValid}>
                 Use this key
               </Button>
             </div>
@@ -152,11 +196,12 @@ function ApiKeyGate({ onSelected }: Readonly<{ onSelected: () => void }>) {
           </div>
         )}
 
-        {createKey.isError && (
+        {(createKey.isError || activateError) && (
           <p className="mt-2 text-xs text-red-600">
-            {createKey.error instanceof Error
-              ? createKey.error.message
-              : "Failed to create key"}
+            {activateError ??
+              (createKey.error instanceof Error
+                ? createKey.error.message
+                : "Failed to create key")}
           </p>
         )}
       </div>

--- a/frontend/src/components/dashboard/wallets-credentials-panel.tsx
+++ b/frontend/src/components/dashboard/wallets-credentials-panel.tsx
@@ -36,7 +36,7 @@ function describeError(err: unknown): { kind: "not-found" | "auth" | "conflict" 
   if (err instanceof ApiError) {
     if (err.status === 404) return { kind: "not-found", message: "No credential for this wallet." };
     if (err.status === 401 || err.status === 403)
-      return { kind: "auth", message: "Not authorized. Check NEXT_PUBLIC_API_KEY." };
+      return { kind: "auth", message: "Not authorized. Select an active API key in the sidebar." };
     if (err.status === 409) return { kind: "conflict", message: "Wallet already has a credential." };
     if (err.status === 400) return { kind: "other", message: "Invalid wallet hex (need 64 chars)." };
     return { kind: "other", message: err.message };
@@ -49,7 +49,7 @@ function describeRegisterError(err: unknown): string {
     if (err.status === 409) return "Wallet is already registered in the membership tree.";
     if (err.status === 400) return "Invalid wallet hex (need exactly 64 hex characters).";
     if (err.status === 401 || err.status === 403)
-      return "Not authorized. Check NEXT_PUBLIC_API_KEY.";
+      return "Not authorized. Select an active API key in the sidebar.";
     return err.message;
   }
   return err instanceof Error ? err.message : "Unknown error";

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -42,11 +42,20 @@ export function useSignOut() {
 
   return useMutation({
     mutationFn: authSignOut,
-    onSuccess: async () => {
-      await clearActiveApiKey().catch(() => {});
-      queryClient.removeQueries();
+    // onSettled instead of onSuccess so we still tear the session down if the
+    // gateway's /auth/logout returns a non-2xx (already-expired session, etc).
+    onSettled: () => {
+      // Push null synchronously so subscribed observers (RequireAuth's
+      // useAuth) re-render immediately. removeQueries() alone unsubscribes
+      // observers without triggering re-renders, which is what was leaving
+      // the UI looking logged-in until a manual refresh.
+      queryClient.setQueryData(authMeQueryKey, null);
+      queryClient.clear();
       disconnect();
       router.replace("/login");
+      // Fire-and-forget: clearing the local active-key cookie shouldn't block
+      // the redirect.
+      void clearActiveApiKey().catch(() => {});
     },
   });
 }

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -42,8 +42,8 @@ export function useSignOut() {
 
   return useMutation({
     mutationFn: authSignOut,
-    onSuccess: () => {
-      clearActiveApiKey();
+    onSuccess: async () => {
+      await clearActiveApiKey().catch(() => {});
       queryClient.removeQueries();
       disconnect();
       router.replace("/login");

--- a/frontend/src/lib/api/active-key.ts
+++ b/frontend/src/lib/api/active-key.ts
@@ -29,20 +29,24 @@ export async function setActiveApiKey(key: string): Promise<void> {
 }
 
 export async function clearActiveApiKey(): Promise<void> {
-  await fetch("/api/active-key", {
+  const res = await fetch("/api/active-key", {
     method: "DELETE",
     credentials: "same-origin",
   });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `failed_to_clear_active_key_${res.status}`);
+  }
   notifyActiveKeyChanged();
 }
 
 function notifyActiveKeyChanged(): void {
-  if (typeof window === "undefined") return;
+  if (globalThis.window === undefined) return;
   globalThis.dispatchEvent(new CustomEvent(ACTIVE_KEY_CHANGED_EVENT));
 }
 
 export function onActiveKeyChanged(handler: () => void): () => void {
-  if (typeof window === "undefined") return () => {};
+  if (globalThis.window === undefined) return () => {};
   globalThis.addEventListener(ACTIVE_KEY_CHANGED_EVENT, handler);
   return () => globalThis.removeEventListener(ACTIVE_KEY_CHANGED_EVENT, handler);
 }

--- a/frontend/src/lib/api/active-key.ts
+++ b/frontend/src/lib/api/active-key.ts
@@ -1,18 +1,48 @@
-const STORAGE_KEY = "zks.active_api_key.v1";
-
-export function getActiveApiKey(): string | null {
-  if (globalThis.window === undefined) return null;
-  return globalThis.localStorage.getItem(STORAGE_KEY);
+export interface ActiveKeyStatus {
+  hasKey: boolean;
+  prefix?: string;
 }
 
-export function setActiveApiKey(key: string): void {
-  if (globalThis.window === undefined) return;
-  globalThis.localStorage.setItem(STORAGE_KEY, key);
-  globalThis.dispatchEvent(new CustomEvent("zks:active-key-changed"));
+const ACTIVE_KEY_CHANGED_EVENT = "zks:active-key-changed";
+
+export async function fetchActiveKeyStatus(): Promise<ActiveKeyStatus> {
+  const res = await fetch("/api/active-key/status", {
+    credentials: "same-origin",
+    cache: "no-store",
+  });
+  if (!res.ok) return { hasKey: false };
+  return (await res.json()) as ActiveKeyStatus;
 }
 
-export function clearActiveApiKey(): void {
-  if (globalThis.window === undefined) return;
-  globalThis.localStorage.removeItem(STORAGE_KEY);
-  globalThis.dispatchEvent(new CustomEvent("zks:active-key-changed"));
+export async function setActiveApiKey(key: string): Promise<void> {
+  const res = await fetch("/api/active-key", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `failed_to_set_active_key_${res.status}`);
+  }
+  notifyActiveKeyChanged();
+}
+
+export async function clearActiveApiKey(): Promise<void> {
+  await fetch("/api/active-key", {
+    method: "DELETE",
+    credentials: "same-origin",
+  });
+  notifyActiveKeyChanged();
+}
+
+function notifyActiveKeyChanged(): void {
+  if (typeof window === "undefined") return;
+  globalThis.dispatchEvent(new CustomEvent(ACTIVE_KEY_CHANGED_EVENT));
+}
+
+export function onActiveKeyChanged(handler: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  globalThis.addEventListener(ACTIVE_KEY_CHANGED_EVENT, handler);
+  return () => globalThis.removeEventListener(ACTIVE_KEY_CHANGED_EVENT, handler);
 }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,6 +1,6 @@
-import { API_BASE_URL } from "../config";
-import { getActiveApiKey } from "./active-key";
 import { getWalletAuthHeaders, isWalletScopedPath } from "./wallet-auth";
+
+const PROXY_BASE = "/api/proxy";
 
 export class ApiError extends Error {
   constructor(
@@ -19,20 +19,15 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
     ...(init.headers as Record<string, string>),
   };
 
-  const activeKey = getActiveApiKey();
-  if (activeKey && !headers.Authorization) {
-    headers.Authorization = `Bearer ${activeKey}`;
-  }
-
   if (isWalletScopedPath(path)) {
     const walletHeaders = await getWalletAuthHeaders();
     Object.assign(headers, walletHeaders);
   }
 
-  const res = await fetch(`${API_BASE_URL}${path}`, {
+  const res = await fetch(`${PROXY_BASE}${path}`, {
     ...init,
     headers,
-    credentials: "include",
+    credentials: "same-origin",
   });
 
   if (!res.ok) {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -3,7 +3,6 @@ import type { PublicKey } from "@solana/web3.js";
 import { z } from "zod";
 
 import { apiFetch } from "@/lib/api/client";
-import { API_BASE_URL } from "@/lib/config";
 import { TenantSchema, type Tenant } from "@/lib/api/schemas";
 
 const ChallengeSchema = z.object({ nonce: z.string().min(1) });
@@ -57,13 +56,7 @@ export async function signIn(
 }
 
 export async function signOut(): Promise<void> {
-  const res = await fetch(`${API_BASE_URL}/auth/logout`, {
-    method: "POST",
-    credentials: "include",
-  });
-  if (!res.ok) {
-    throw new Error(`Logout failed: ${res.status}`);
-  }
+  await apiFetch("/auth/logout", { method: "POST" });
 }
 
 export async function getMe(): Promise<Tenant> {

--- a/frontend/src/lib/server/active-key-cookie.ts
+++ b/frontend/src/lib/server/active-key-cookie.ts
@@ -1,0 +1,40 @@
+import type { NextResponse } from "next/server";
+
+export const ACTIVE_KEY_COOKIE = "zks_active_key";
+const SEVEN_DAYS_SECONDS = 60 * 60 * 24 * 7;
+
+interface CookieOptions {
+  httpOnly: true;
+  sameSite: "lax";
+  path: "/";
+  secure: boolean;
+  maxAge?: number;
+}
+
+function cookieOptions(): CookieOptions {
+  return {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: SEVEN_DAYS_SECONDS,
+  };
+}
+
+export function setActiveKeyCookie(res: NextResponse, key: string): void {
+  res.cookies.set(ACTIVE_KEY_COOKIE, key, cookieOptions());
+}
+
+export function clearActiveKeyCookie(res: NextResponse): void {
+  res.cookies.set(ACTIVE_KEY_COOKIE, "", {
+    ...cookieOptions(),
+    maxAge: 0,
+  });
+}
+
+export function keyPrefix(key: string): string {
+  if (key.length <= 12) return key;
+  return `${key.slice(0, 8)}…${key.slice(-4)}`;
+}
+
+export const KEY_FORMAT = /^zks_[A-Za-z0-9_-]{32,}$/;


### PR DESCRIPTION
Closes #154. Replaces #159 (which had 91 commits, scope creep, and a flagged XSS concern around persisting bearer keys in `localStorage`).

## Problem

`NEXT_PUBLIC_API_KEY` was shipped in the browser bundle. Any user-selectable replacement that puts the full key in `localStorage` is vulnerable to XSS exfiltration — flagged on #159 review by CodeRabbit and confirmed in team feedback ("let's use HttpOnly").

## Solution — BFF (Backend-for-Frontend) pattern

The API key now lives only on the Next.js server as an **HttpOnly + SameSite=Lax + Secure (in prod)** cookie. JS in the browser never sees it.

Three new server routes:
- `POST/DELETE /api/active-key` — set / clear the cookie
- `GET /api/active-key/status` — returns `{ hasKey, prefix }` only (never the full value)
- `GET/POST/PUT/PATCH/DELETE /api/proxy/[...path]` — same-origin catch-all that reads the cookie and injects `Authorization: Bearer` before forwarding to the gateway

Browser `apiFetch` now hits `/api/proxy/*` instead of the gateway directly, so:
- No `Authorization` header ever set client-side
- No CORS surface for the gateway from browsers
- Gateway session cookies (SIWS) and wallet-auth headers continue to flow through the proxy

## What's in scope (issue #154)

- Drop `NEXT_PUBLIC_API_KEY` from env, panel error messages, and INTEGRATION.md
- Server-side cookie management + same-origin proxy
- `RequireApiKey` gate: skeleton-while-loading (no flicker), tightened paste regex (`^zks_[A-Za-z0-9_-]{32,}$`), inline reveal-then-activate flow so users get to copy newly created keys
- `ApiKeysPanel`: native `<dialog>` revoke confirmation (replaces `window.confirm`), "active" pill on the active key, auto-clears the cookie when the active key is revoked
- Logout updates the UI immediately (was previously requiring a manual refresh — `removeQueries()` doesn't notify observers)

## Bugs caught & fixed during local testing

These would have shipped silently with #159:

- **Proxy stripped `Set-Cookie`** → broke SIWS session establishment (\`/auth/login\` worked but \`/auth/me\` always 401'd)
- **\`signOut()\` bypassed the proxy** → CORS-blocked once we removed the direct origin
- **Strict Mode dialog flash** → React's dev mount→cleanup→mount cycle fired the dialog's \`close\` event mid-mount; with \`onClose={onDismiss}\` the reveal/revoke modals unmounted before the user could see them
- **Gate's "Create key" never showed the secret** → was activating the cookie immediately without a reveal step, so users had no way to copy the key for SDK/curl use
- **Logout was a no-op until refresh** → \`queryClient.removeQueries()\` doesn't push state to subscribed observers; switched to \`setQueryData(authMeQueryKey, null)\` + \`onSettled\` so the UI updates regardless of whether the gateway returns success

## Drive-by infra fix (not strictly part of #154)

The repo's docker-compose was missing two required gateway env vars — anyone running \`docker compose up\` would crash with \`jwt_secret not configured\` / \`siws_domain must be configured\` on first SIWS login. Adds:
- \`GATEWAY_JWT_SECRET\` — required (no default), follows the existing \`INDEXER_HELIUS_AUTH_TOKEN\` pattern; rotation guidance in \`.env.example\`
- \`GATEWAY_SIWS_DOMAIN\` — defaults to \`localhost:3000\` in compose since the browser-signed message always carries that host in dev

These are isolated to a single \`chore(infra):\` commit and could be cherry-picked into a separate PR if reviewers prefer.

## Diff size vs #159

| | This PR | #159 |
|---|---:|---:|
| Commits | 10 | 91 |
| Files | 18 | 64 |
| Additions | 646 | 2725 |
| Deletions | 147 | 167 |

Out of scope from #159 and intentionally not pulled in: prove-flow page (already merged via #151), wallet signature auth, issuer-service handlers, gateway rate-limit changes, on-chain transfer_hook changes.

## Test plan — manually verified

- [x] **Test 1** — `zks_active_key` cookie has `HttpOnly` flag set; `document.cookie` does not expose it; no `localStorage` entry holds the full key
- [x] **Test 2** — End-to-end happy path: SIWS login → create key → reveal modal → dashboard panels render via `/api/proxy/*` with no `Authorization` header on browser requests
- [x] **Test 3** — Switching keys: new key auto-activates, "active" pill follows, persists across refresh
- [x] **Test 4** — Logout clears both `zks_active_key` and the SIWS session; UI updates instantly
- [x] **Test 5** — Revoking the active key auto-clears the cookie via `DELETE /api/active-key`; gate reappears
- [x] **Test 6** — Revoking a non-active key leaves the active cookie untouched
- [x] **Test 7** — Hard refresh shows skeleton then panels (no panel-flash before gate)
- [x] **Test 8** — Paste validation rejects `zks_`, short keys, and non-prefixed strings; accepts `zks_` + 32+ chars
- [x] **Test 11** — `curl` round-trip confirms `Set-Cookie: HttpOnly; SameSite=Lax`, status returns prefix only, invalid formats return 400
- [x] `pnpm typecheck` — only pre-existing errors in untouched files (\`act-three-engine.test\`, \`code-block.test\`, \`api-hooks.test\`, \`use-prove-flow\`, \`export.test\`)
- [x] `pnpm test` — 83/83 unit tests pass

## Notes for reviewer

- **CSRF posture**: \`SameSite=Lax\` blocks cross-site `POST`/`DELETE` from carrying the cookie, sufficient for v1. Add a CSRF token if cross-site embedding becomes a need.
- **Cookie lifetime**: 7 days. Rotate via \`Max-Age\` change on the route handler.
- **Multi-key UX trade-off**: removed the "stored keys" localStorage list. To switch between keys, the user re-pastes — same flow as creation. Acceptable for security; if product wants the convenience back, store *prefix + label only* (never the secret) in localStorage.
- **\`/dashboard/prove\` is broken on \`main\`** — missing \`@coral-xyz/anchor\` dep from PR #151. Not introduced or addressed here; worth a separate one-line bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - API key selection and management now available in the dashboard sidebar
  - Secure HttpOnly cookie-based authentication for API requests
  - Improved dialogs for API key creation and revocation workflows

* **Updates**
  - Error messages now guide users to select active API key in sidebar
  - Simplified configuration by removing API key environment variable requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->