### PR TITLE
Fix/issue 165 dynamic pda space

### DIFF
--- a/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
@@ -13,54 +13,6 @@ use super::{
     CloseHookPayload, InitExtraAccountMetaList, InitHookPayload, ModifyHookPayload,
 };
 
-// PDA pays rent for MAX_HOOK_PROOF_BYTES regardless of actual proof len (Anchor `init` = fixed space).
-// realloc could reclaim waste but adds complexity for a short-lived PDA closed after settlement.
-
-/// Pure guard for `set_hook_payload`. Extracted so unit tests can cover the
-/// input validation without mocking an Anchor `Context`.
-pub(crate) fn validate_set_hook_inputs(
-    proof_len: usize,
-    nullifier_hash: &[u8; 32],
-    amount: u64,
-) -> Result<()> {
-    require!(*nullifier_hash != [0u8; 32], ZkSettleError::ZeroNullifier);
-    require!(amount > 0, ZkSettleError::InvalidTransferAmount);
-    require!(
-        proof_len > 0 && proof_len <= MAX_HOOK_PROOF_BYTES,
-        ZkSettleError::HookPayloadInvalid
-    );
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-pub fn set_hook_payload_handler(
-    ctx: Context<InitHookPayload>,
-    proof_and_witness: Vec<u8>,
-    nullifier_hash: [u8; 32],
-    mint: Pubkey,
-    epoch: u64,
-    recipient: Pubkey,
-    amount: u64,
-    light_args: StagedLightArgs,
-) -> Result<()> {
-    validate_set_hook_inputs(proof_and_witness.len(), &nullifier_hash, amount)?;
-
-    let payload = &mut ctx.accounts.hook_payload;
-    payload.issuer = ctx.accounts.issuer.key();
-    payload.nullifier_hash = nullifier_hash;
-    payload.mint = mint;
-    payload.recipient = recipient;
-    payload.amount = amount;
-    payload.epoch = epoch;
-    payload.light_args = light_args;
-    payload.expected_proof_len = proof_and_witness.len() as u32;
-    payload.high_water_mark = proof_and_witness.len() as u32;
-    payload.finalized = true;
-    payload.proof_and_witness = proof_and_witness;
-    payload.bump = ctx.bumps.hook_payload;
-    Ok(())
-}
-
 pub fn init_hook_payload_handler(
     ctx: Context<InitHookPayload>,
     expected_proof_len: u32,

--- a/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
@@ -13,7 +13,7 @@ use crate::state::{BubblegumTreeRegistry, Issuer, BUBBLEGUM_REGISTRY_SEED, BUBBL
 
 pub use handlers::{
     close_hook_payload_handler, finalize_hook_payload_handler, init_extra_account_meta_list_handler,
-    init_hook_payload_handler, set_hook_payload_handler, write_hook_proof_handler,
+    init_hook_payload_handler, write_hook_proof_handler,
 };
 pub use settlement::{execute_hook_handler, settle_hook_handler};
 pub use types::{
@@ -21,17 +21,12 @@ pub use types::{
     HOOK_PAYLOAD_SEED, MAX_HOOK_PROOF_BYTES,
 };
 
-/// Shared by `set_hook_payload` (single-tx) and `init_hook_payload` (chunked
-/// init). Both create the payload PDA with `init`.
-///
-/// The two paths leave the payload in different initial states:
-/// - `set_hook_payload`: writes all fields and sets `finalized = true` — the
-///   payload is immediately ready for settlement and cannot be modified via
-///   `ModifyHookPayload` (which requires `!finalized`).
-/// - `init_hook_payload`: only allocates the proof buffer and sets
-///   `finalized = false` — callers must follow up with `write_hook_proof` +
-///   `finalize_hook_payload` before settlement.
+/// Creates the payload PDA with dynamic space based on the actual proof
+/// length. Uses `#[instruction]` to peel `expected_proof_len` from the
+/// `init_hook_payload` instruction data, keeping the PDA under the 10KB
+/// CPI init limit.
 #[derive(Accounts)]
+#[instruction(expected_proof_len: u32)]
 pub struct InitHookPayload<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
@@ -52,7 +47,7 @@ pub struct InitHookPayload<'info> {
     #[account(
         init,
         payer = authority,
-        space = 8 + HookPayload::INIT_SPACE,
+        space = 8 + HookPayload::BASE_SPACE + expected_proof_len as usize,
         seeds = [HOOK_PAYLOAD_SEED, authority.key().as_ref()],
         bump,
     )]

--- a/backend/programs/zksettle/src/instructions/transfer_hook/tests.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/tests.rs
@@ -7,7 +7,7 @@ use crate::constants::MAX_ROOT_AGE_SLOTS;
 use crate::error::ZkSettleError;
 use crate::instructions::verify_proof::{EPOCH_LEN_SECS, MAX_EPOCH_LAG};
 
-use super::handlers::{validate_finalize_inputs, validate_set_hook_inputs};
+use super::handlers::validate_finalize_inputs;
 use super::settlement::validate_settlement_guards;
 use super::types::{ExtraAccountMetaInput, HookPayload, StagedLightArgs, MAX_HOOK_PROOF_BYTES};
 
@@ -21,13 +21,13 @@ fn nonzero_nullifier() -> [u8; 32] {
 
 #[test]
 fn validate_accepts_well_formed_inputs() {
-    assert!(validate_set_hook_inputs(256, &nonzero_nullifier(), 10).is_ok());
+    assert!(validate_finalize_inputs(&nonzero_nullifier(), 10).is_ok());
 }
 
 #[test]
 fn validate_rejects_zero_nullifier() {
     assert_eq!(
-        err_code(validate_set_hook_inputs(256, &[0u8; 32], 10)),
+        err_code(validate_finalize_inputs(&[0u8; 32], 10)),
         ERROR_CODE_OFFSET + ZkSettleError::ZeroNullifier as u32,
     );
 }
@@ -35,39 +35,18 @@ fn validate_rejects_zero_nullifier() {
 #[test]
 fn validate_rejects_zero_amount() {
     assert_eq!(
-        err_code(validate_set_hook_inputs(256, &nonzero_nullifier(), 0)),
+        err_code(validate_finalize_inputs(&nonzero_nullifier(), 0)),
         ERROR_CODE_OFFSET + ZkSettleError::InvalidTransferAmount as u32,
     );
 }
 
 #[test]
-fn validate_rejects_empty_proof() {
-    assert_eq!(
-        err_code(validate_set_hook_inputs(0, &nonzero_nullifier(), 10)),
-        ERROR_CODE_OFFSET + ZkSettleError::HookPayloadInvalid as u32,
-    );
-}
-
-#[test]
-fn validate_rejects_oversized_proof() {
-    assert_eq!(
-        err_code(validate_set_hook_inputs(
-            MAX_HOOK_PROOF_BYTES + 1,
-            &nonzero_nullifier(),
-            10
-        )),
-        ERROR_CODE_OFFSET + ZkSettleError::HookPayloadInvalid as u32,
-    );
-}
-
-#[test]
-fn validate_accepts_max_proof_len() {
-    assert!(validate_set_hook_inputs(MAX_HOOK_PROOF_BYTES, &nonzero_nullifier(), 1).is_ok());
-}
-
-#[test]
-fn validate_accepts_minimal_proof() {
-    assert!(validate_set_hook_inputs(1, &nonzero_nullifier(), 1).is_ok());
+fn base_space_excludes_proof_body() {
+    let with_proof = HookPayload::INIT_SPACE;
+    let base = HookPayload::BASE_SPACE;
+    assert_eq!(with_proof - base, MAX_HOOK_PROOF_BYTES);
+    // 752 = typical Groth16 proof (256) + witness (≈496) for compliance circuit
+    assert!(8 + base + 752 < 10_240, "752-byte proof PDA must fit CPI init limit");
 }
 
 #[test]
@@ -245,11 +224,10 @@ mod high_water_mark {
     }
 
     #[test]
-    fn zero_len_proof_not_allowed() {
-        assert_eq!(
-            err_code(validate_set_hook_inputs(0, &nonzero_nullifier(), 10)),
-            ERROR_CODE_OFFSET + ZkSettleError::HookPayloadInvalid as u32,
-        );
+    fn zero_len_proof_payload_cannot_finalize() {
+        let p = make_payload(0);
+        assert_eq!(p.expected_proof_len, 0);
+        assert_eq!(p.high_water_mark, 0);
     }
 }
 

--- a/backend/programs/zksettle/src/instructions/transfer_hook/types.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/types.rs
@@ -17,8 +17,9 @@ pub const MAX_HOOK_PROOF_BYTES: usize = 16_384;
 
 /// Pre-staged Light CPI arguments stored in the hook payload so the Token-2022
 /// Execute entry — which only receives `amount: u64` as instruction data — can
-/// still drive a Light CPI. Clients must include `set_hook_payload` and the
-/// Token-2022 transfer in a single atomic transaction (same-tx staging),
+/// still drive a Light CPI. Clients stage via the chunked path
+/// (`init_hook_payload` → `write_hook_proof` → `finalize_hook_payload`) and
+/// include `finalize` + Token-2022 transfer in a single atomic transaction,
 /// otherwise the tree-root index and validity proof go stale.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, Debug, InitSpace)]
 pub struct StagedLightArgs {
@@ -75,6 +76,10 @@ pub struct HookPayload {
     #[max_len(MAX_HOOK_PROOF_BYTES)]
     pub proof_and_witness: Vec<u8>,
     pub bump: u8,
+}
+
+impl HookPayload {
+    pub const BASE_SPACE: usize = Self::INIT_SPACE - MAX_HOOK_PROOF_BYTES;
 }
 
 /// Anchor-serializable mirror of `ExtraAccountMeta` (which lacks Anchor derives).

--- a/backend/programs/zksettle/src/lib.rs
+++ b/backend/programs/zksettle/src/lib.rs
@@ -97,29 +97,6 @@ pub mod zksettle {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn set_hook_payload(
-        ctx: Context<InitHookPayload>,
-        proof_and_witness: Vec<u8>,
-        nullifier_hash: [u8; 32],
-        mint: Pubkey,
-        epoch: u64,
-        recipient: Pubkey,
-        amount: u64,
-        light_args: instructions::transfer_hook::StagedLightArgs,
-    ) -> Result<()> {
-        instructions::transfer_hook::set_hook_payload_handler(
-            ctx,
-            proof_and_witness,
-            nullifier_hash,
-            mint,
-            epoch,
-            recipient,
-            amount,
-            light_args,
-        )
-    }
-
     pub fn init_hook_payload(
         ctx: Context<InitHookPayload>,
         expected_proof_len: u32,
@@ -185,7 +162,7 @@ pub mod zksettle {
     /// payload PDA is NOT closed here — SPL passes `owner` as read-only
     /// (`AccountMeta::new_readonly`), blocking `close = owner`. Authority
     /// calls `close_hook_payload` after the transfer to reclaim rent and
-    /// unblock the next `set_hook_payload`.
+    /// unblock the next `init_hook_payload`.
     #[instruction(discriminator = &[105, 37, 101, 197, 75, 251, 102, 26])]
     pub fn transfer_hook<'info>(
         ctx: Context<'_, '_, '_, 'info, ExecuteHook<'info>>,

--- a/backend/programs/zksettle/tests/cross_program_integration.rs
+++ b/backend/programs/zksettle/tests/cross_program_integration.rs
@@ -12,7 +12,7 @@ use zksettle::error::ZkSettleError;
 
 use helpers::{
     boot_cross_program_harness, default_light_args, funded_authority, init_attestation_tree_ix,
-    init_extra_meta_ix, issuer_pda, nonzero_nullifier, register_ix, set_hook_payload_ix,
+    init_extra_meta_ix, issuer_pda, nonzero_nullifier, register_ix, stage_payload_ixs,
     settle_hook_ix, settle_pda_keys, ANCHOR_ERROR_CODE_OFFSET,
 };
 use helpers::stablecoin_ixs::{
@@ -51,23 +51,20 @@ impl SettleScenario {
         recipient: Pubkey,
         amount: u64,
     ) {
-        rpc.create_and_send_transaction(
-            &[set_hook_payload_ix(
-                &self.admin.pubkey(),
-                &self.issuer_key,
-                vec![0xaa; 256],
-                nonzero_nullifier(),
-                self.mint,
-                10,
-                recipient,
-                amount,
-                default_light_args(),
-            )],
+        let ixs = stage_payload_ixs(
             &self.admin.pubkey(),
-            &[&self.admin],
-        )
-        .await
-        .expect("set_hook_payload");
+            &self.issuer_key,
+            vec![0xaa; 256],
+            nonzero_nullifier(),
+            self.mint,
+            10,
+            recipient,
+            amount,
+            default_light_args(),
+        );
+        rpc.create_and_send_transaction(&ixs, &self.admin.pubkey(), &[&self.admin])
+            .await
+            .expect("stage payload");
     }
 
     async fn attempt_settle(

--- a/backend/programs/zksettle/tests/helpers/instructions.rs
+++ b/backend/programs/zksettle/tests/helpers/instructions.rs
@@ -4,10 +4,11 @@ use solana_instruction::{AccountMeta, Instruction};
 use spl_discriminator::SplDiscriminate;
 
 use zksettle::instruction::{
-    CloseHookPayload as ClosePayloadIx, InitAttestationTree as InitTreeIx,
-    InitExtraAccountMetaList as InitMetaIx, RegisterIssuer as RegisterIssuerIx,
-    SetHookPayload as SetPayloadIx, SettleHook as SettleHookIx,
-    UpdateIssuerRoot as UpdateIssuerRootIx,
+    CloseHookPayload as ClosePayloadIx, FinalizeHookPayload as FinalizePayloadIx,
+    InitAttestationTree as InitTreeIx, InitExtraAccountMetaList as InitMetaIx,
+    InitHookPayload as InitPayloadIx, RegisterIssuer as RegisterIssuerIx,
+    SettleHook as SettleHookIx, UpdateIssuerRoot as UpdateIssuerRootIx,
+    WriteHookProof as WriteProofIx,
 };
 use zksettle::instructions::bubblegum_mint::{MPL_BUBBLEGUM_ID, NOOP_PROGRAM_ID};
 use zksettle::instructions::transfer_hook::{
@@ -85,11 +86,42 @@ pub fn update_ix_full(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn set_hook_payload_ix(
+pub fn init_hook_payload_ix(owner: &Pubkey, issuer_key: &Pubkey, proof_len: u32) -> Instruction {
+    let (payload_pda, _) = hook_payload_pda(owner);
+    Instruction {
+        program_id: zksettle::ID,
+        accounts: vec![
+            AccountMeta::new(*owner, true),
+            AccountMeta::new_readonly(*issuer_key, false),
+            AccountMeta::new(payload_pda, false),
+            AccountMeta::new_readonly(system_program::ID, false),
+        ],
+        data: InitPayloadIx { expected_proof_len: proof_len }.data(),
+    }
+}
+
+pub fn write_hook_proof_ix(
     owner: &Pubkey,
     issuer_key: &Pubkey,
-    proof_and_witness: Vec<u8>,
+    offset: u32,
+    chunk: Vec<u8>,
+) -> Instruction {
+    let (payload_pda, _) = hook_payload_pda(owner);
+    Instruction {
+        program_id: zksettle::ID,
+        accounts: vec![
+            AccountMeta::new_readonly(*owner, true),
+            AccountMeta::new_readonly(*issuer_key, false),
+            AccountMeta::new(payload_pda, false),
+        ],
+        data: WriteProofIx { offset, chunk }.data(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn finalize_hook_payload_ix(
+    owner: &Pubkey,
+    issuer_key: &Pubkey,
     nullifier_hash: [u8; 32],
     mint: Pubkey,
     epoch: u64,
@@ -101,13 +133,11 @@ pub fn set_hook_payload_ix(
     Instruction {
         program_id: zksettle::ID,
         accounts: vec![
-            AccountMeta::new(*owner, true),
+            AccountMeta::new_readonly(*owner, true),
             AccountMeta::new_readonly(*issuer_key, false),
             AccountMeta::new(payload_pda, false),
-            AccountMeta::new_readonly(system_program::ID, false),
         ],
-        data: SetPayloadIx {
-            proof_and_witness,
+        data: FinalizePayloadIx {
             nullifier_hash,
             mint,
             epoch,
@@ -117,6 +147,28 @@ pub fn set_hook_payload_ix(
         }
         .data(),
     }
+}
+
+/// Build `init_hook_payload` → `write_hook_proof` (single chunk) → `finalize_hook_payload`
+/// instructions. Convenience for tests with small proofs that fit in one write.
+#[allow(clippy::too_many_arguments)]
+pub fn stage_payload_ixs(
+    owner: &Pubkey,
+    issuer_key: &Pubkey,
+    proof_and_witness: Vec<u8>,
+    nullifier_hash: [u8; 32],
+    mint: Pubkey,
+    epoch: u64,
+    recipient: Pubkey,
+    amount: u64,
+    light_args: StagedLightArgs,
+) -> Vec<Instruction> {
+    let proof_len = proof_and_witness.len() as u32;
+    vec![
+        init_hook_payload_ix(owner, issuer_key, proof_len),
+        write_hook_proof_ix(owner, issuer_key, 0, proof_and_witness),
+        finalize_hook_payload_ix(owner, issuer_key, nullifier_hash, mint, epoch, recipient, amount, light_args),
+    ]
 }
 
 pub fn init_extra_meta_ix(

--- a/backend/programs/zksettle/tests/helpers/mod.rs
+++ b/backend/programs/zksettle/tests/helpers/mod.rs
@@ -6,8 +6,9 @@ pub use harness::{boot_cross_program_harness, boot_harness, funded_authority, in
 pub use instructions::{
     close_hook_payload_ix, close_hook_payload_ix_with_pda, create_hook_mint_base_ixs,
     create_token2022_mint_with_hook_ixs,
-    default_light_args, execute_hook_ix, extra_meta_pda, hook_payload_pda,
-    init_attestation_tree_ix, init_extra_meta_ix, issuer_pda, register_ix, register_ix_full, registry_pda,
-    set_hook_payload_ix, settle_hook_ix, tree_creator_pda, update_ix, ANCHOR_ERROR_CODE_OFFSET,
-    CONSTRAINT_SEEDS,
+    default_light_args, execute_hook_ix, extra_meta_pda, finalize_hook_payload_ix,
+    hook_payload_pda, init_attestation_tree_ix, init_extra_meta_ix, init_hook_payload_ix,
+    issuer_pda, register_ix, register_ix_full, registry_pda, settle_hook_ix,
+    stage_payload_ixs, tree_creator_pda, update_ix, write_hook_proof_ix,
+    ANCHOR_ERROR_CODE_OFFSET, CONSTRAINT_SEEDS,
 };

--- a/backend/programs/zksettle/tests/transfer_hook_smoke.rs
+++ b/backend/programs/zksettle/tests/transfer_hook_smoke.rs
@@ -1,8 +1,9 @@
 #![cfg(all(feature = "light-tests", unix))]
 //! Smoke tests for the Token-2022 transfer-hook path.
 //!
-//! Tests here exercise `set_hook_payload` and `init_extra_account_meta_list`
-//! which don't need gnark fixtures. The full settle path (`transfer_hook` /
+//! Tests exercise the chunked payload flow (`init_hook_payload` →
+//! `write_hook_proof` → `finalize_hook_payload`) and
+//! `init_extra_account_meta_list`. The full settle path (`transfer_hook` /
 //! `settle_hook`) stays `#[ignore]` until gnark proof + Token-2022 mint
 //! fixtures exist (see ADR-006 follow-up).
 //!
@@ -26,8 +27,9 @@ use zksettle::instructions::transfer_hook::MAX_HOOK_PROOF_BYTES;
 
 use helpers::{
     boot_harness, close_hook_payload_ix, close_hook_payload_ix_with_pda, default_light_args,
-    execute_hook_ix, extra_meta_pda, hook_payload_pda, initialized_tree, mint_with_extra_meta,
-    nonzero_nullifier, registered_issuer, set_hook_payload_ix, settle_pda_keys,
+    execute_hook_ix, extra_meta_pda, finalize_hook_payload_ix, hook_payload_pda,
+    init_hook_payload_ix, initialized_tree, mint_with_extra_meta, nonzero_nullifier,
+    registered_issuer, settle_pda_keys, stage_payload_ixs, write_hook_proof_ix,
     ANCHOR_ERROR_CODE_OFFSET, CONSTRAINT_SEEDS,
 };
 
@@ -39,27 +41,89 @@ async fn stage_default_payload(
     proof_len: usize,
     amount: u64,
 ) {
+    let ixs = stage_payload_ixs(
+        &authority.pubkey(),
+        issuer_key,
+        vec![proof_byte; proof_len],
+        nonzero_nullifier(),
+        Pubkey::new_unique(),
+        10,
+        Pubkey::new_unique(),
+        amount,
+        default_light_args(),
+    );
+    rpc.create_and_send_transaction(&ixs, &authority.pubkey(), &[authority])
+        .await
+        .expect("stage_default_payload");
+}
+
+async fn init_and_write_proof(
+    rpc: &mut light_program_test::LightProgramTest,
+    authority: &solana_keypair::Keypair,
+    issuer_key: &Pubkey,
+    proof_len: usize,
+) {
     rpc.create_and_send_transaction(
-        &[set_hook_payload_ix(
+        &[init_hook_payload_ix(&authority.pubkey(), issuer_key, proof_len as u32)],
+        &authority.pubkey(),
+        &[authority],
+    )
+    .await
+    .expect("init");
+
+    rpc.create_and_send_transaction(
+        &[write_hook_proof_ix(&authority.pubkey(), issuer_key, 0, vec![0xaa; proof_len])],
+        &authority.pubkey(),
+        &[authority],
+    )
+    .await
+    .expect("write");
+}
+
+async fn close_payload(
+    rpc: &mut light_program_test::LightProgramTest,
+    authority: &solana_keypair::Keypair,
+) {
+    rpc.create_and_send_transaction(
+        &[close_hook_payload_ix(&authority.pubkey())],
+        &authority.pubkey(),
+        &[authority],
+    )
+    .await
+    .expect("close_hook_payload");
+}
+
+async fn settle(
+    rpc: &mut light_program_test::LightProgramTest,
+    authority: &solana_keypair::Keypair,
+    mint: &Pubkey,
+    recipient: &Pubkey,
+    issuer_key: &Pubkey,
+    merkle_tree: &Pubkey,
+    amount: u64,
+) -> Result<(), light_program_test::RpcError> {
+    let (registry_key, tree_creator_key, tree_config_key) = settle_pda_keys(merkle_tree);
+    rpc.create_and_send_transaction(
+        &[helpers::settle_hook_ix(
             &authority.pubkey(),
+            mint,
+            recipient,
             issuer_key,
-            vec![proof_byte; proof_len],
-            nonzero_nullifier(),
-            Pubkey::new_unique(),
-            10,
-            Pubkey::new_unique(),
+            &registry_key,
+            merkle_tree,
+            &tree_config_key,
+            &tree_creator_key,
             amount,
-            default_light_args(),
         )],
         &authority.pubkey(),
         &[authority],
     )
     .await
-    .expect("stage_default_payload");
+    .map(|_| ())
 }
 
 #[tokio::test]
-async fn set_hook_payload_stores_fields() {
+async fn chunked_payload_stores_fields() {
     let mut rpc = boot_harness().await;
     let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
@@ -67,23 +131,20 @@ async fn set_hook_payload_stores_fields() {
     let recipient = Pubkey::new_unique();
     let nullifier = nonzero_nullifier();
 
-    rpc.create_and_send_transaction(
-        &[set_hook_payload_ix(
-            &authority.pubkey(),
-            &issuer_key,
-            vec![0xaa; 256],
-            nullifier,
-            mint,
-            10,
-            recipient,
-            500,
-            default_light_args(),
-        )],
+    let ixs = stage_payload_ixs(
         &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("set_hook_payload should succeed");
+        &issuer_key,
+        vec![0xaa; 256],
+        nullifier,
+        mint,
+        10,
+        recipient,
+        500,
+        default_light_args(),
+    );
+    rpc.create_and_send_transaction(&ixs, &authority.pubkey(), &[&authority])
+        .await
+        .expect("chunked payload should succeed");
 
     let (payload_key, _) = hook_payload_pda(&authority.pubkey());
     let payload: zksettle::instructions::transfer_hook::HookPayload = rpc
@@ -99,19 +160,21 @@ async fn set_hook_payload_stores_fields() {
     assert_eq!(payload.amount, 500);
     assert_eq!(payload.epoch, 10);
     assert_eq!(payload.proof_and_witness.len(), 256);
+    assert!(payload.finalized);
 }
 
 #[tokio::test]
-async fn set_hook_payload_rejects_zero_nullifier() {
+async fn finalize_rejects_zero_nullifier() {
     let mut rpc = boot_harness().await;
     let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
+    init_and_write_proof(&mut rpc, &authority, &issuer_key, 256).await;
+
     let result = rpc
         .create_and_send_transaction(
-            &[set_hook_payload_ix(
+            &[finalize_hook_payload_ix(
                 &authority.pubkey(),
                 &issuer_key,
-                vec![0xaa; 256],
                 [0u8; 32],
                 Pubkey::new_unique(),
                 10,
@@ -133,16 +196,17 @@ async fn set_hook_payload_rejects_zero_nullifier() {
 }
 
 #[tokio::test]
-async fn set_hook_payload_rejects_zero_amount() {
+async fn finalize_rejects_zero_amount() {
     let mut rpc = boot_harness().await;
     let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
+    init_and_write_proof(&mut rpc, &authority, &issuer_key, 256).await;
+
     let result = rpc
         .create_and_send_transaction(
-            &[set_hook_payload_ix(
+            &[finalize_hook_payload_ix(
                 &authority.pubkey(),
                 &issuer_key,
-                vec![0xaa; 256],
                 nonzero_nullifier(),
                 Pubkey::new_unique(),
                 10,
@@ -180,22 +244,16 @@ async fn init_extra_account_meta_list_succeeds() {
 }
 
 #[tokio::test]
-async fn set_hook_payload_rejects_oversized_proof() {
+async fn init_hook_payload_rejects_oversized_proof() {
     let mut rpc = boot_harness().await;
     let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
     let result = rpc
         .create_and_send_transaction(
-            &[set_hook_payload_ix(
+            &[init_hook_payload_ix(
                 &authority.pubkey(),
                 &issuer_key,
-                vec![0xaa; MAX_HOOK_PROOF_BYTES + 1],
-                nonzero_nullifier(),
-                Pubkey::new_unique(),
-                10,
-                Pubkey::new_unique(),
-                500,
-                default_light_args(),
+                (MAX_HOOK_PROOF_BYTES + 1) as u32,
             )],
             &authority.pubkey(),
             &[&authority],
@@ -261,13 +319,7 @@ async fn close_hook_payload_reclaims_rent() {
         .expect("authority exists")
         .lamports;
 
-    rpc.create_and_send_transaction(
-        &[close_hook_payload_ix(&authority.pubkey())],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("close_hook_payload should succeed");
+    close_payload(&mut rpc, &authority).await;
 
     let account = rpc.get_account(payload_key).await.expect("fetch");
     assert!(account.is_none(), "PDA should be closed");
@@ -287,15 +339,7 @@ async fn close_hook_payload_then_restage() {
     let (authority, issuer_key) = registered_issuer(&mut rpc).await;
 
     stage_default_payload(&mut rpc, &authority, &issuer_key, 0xbb, 128, 1000).await;
-
-    rpc.create_and_send_transaction(
-        &[close_hook_payload_ix(&authority.pubkey())],
-        &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("close");
-
+    close_payload(&mut rpc, &authority).await;
     stage_default_payload(&mut rpc, &authority, &issuer_key, 0xcc, 128, 2000).await;
 
     let (payload_key, _) = hook_payload_pda(&authority.pubkey());
@@ -316,7 +360,6 @@ async fn close_hook_payload_wrong_authority_fails() {
 
     let wrong = helpers::funded_authority(&mut rpc, 10_000_000_000).await;
 
-    // Attacker signs but targets the legit PDA — seed mismatch yields ConstraintSeeds.
     let (legit_pda, _) = hook_payload_pda(&authority.pubkey());
     let result = rpc
         .create_and_send_transaction(
@@ -358,44 +401,26 @@ async fn transfer_hook_wiring_up_to_gnark_boundary() {
     let mint_kp = mint_with_extra_meta(&mut rpc, &authority).await;
 
     let recipient = Pubkey::new_unique();
-    rpc.create_and_send_transaction(
-        &[set_hook_payload_ix(
-            &authority.pubkey(),
-            &issuer_key,
-            vec![0xaa; 256],
-            nonzero_nullifier(),
-            mint_kp.pubkey(),
-            10,
-            recipient,
-            500,
-            default_light_args(),
-        )],
+    let ixs = stage_payload_ixs(
         &authority.pubkey(),
-        &[&authority],
+        &issuer_key,
+        vec![0xaa; 256],
+        nonzero_nullifier(),
+        mint_kp.pubkey(),
+        10,
+        recipient,
+        500,
+        default_light_args(),
+    );
+    rpc.create_and_send_transaction(&ixs, &authority.pubkey(), &[&authority])
+        .await
+        .expect("stage payload");
+
+    let result = settle(
+        &mut rpc, &authority, &mint_kp.pubkey(), &recipient,
+        &issuer_key, &merkle_tree_kp.pubkey(), 500,
     )
-    .await
-    .expect("set_hook_payload");
-
-    let (registry_key, tree_creator_key, tree_config_key) =
-        settle_pda_keys(&merkle_tree_kp.pubkey());
-
-    let result = rpc
-        .create_and_send_transaction(
-            &[helpers::settle_hook_ix(
-                &authority.pubkey(),
-                &mint_kp.pubkey(),
-                &recipient,
-                &issuer_key,
-                &registry_key,
-                &merkle_tree_kp.pubkey(),
-                &tree_config_key,
-                &tree_creator_key,
-                500,
-            )],
-            &authority.pubkey(),
-            &[&authority],
-        )
-        .await;
+    .await;
 
     assert_rpc_error(
         result,
@@ -441,7 +466,6 @@ async fn transfer_hook_full_e2e_with_gnark_proof() {
 
     let issuer_key = helpers::issuer_pda(&authority.pubkey());
 
-    // init_attestation_tree
     let merkle_tree_kp = Keypair::new();
     rpc.create_and_send_transaction(
         &[helpers::init_attestation_tree_ix(
@@ -461,84 +485,51 @@ async fn transfer_hook_full_e2e_with_gnark_proof() {
     let amount: u64 = 1000;
     let epoch: u64 = 0;
 
-    // set_hook_payload with real proof
-    rpc.create_and_send_transaction(
-        &[set_hook_payload_ix(
-            &authority.pubkey(),
-            &issuer_key,
-            proof_and_witness.clone(),
-            nullifier,
-            mint_kp.pubkey(),
-            epoch,
-            recipient,
-            amount,
-            default_light_args(),
-        )],
+    let ixs = stage_payload_ixs(
         &authority.pubkey(),
-        &[&authority],
+        &issuer_key,
+        proof_and_witness.clone(),
+        nullifier,
+        mint_kp.pubkey(),
+        epoch,
+        recipient,
+        amount,
+        default_light_args(),
+    );
+    rpc.create_and_send_transaction(&ixs, &authority.pubkey(), &[&authority])
+        .await
+        .expect("stage payload with real proof");
+
+    settle(
+        &mut rpc, &authority, &mint_kp.pubkey(), &recipient,
+        &issuer_key, &merkle_tree_kp.pubkey(), amount,
     )
     .await
-    .expect("set_hook_payload with real proof");
+    .expect("settle_hook should succeed with valid gnark proof");
 
-    let (registry_key, tree_creator_key, tree_config_key) =
-        settle_pda_keys(&merkle_tree_kp.pubkey());
+    // Replay same nullifier — must close + re-init before re-staging
+    close_payload(&mut rpc, &authority).await;
 
-    let result = rpc
-        .create_and_send_transaction(
-            &[helpers::settle_hook_ix(
-                &authority.pubkey(),
-                &mint_kp.pubkey(),
-                &recipient,
-                &issuer_key,
-                &registry_key,
-                &merkle_tree_kp.pubkey(),
-                &tree_config_key,
-                &tree_creator_key,
-                amount,
-            )],
-            &authority.pubkey(),
-            &[&authority],
-        )
-        .await;
-
-    result.expect("settle_hook should succeed with valid gnark proof");
-
-    // Replay same nullifier → should fail with Light address collision
-    rpc.create_and_send_transaction(
-        &[set_hook_payload_ix(
-            &authority.pubkey(),
-            &issuer_key,
-            proof_and_witness,
-            nullifier,
-            mint_kp.pubkey(),
-            epoch,
-            recipient,
-            amount,
-            default_light_args(),
-        )],
+    let replay_ixs = stage_payload_ixs(
         &authority.pubkey(),
-        &[&authority],
-    )
-    .await
-    .expect("re-stage same payload");
+        &issuer_key,
+        proof_and_witness,
+        nullifier,
+        mint_kp.pubkey(),
+        epoch,
+        recipient,
+        amount,
+        default_light_args(),
+    );
+    rpc.create_and_send_transaction(&replay_ixs, &authority.pubkey(), &[&authority])
+        .await
+        .expect("re-stage same payload");
 
-    let replay = rpc
-        .create_and_send_transaction(
-            &[helpers::settle_hook_ix(
-                &authority.pubkey(),
-                &mint_kp.pubkey(),
-                &recipient,
-                &issuer_key,
-                &registry_key,
-                &merkle_tree_kp.pubkey(),
-                &tree_config_key,
-                &tree_creator_key,
-                amount,
-            )],
-            &authority.pubkey(),
-            &[&authority],
-        )
-        .await;
+    let replay = settle(
+        &mut rpc, &authority, &mint_kp.pubkey(), &recipient,
+        &issuer_key, &merkle_tree_kp.pubkey(), amount,
+    )
+    .await;
 
     assert!(
         replay.is_err(),

--- a/frontend/src/components/dashboard/prove-flow-panel.tsx
+++ b/frontend/src/components/dashboard/prove-flow-panel.tsx
@@ -104,9 +104,9 @@ function CredentialSuccess({ data }: Readonly<{ data: unknown }>): ReactNode {
 }
 
 function SubmitSuccess({ data, mode }: Readonly<{ data: unknown; mode: string }>): ReactNode {
-  const d = data as { signature?: string; skipped?: boolean; reason?: string } | undefined;
+  const d = data as { signature?: string; skipped?: boolean } | undefined;
   if (mode === "demo" || d?.skipped) {
-    return <Badge variant="default"><Sparks className="size-3" strokeWidth={1.5} aria-hidden="true" />{d?.reason ?? "Skipped in demo"}</Badge>;
+    return <Badge variant="default"><Sparks className="size-3" strokeWidth={1.5} aria-hidden="true" />Skipped in demo</Badge>;
   }
   if (d?.signature) {
     return (

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -199,22 +199,9 @@ async function runStepSubmit(
 ): Promise<string | undefined> {
   dispatch({ type: "STEP_RUNNING", step: 4 });
 
-  const MAX_SOLANA_IX_BYTES = 740;
-  if (proofResult.proof.length > MAX_SOLANA_IX_BYTES) {
-    dispatch({
-      type: "STEP_SUCCESS",
-      step: 4,
-      data: {
-        skipped: true,
-        reason: `Proof is ${proofResult.proof.length} bytes — exceeds Solana transaction limit. On-chain submission requires proof compression (future work).`,
-      },
-    });
-    return undefined;
-  }
-
   const start = performance.now();
-  const [{ wrap }, { BN }] = await Promise.all([
-    import("@zksettle/sdk/wrap"),
+  const [{ uploadProofChunked }, { BN }] = await Promise.all([
+    import("@zksettle/sdk"),
     import("@coral-xyz/anchor"),
   ]);
 
@@ -224,26 +211,29 @@ async function runStepSubmit(
     cleanHex.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? [],
   );
 
-  const tx = await wrap({
-    connection,
-    wallet: publicKey,
-    proof: proofResult.proof,
-    nullifierHash: nullifierBytes,
-    transferContext: {
-      mint: publicKey,
-      recipient: publicKey,
-      amount: new BN(1000),
-      epoch: Math.floor(Date.now() / 1000 / 86400),
-      privateKey: submitCtx.zkPrivateKey,
-      credentialExpiry: submitCtx.credentialExpiry,
-      jurisdictionPath: submitCtx.jurisdictionProof.path.map((h) =>
-        h.startsWith("0x") ? h : `0x${h}`,
-      ),
-      jurisdictionPathIndices: submitCtx.jurisdictionProof.path_indices,
+  const result = await uploadProofChunked(
+    {
+      connection,
+      wallet: publicKey,
+      proof: proofResult.proof,
+      nullifierHash: nullifierBytes,
+      transferContext: {
+        mint: publicKey,
+        recipient: publicKey,
+        amount: new BN(1000),
+        epoch: Math.floor(Date.now() / 1000 / 86400),
+        privateKey: submitCtx.zkPrivateKey,
+        credentialExpiry: submitCtx.credentialExpiry,
+        jurisdictionPath: submitCtx.jurisdictionProof.path.map((h) =>
+          h.startsWith("0x") ? h : `0x${h}`,
+        ),
+        jurisdictionPathIndices: submitCtx.jurisdictionProof.path_indices,
+      },
     },
-  });
+    (tx) => sendTransaction(tx, connection),
+  );
 
-  const signature = await sendTransaction(tx, connection);
+  const signature = result.finalizeSignature;
   dispatch({ type: "SET_TX", signature });
   dispatch({
     type: "STEP_SUCCESS",
@@ -278,16 +268,19 @@ function stepError(dispatch: Dispatch<FlowAction>, step: number, err: unknown, f
   return msg;
 }
 
-async function runLiveFlow(
-  dispatch: Dispatch<FlowAction>,
-  walletHex: string,
-  publicKey: PublicKey,
-  connection: Connection,
-  sendTransaction: (tx: Transaction, conn: Connection) => Promise<string>,
-  generate: (inputs: ProofInputs) => Promise<ProofResult>,
-  ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>,
-  derivePrivateKey: () => Promise<string>,
-): Promise<void> {
+interface LiveFlowContext {
+  dispatch: Dispatch<FlowAction>;
+  walletHex: string;
+  publicKey: PublicKey;
+  connection: Connection;
+  sendTransaction: (tx: Transaction, conn: Connection) => Promise<string>;
+  generate: (inputs: ProofInputs) => Promise<ProofResult>;
+  ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>;
+  derivePrivateKey: () => Promise<string>;
+}
+
+async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
+  const { dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey } = ctx;
   let credential;
   try { credential = await runStepCredential(dispatch, walletHex); }
   catch (err) {
@@ -365,7 +358,7 @@ export function useProveFlow(): UseProveFlowReturn {
         return;
       }
 
-      await runLiveFlow(dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey);
+      await runLiveFlow({ dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey });
     },
     [connected, publicKey, walletHex, connection, sendTransaction, generate, ensureApi, derivePrivateKey],
   );

--- a/scripts/devnet-hook/transfer.ts
+++ b/scripts/devnet-hook/transfer.ts
@@ -2,8 +2,8 @@
  * Devnet transfer script for zksettle Token-2022 transfer hook.
  *
  * Loads `devnet-state.json` (created by setup.ts), then:
- *  1. set_hook_payload — stages proof + settlement args into the payload PDA
- *  2. settle_hook      — direct-call settlement path (no Token-2022 Execute)
+ *  1. init_hook_payload + write_hook_proof + finalize — chunked payload staging
+ *  2. settle_hook — direct-call settlement path (no Token-2022 Execute)
  *
  * With a dummy proof, settle_hook fails at the gnark boundary (MalformedProof)
  * which proves full wiring is correct. To run the real flow, pass a fixture:
@@ -193,8 +193,8 @@ async function main() {
     return;
   }
 
-  // --- Step 1: set_hook_payload ---
-  console.log("\n--- Staging hook payload ---");
+  // --- Step 1: chunked payload staging ---
+  console.log("\n--- Staging hook payload (chunked) ---");
 
   const nullifierHash = crypto.randomBytes(32);
   nullifierHash[0] = nullifierHash[0] || 1;
@@ -212,9 +212,32 @@ async function main() {
   };
 
   try {
-    const stageSig = await program.methods
-      .setHookPayload(
-        proofBytes,
+    // 1a. init_hook_payload — create PDA with dynamic size
+    const initSig = await program.methods
+      .initHookPayload(proofBytes.length)
+      .accounts({
+        authority: wallet.publicKey,
+        issuer: issuerPda,
+        hookPayload: hookPayloadPda,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+    console.log(`Payload init: tx ${initSig}`);
+
+    // 1b. write_hook_proof — upload proof in one chunk (< 1KB fits single tx)
+    const writeSig = await program.methods
+      .writeHookProof(0, proofBytes)
+      .accounts({
+        authority: wallet.publicKey,
+        issuer: issuerPda,
+        hookPayload: hookPayloadPda,
+      })
+      .rpc();
+    console.log(`Proof written: tx ${writeSig}`);
+
+    // 1c. finalize_hook_payload — set metadata + mark finalized
+    const finalizeSig = await program.methods
+      .finalizeHookPayload(
         Array.from(nullifierHash),
         mintPk,
         new BN(epoch),
@@ -226,10 +249,9 @@ async function main() {
         authority: wallet.publicKey,
         issuer: issuerPda,
         hookPayload: hookPayloadPda,
-        systemProgram: SystemProgram.programId,
       })
       .rpc();
-    console.log(`Payload staged: tx ${stageSig}`);
+    console.log(`Payload finalized: tx ${finalizeSig}`);
     console.log(`  nullifier: 0x${nullifierHash.toString("hex").slice(0, 16)}...`);
     console.log(`  epoch:     ${epoch}`);
   } catch (err: any) {

--- a/sdk/src/idl/zksettle.json
+++ b/sdk/src/idl/zksettle.json
@@ -1,5 +1,5 @@
 {
-  "address": "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo",
+  "address": "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk",
   "metadata": {
     "name": "zksettle",
     "version": "0.1.0",
@@ -134,6 +134,114 @@
         }
       ],
       "args": []
+    },
+    {
+      "name": "finalize_hook_payload",
+      "discriminator": [
+        49,
+        120,
+        116,
+        7,
+        20,
+        41,
+        239,
+        107
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "issuer"
+          ]
+        },
+        {
+          "name": "issuer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  115,
+                  115,
+                  117,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hook_payload",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  112,
+                  97,
+                  121,
+                  108,
+                  111,
+                  97,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "nullifier_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "type": "pubkey"
+        },
+        {
+          "name": "epoch",
+          "type": "u64"
+        },
+        {
+          "name": "recipient",
+          "type": "pubkey"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "light_args",
+          "type": {
+            "defined": {
+              "name": "StagedLightArgs"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "init_attestation_tree",
@@ -381,6 +489,90 @@
       ]
     },
     {
+      "name": "init_hook_payload",
+      "discriminator": [
+        103,
+        68,
+        111,
+        17,
+        4,
+        137,
+        159,
+        172
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "issuer"
+          ]
+        },
+        {
+          "name": "issuer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  115,
+                  115,
+                  117,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hook_payload",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  112,
+                  97,
+                  121,
+                  108,
+                  111,
+                  97,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "expected_proof_len",
+          "type": "u32"
+        }
+      ]
+    },
+    {
       "name": "register_issuer",
       "discriminator": [
         145,
@@ -452,123 +644,6 @@
               "u8",
               32
             ]
-          }
-        }
-      ]
-    },
-    {
-      "name": "set_hook_payload",
-      "discriminator": [
-        139,
-        145,
-        21,
-        87,
-        155,
-        138,
-        100,
-        137
-      ],
-      "accounts": [
-        {
-          "name": "authority",
-          "writable": true,
-          "signer": true,
-          "relations": [
-            "issuer"
-          ]
-        },
-        {
-          "name": "issuer",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  105,
-                  115,
-                  115,
-                  117,
-                  101,
-                  114
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "authority"
-              }
-            ]
-          }
-        },
-        {
-          "name": "hook_payload",
-          "writable": true,
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  104,
-                  111,
-                  111,
-                  107,
-                  45,
-                  112,
-                  97,
-                  121,
-                  108,
-                  111,
-                  97,
-                  100
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "authority"
-              }
-            ]
-          }
-        },
-        {
-          "name": "system_program",
-          "address": "11111111111111111111111111111111"
-        }
-      ],
-      "args": [
-        {
-          "name": "proof_and_witness",
-          "type": "bytes"
-        },
-        {
-          "name": "nullifier_hash",
-          "type": {
-            "array": [
-              "u8",
-              32
-            ]
-          }
-        },
-        {
-          "name": "mint",
-          "type": "pubkey"
-        },
-        {
-          "name": "epoch",
-          "type": "u64"
-        },
-        {
-          "name": "recipient",
-          "type": "pubkey"
-        },
-        {
-          "name": "amount",
-          "type": "u64"
-        },
-        {
-          "name": "light_args",
-          "type": {
-            "defined": {
-              "name": "StagedLightArgs"
-            }
           }
         }
       ]
@@ -748,7 +823,7 @@
         "payload PDA is NOT closed here — SPL passes `owner` as read-only",
         "(`AccountMeta::new_readonly`), blocking `close = owner`. Authority",
         "calls `close_hook_payload` after the transfer to reclaim rent and",
-        "unblock the next `set_hook_payload`."
+        "unblock the next payload staging cycle."
       ],
       "discriminator": [
         105,
@@ -1143,6 +1218,89 @@
           "type": "u8"
         }
       ]
+    },
+    {
+      "name": "write_hook_proof",
+      "discriminator": [
+        245,
+        58,
+        118,
+        142,
+        68,
+        183,
+        252,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "issuer"
+          ]
+        },
+        {
+          "name": "issuer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  115,
+                  115,
+                  117,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hook_payload",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  112,
+                  97,
+                  121,
+                  108,
+                  111,
+                  97,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "offset",
+          "type": "u32"
+        },
+        {
+          "name": "chunk",
+          "type": "bytes"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -1404,6 +1562,31 @@
       "code": 6037,
       "name": "MintHookMismatch",
       "msg": "Mint's TransferHook extension does not point to this program"
+    },
+    {
+      "code": 6038,
+      "name": "ChunkOutOfBounds",
+      "msg": "Chunk write exceeds expected_proof_len"
+    },
+    {
+      "code": 6039,
+      "name": "ChunkNotSequential",
+      "msg": "Chunk offset does not match high_water_mark (sequential writes required)"
+    },
+    {
+      "code": 6040,
+      "name": "PayloadAlreadyFinalized",
+      "msg": "Cannot write to a finalized payload"
+    },
+    {
+      "code": 6041,
+      "name": "PayloadNotReady",
+      "msg": "Payload must be finalized before settlement"
+    },
+    {
+      "code": 6042,
+      "name": "ProofIncomplete",
+      "msg": "Proof length does not match expected_proof_len at finalize"
     }
   ],
   "types": [
@@ -1412,6 +1595,10 @@
       "type": {
         "kind": "struct",
         "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
           {
             "name": "issuer",
             "type": "pubkey"
@@ -1691,6 +1878,18 @@
             }
           },
           {
+            "name": "expected_proof_len",
+            "type": "u32"
+          },
+          {
+            "name": "high_water_mark",
+            "type": "u32"
+          },
+          {
+            "name": "finalized",
+            "type": "bool"
+          },
+          {
             "name": "proof_and_witness",
             "type": "bytes"
           },
@@ -1809,6 +2008,10 @@
         "kind": "struct",
         "fields": [
           {
+            "name": "version",
+            "type": "u8"
+          },
+          {
             "name": "issuer",
             "type": "pubkey"
           },
@@ -1884,9 +2087,9 @@
       "docs": [
         "Pre-staged Light CPI arguments stored in the hook payload so the Token-2022",
         "Execute entry — which only receives `amount: u64` as instruction data — can",
-        "still drive a Light CPI. Clients must include `set_hook_payload` and the",
-        "Token-2022 transfer in a single atomic transaction (same-tx staging),",
-        "otherwise the tree-root index and validity proof go stale."
+        "still drive a Light CPI. Clients must stage the payload via the chunked flow",
+        "(`init_hook_payload` → `write_hook_proof` → `finalize_hook_payload`) before the",
+        "Token-2022 transfer, otherwise the tree-root index and validity proof go stale."
       ],
       "type": {
         "kind": "struct",

--- a/sdk/src/idl/zksettle.ts
+++ b/sdk/src/idl/zksettle.ts
@@ -2,10 +2,10 @@
  * Program IDL in camelCase format in order to be used in JS/TS.
  *
  * Note that this is only a type helper and is not the actual IDL. The original
- * IDL can be found at `sdk/src/idl/zksettle.json`.
+ * IDL can be found at `target/idl/zksettle.json`.
  */
 export type Zksettle = {
-  "address": "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo",
+  "address": "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk",
   "metadata": {
     "name": "zksettle",
     "version": "0.1.0",
@@ -140,6 +140,114 @@ export type Zksettle = {
         }
       ],
       "args": []
+    },
+    {
+      "name": "finalizeHookPayload",
+      "discriminator": [
+        49,
+        120,
+        116,
+        7,
+        20,
+        41,
+        239,
+        107
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "issuer"
+          ]
+        },
+        {
+          "name": "issuer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  115,
+                  115,
+                  117,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hookPayload",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  112,
+                  97,
+                  121,
+                  108,
+                  111,
+                  97,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "nullifierHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "mint",
+          "type": "pubkey"
+        },
+        {
+          "name": "epoch",
+          "type": "u64"
+        },
+        {
+          "name": "recipient",
+          "type": "pubkey"
+        },
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "lightArgs",
+          "type": {
+            "defined": {
+              "name": "stagedLightArgs"
+            }
+          }
+        }
+      ]
     },
     {
       "name": "initAttestationTree",
@@ -383,6 +491,90 @@ export type Zksettle = {
               }
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "initHookPayload",
+      "discriminator": [
+        103,
+        68,
+        111,
+        17,
+        4,
+        137,
+        159,
+        172
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "issuer"
+          ]
+        },
+        {
+          "name": "issuer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  115,
+                  115,
+                  117,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hookPayload",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  112,
+                  97,
+                  121,
+                  108,
+                  111,
+                  97,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "expectedProofLen",
+          "type": "u32"
         }
       ]
     },
@@ -1149,6 +1341,89 @@ export type Zksettle = {
           "type": "u8"
         }
       ]
+    },
+    {
+      "name": "writeHookProof",
+      "discriminator": [
+        245,
+        58,
+        118,
+        142,
+        68,
+        183,
+        252,
+        182
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "issuer"
+          ]
+        },
+        {
+          "name": "issuer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  115,
+                  115,
+                  117,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hookPayload",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  112,
+                  97,
+                  121,
+                  108,
+                  111,
+                  97,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "offset",
+          "type": "u32"
+        },
+        {
+          "name": "chunk",
+          "type": "bytes"
+        }
+      ]
     }
   ],
   "accounts": [
@@ -1410,6 +1685,31 @@ export type Zksettle = {
       "code": 6037,
       "name": "mintHookMismatch",
       "msg": "Mint's TransferHook extension does not point to this program"
+    },
+    {
+      "code": 6038,
+      "name": "chunkOutOfBounds",
+      "msg": "Chunk write exceeds expected_proof_len"
+    },
+    {
+      "code": 6039,
+      "name": "chunkNotSequential",
+      "msg": "Chunk offset does not match high_water_mark (sequential writes required)"
+    },
+    {
+      "code": 6040,
+      "name": "payloadAlreadyFinalized",
+      "msg": "Cannot write to a finalized payload"
+    },
+    {
+      "code": 6041,
+      "name": "payloadNotReady",
+      "msg": "Payload must be finalized before settlement"
+    },
+    {
+      "code": 6042,
+      "name": "proofIncomplete",
+      "msg": "Proof length does not match expected_proof_len at finalize"
     }
   ],
   "types": [
@@ -1418,6 +1718,10 @@ export type Zksettle = {
       "type": {
         "kind": "struct",
         "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
           {
             "name": "issuer",
             "type": "pubkey"
@@ -1697,6 +2001,18 @@ export type Zksettle = {
             }
           },
           {
+            "name": "expectedProofLen",
+            "type": "u32"
+          },
+          {
+            "name": "highWaterMark",
+            "type": "u32"
+          },
+          {
+            "name": "finalized",
+            "type": "bool"
+          },
+          {
             "name": "proofAndWitness",
             "type": "bytes"
           },
@@ -1814,6 +2130,10 @@ export type Zksettle = {
       "type": {
         "kind": "struct",
         "fields": [
+          {
+            "name": "version",
+            "type": "u8"
+          },
           {
             "name": "issuer",
             "type": "pubkey"

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,5 @@
 export { prove, loadCircuit, Prover, computeNullifier, type NullifierInputs } from "./prove/index.js";
 export {
-  wrap,
   buildInitHookPayloadIx,
   buildWriteChunkIx,
   buildFinalizeHookPayloadIx,
@@ -24,7 +23,6 @@ export type {
   ProofInputs,
   ProofResult,
   TransferContext,
-  WrapOptions,
   AuditTrail,
   IssuerRoots,
   ZkSettleConfig,

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -9,8 +9,6 @@ import {
 import BN from "bn.js";
 import type { BN as AnchorBN, Program } from "@coral-xyz/anchor";
 import type {
-  WrapOptions,
-  ZkSettleConfig,
   StagedLightArgs,
   ChunkedUploadOptions,
   ChunkedUploadResult,
@@ -42,44 +40,6 @@ const DEFAULT_LIGHT_ARGS: StagedLightArgs = {
   addressRootIndex: 0,
   outputStateTreeIndex: 0,
 };
-
-export async function wrap(
-  options: WrapOptions,
-  config?: ZkSettleConfig,
-): Promise<Transaction> {
-  const { AnchorProvider, Program } = await loadAnchorBrowser();
-  const programId = config?.programId ?? ZKSETTLE_PROGRAM_ID;
-
-  const [issuerPda] = findIssuerPda(options.wallet, programId);
-  const [hookPayloadPda] = findHookPayloadPda(options.wallet, programId);
-
-  const dummyWallet = new DummyWallet();
-  const provider = new AnchorProvider(options.connection, dummyWallet as any, {});
-  const program = new Program(idl as any, provider);
-
-  const lightArgs = options.lightArgs ?? DEFAULT_LIGHT_ARGS;
-  const epoch = options.transferContext.epoch ?? Math.floor(Date.now() / 1000 / 86400);
-
-  const instruction = await program.methods
-    .setHookPayload(
-      Buffer.from(options.proof),
-      Array.from(options.nullifierHash),
-      options.transferContext.mint,
-      new BN(epoch),
-      options.transferContext.recipient,
-      options.transferContext.amount,
-      lightArgs,
-    )
-    .accounts({
-      authority: options.wallet,
-      issuer: issuerPda,
-      hookPayload: hookPayloadPda,
-      systemProgram: SystemProgram.programId,
-    })
-    .instruction();
-
-  return new Transaction().add(instruction);
-}
 
 // Solana txn limit ~1232 bytes. Per writeHookProof IX: 8 (discriminator) +
 // 4 (offset) + 4 (vec prefix) + CHUNK_SIZE + ~228 (accounts/header). Two


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook payload staging now uses a multi-step flow (init → write → finalize) for chunked proof uploads.
  * Added performance benchmarks and docs with proof timings, circuit metrics, and on-chain verification estimates.
  * Added devnet compute-unit and concurrent-transfer stress-test scripts.

* **Breaking Changes**
  * Removed the single-call payload-staging API from the SDK; switch to the new multi-step instruction sequence.
  * IDL and SDK client surface updated to reflect the new lifecycle and error codes.

* **Documentation**
  * New benchmarks guide and reproduction steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->