### PR TITLE
fix(frontend): use toast notifications instead of inline messages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "shiki": "^4.0.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "three": "^0.184.0",
     "zod": "^4.3.6"

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -7,6 +7,7 @@ import { ConnectionProvider, WalletProvider } from "@solana/wallet-adapter-react
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { SolflareWalletAdapter } from "@solana/wallet-adapter-solflare";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { Toaster } from "sonner";
 
 import { AuthProvider } from "@/contexts/auth-context";
 import { createQueryClient } from "@/lib/api/query-client";
@@ -33,7 +34,23 @@ export function Providers({ children }: Readonly<{ children: React.ReactNode }>)
       <WalletProvider wallets={wallets} autoConnect onError={handleWalletError}>
         <WalletModalProvider>
           <QueryClientProvider client={queryClient}>
-            <AuthProvider>{children}</AuthProvider>
+            <AuthProvider>
+              {children}
+              <Toaster
+                position="bottom-right"
+                toastOptions={{
+                  style: {
+                    fontFamily: "var(--font-mono)",
+                    fontSize: "13px",
+                    borderRadius: "var(--radius-6)",
+                    border: "1px solid var(--color-border-subtle)",
+                    background: "var(--color-surface-deep)",
+                    color: "var(--color-quill)",
+                    boxShadow: "0 1px 3px 0 rgb(0 0 0 / 0.05)",
+                  },
+                }}
+              />
+            </AuthProvider>
           </QueryClientProvider>
         </WalletModalProvider>
       </WalletProvider>

--- a/frontend/src/components/dashboard/api-keys-panel.tsx
+++ b/frontend/src/components/dashboard/api-keys-panel.tsx
@@ -2,6 +2,7 @@
 
 import { Copy, Trash, WarningTriangle } from "iconoir-react";
 import { useEffect, useRef, useState, type SyntheticEvent } from "react";
+import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -73,6 +74,10 @@ export function ApiKeysPanel() {
   const [activePrefix, setActivePrefix] = useState<string | null>(null);
 
   useEffect(() => {
+    if (isError) toast.error(describeError(error));
+  }, [isError, error]);
+
+  useEffect(() => {
     let cancelled = false;
     const refresh = async () => {
       const fallback: ActiveKeyStatus = { hasKey: false };
@@ -93,8 +98,8 @@ export function ApiKeysPanel() {
       setRevealed(created);
       setOwner("");
       setCopied(false);
-    } catch {
-      // surfaced via createKey.error
+    } catch (err) {
+      toast.error(describeError(err));
     }
   };
 
@@ -141,11 +146,12 @@ export function ApiKeysPanel() {
     setPendingRevoke(null);
     try {
       await deleteKey.mutateAsync(target.key_hash);
+      toast.success("API key revoked");
       if (targetPrefix && activePrefix && targetPrefix === activePrefix) {
         await clearActiveApiKey();
       }
-    } catch {
-      // surfaced via deleteKey.error
+    } catch (err) {
+      toast.error(describeError(err));
     }
   };
 
@@ -195,15 +201,6 @@ export function ApiKeysPanel() {
           </Button>
         </form>
 
-        {createKey.error ? (
-          <p
-            role="alert"
-            className="mt-3 flex items-start gap-2 font-mono text-xs text-rust"
-          >
-            <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-            {describeError(createKey.error)}
-          </p>
-        ) : null}
       </section>
 
       <section
@@ -227,30 +224,9 @@ export function ApiKeysPanel() {
           </div>
         </div>
         <p className="mt-2 text-xs text-stone">
-          Lives on the gateway via <span className="font-mono text-quill">GET /api-keys</span>. The
-          full key is shown only at creation time; we cache the prefix locally so you can
+          The full key is shown only at creation time; we cache the prefix locally so you can
           recognise it later.
         </p>
-
-        {isError ? (
-          <p
-            role="alert"
-            className="mt-4 flex items-start gap-2 font-mono text-xs text-rust"
-          >
-            <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-            {describeError(error)}
-          </p>
-        ) : null}
-
-        {deleteKey.error ? (
-          <p
-            role="alert"
-            className="mt-3 flex items-start gap-2 font-mono text-xs text-rust"
-          >
-            <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-            {describeError(deleteKey.error)}
-          </p>
-        ) : null}
 
         {!isError && keys.length === 0 && !isLoading ? (
           <p className="mt-6 font-mono text-xs text-muted">

--- a/frontend/src/components/dashboard/attestation-explorer-panel.tsx
+++ b/frontend/src/components/dashboard/attestation-explorer-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Copy, NavArrowDown, Search, WarningTriangle, Xmark } from "iconoir-react";
-import { useState, type ReactNode, type SyntheticEvent } from "react";
+import { Copy, NavArrowDown, Search, Xmark } from "iconoir-react";
+import { useEffect, useState, type ReactNode, type SyntheticEvent } from "react";
+import { toast } from "sonner";
 
 import { StatusPill, type StatusKind } from "@/components/dashboard/status-pill";
 import { Button } from "@/components/ui/button";
@@ -142,19 +143,7 @@ export function AttestationExplorerPanel() {
           <p id="wallet-help" className="mt-2 font-mono text-xs text-rust">
             Wallet must be 64 hex characters.
           </p>
-        ) : (
-          <p id="wallet-help" className="mt-2 font-mono text-xs text-muted">
-            Calls{" "}
-            <span className="text-quill">
-              GET /v1/proofs/membership/&#123;wallet&#125;
-            </span>{" "}
-            and{" "}
-            <span className="text-quill">
-              GET /v1/proofs/sanctions/&#123;wallet&#125;
-            </span>{" "}
-            .
-          </p>
-        )}
+        ) : null}
       </section>
 
       {/* Compliance status */}
@@ -241,6 +230,24 @@ function AttestationStatusSection({
   const membershipError = membershipQuery.isError ? describeProofError(membershipQuery.error) : null;
   const sanctionsError = sanctionsQuery.isError ? describeProofError(sanctionsQuery.error) : null;
 
+  useEffect(() => {
+    if (membershipError && membershipError.kind !== "not-found") {
+      toast.error(`Membership: ${membershipError.message}`);
+    }
+  }, [membershipError]);
+
+  useEffect(() => {
+    if (sanctionsError && sanctionsError.kind !== "not-found") {
+      toast.error(`Sanctions: ${sanctionsError.message}`);
+    }
+  }, [sanctionsError]);
+
+  useEffect(() => {
+    if (membershipRootMatch === false || sanctionsRootMatch === false) {
+      toast.warning(rootMismatchMessage(membershipRootMatch, sanctionsRootMatch));
+    }
+  }, [membershipRootMatch, sanctionsRootMatch]);
+
   return (
     <section
       aria-labelledby="status-heading"
@@ -261,27 +268,6 @@ function AttestationStatusSection({
 
       {status === "loading" ? (
         <p className="mt-4 font-mono text-xs text-stone">Loading proofs…</p>
-      ) : null}
-
-      {membershipError && membershipError.kind !== "not-found" ? (
-        <p role="alert" className="mt-4 flex items-start gap-2 font-mono text-xs text-rust">
-          <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-          Membership: {membershipError.message}
-        </p>
-      ) : null}
-
-      {sanctionsError && sanctionsError.kind !== "not-found" ? (
-        <p role="alert" className="mt-4 flex items-start gap-2 font-mono text-xs text-rust">
-          <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-          Sanctions: {sanctionsError.message}
-        </p>
-      ) : null}
-
-      {(membershipRootMatch === false || sanctionsRootMatch === false) ? (
-        <p className="mt-4 flex items-start gap-2 font-mono text-xs text-warning-text">
-          <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-          {rootMismatchMessage(membershipRootMatch, sanctionsRootMatch)}
-        </p>
       ) : null}
     </section>
   );

--- a/frontend/src/components/dashboard/audit-log-table.tsx
+++ b/frontend/src/components/dashboard/audit-log-table.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Refresh, WarningTriangle } from "iconoir-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Refresh } from "iconoir-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import { StatusPill } from "@/components/dashboard/status-pill";
 import { Button } from "@/components/ui/button";
@@ -67,15 +68,6 @@ function describeError(err: unknown): string {
 }
 
 export function AuditLogTable() {
-  const [toast, setToast] = useState<string | null>(null);
-  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    };
-  }, []);
-
   const [range, setRange] = useState<RangeValue>("30d");
   const [issuerInput, setIssuerInput] = useState("");
   const [recipientInput, setRecipientInput] = useState("");
@@ -127,18 +119,13 @@ export function AuditLogTable() {
     setRange("30d");
   };
 
-  const showToast = useCallback((message: string) => {
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    setToast(message);
-    toastTimerRef.current = setTimeout(() => {
-      setToast(null);
-      toastTimerRef.current = null;
-    }, 3_000);
-  }, []);
+  useEffect(() => {
+    if (isError) toast.error(describeError(error));
+  }, [isError, error]);
 
   const handleExportCsv = () => {
     if (events.length === 0) {
-      showToast("No events to export");
+      toast("No events to export");
       return;
     }
     exportToCsv(events, "zksettle-audit-log.csv");
@@ -146,7 +133,7 @@ export function AuditLogTable() {
 
   const handleExportJson = () => {
     if (events.length === 0) {
-      showToast("No events to export");
+      toast("No events to export");
       return;
     }
     exportToJson(events, "zksettle-audit-log.json");
@@ -199,19 +186,8 @@ export function AuditLogTable() {
         </div>
         <div className="flex flex-wrap items-center gap-3 font-mono text-xs text-muted">
           <span>{eventCountStatus(isLoading, isError, events.length)}</span>
-          <span>· filters applied server-side via GET /v1/events</span>
         </div>
       </div>
-
-      {isError ? (
-        <p
-          role="alert"
-          className="flex items-start gap-2 rounded-[var(--radius-3)] border border-rust/30 bg-danger-bg px-4 py-3 font-mono text-xs text-rust"
-        >
-          <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-          {describeError(error)}
-        </p>
-      ) : null}
 
       <div className="overflow-x-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface">
         <table className="w-full min-w-[960px] border-collapse text-left">
@@ -296,15 +272,6 @@ export function AuditLogTable() {
         {!hasNextPage && events.length > 0 && <span>End of results</span>}
       </div>
 
-      {toast ? (
-        <div
-          role="status"
-          aria-live="polite"
-          className="fixed right-6 bottom-6 z-50 rounded-[var(--radius-6)] border border-border-subtle bg-surface-deep px-4 py-3 text-sm text-quill shadow-sm"
-        >
-          {toast}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/billing-cards.tsx
+++ b/frontend/src/components/dashboard/billing-cards.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useEffect } from "react";
+import { toast } from "sonner";
+
 import { BillingUsageChart } from "@/components/dashboard/billing-usage-chart";
 import { useUsage, useUsageHistory } from "@/hooks/use-usage";
 import { TIER_PRICE_CENTS, type Tier } from "@/lib/api/schemas";
@@ -21,7 +24,7 @@ function tierPriceLabel(tier: Tier, monthlyLimit: number): string {
 
 export function BillingCards() {
   const { data: usage, isLoading, isError, error } = useUsage();
-  const { data: history, isLoading: historyLoading, isError: historyError } =
+  const { data: history, isLoading: historyLoading, isError: historyError, error: historyErrorObj } =
     useUsageHistory(30);
 
   const tier: Tier = usage?.tier ?? "developer";
@@ -31,6 +34,18 @@ export function BillingCards() {
     monthlyLimit > 0 ? Math.min(100, Math.round((usedThisMonth / monthlyLimit) * 100)) : 0;
   const historyData = history?.history ?? [];
   const historyPeak = historyData.reduce((max, d) => Math.max(max, d.count), 0);
+
+  useEffect(() => {
+    if (isError) {
+      toast.error(error instanceof Error ? error.message : "Failed to load usage");
+    }
+  }, [isError, error]);
+
+  useEffect(() => {
+    if (historyError) {
+      toast.error(historyErrorObj instanceof Error ? historyErrorObj.message : "Failed to load usage history");
+    }
+  }, [historyError, historyErrorObj]);
 
   return (
     <div className="flex flex-col gap-6">
@@ -56,11 +71,6 @@ export function BillingCards() {
                 {isLoading || isError ? "" : tierPriceLabel(tier, monthlyLimit)}
               </span>
             </div>
-            {isError ? (
-              <p className="mt-2 font-mono text-xs text-rust">
-                {error instanceof Error ? error.message : "Failed to load usage"}
-              </p>
-            ) : null}
           </div>
         </div>
 
@@ -100,7 +110,7 @@ export function BillingCards() {
           <span className="font-mono text-xs text-stone">
             {historyLoading && "loading…"}
             {!historyLoading && historyError && "Unavailable"}
-            {!historyLoading && !historyError && `Peak ${fmtCompact(historyPeak)} · GET /usage/history`}
+            {!historyLoading && !historyError && `Peak ${fmtCompact(historyPeak)}`}
           </span>
         </div>
         <div className="mt-4">

--- a/frontend/src/components/dashboard/issuer-status-panel.tsx
+++ b/frontend/src/components/dashboard/issuer-status-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Copy, Refresh, WarningTriangle } from "iconoir-react";
-import { useState } from "react";
+import { Copy, Refresh } from "iconoir-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 
 import { StatCard } from "@/components/dashboard/stat-card";
 import { StatusPill } from "@/components/dashboard/status-pill";
@@ -67,7 +68,10 @@ export function IssuerStatusPanel() {
   const { data: roots, isLoading, isError, error, refetch, isFetching } = useRoots();
   const publish = usePublishRoots();
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
-  const [publishToast, setPublishToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isError) toast.error(describeError(error));
+  }, [isError, error]);
 
   const copy = async (text: string, key: string) => {
     try {
@@ -80,17 +84,15 @@ export function IssuerStatusPanel() {
   };
 
   const onPublish = async () => {
-    setPublishToast(null);
     try {
       const res = await publish.mutateAsync();
-      setPublishToast(
+      toast.success(
         res.registered
           ? `Published at slot ${res.slot.toLocaleString("en-US")}`
           : `Submitted at slot ${res.slot.toLocaleString("en-US")} (issuer not yet registered)`,
       );
-      setTimeout(() => setPublishToast(null), 4_000);
-    } catch {
-      // surfaced via publish.error below
+    } catch (err) {
+      toast.error(describeError(err));
     }
   };
 
@@ -132,16 +134,6 @@ export function IssuerStatusPanel() {
         </div>
       </section>
 
-      {publish.error ? (
-        <p
-          role="alert"
-          className="flex items-start gap-2 rounded-[var(--radius-3)] border border-rust/30 bg-danger-bg px-4 py-3 font-mono text-xs text-rust"
-        >
-          <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-          {describeError(publish.error)}
-        </p>
-      ) : null}
-
       <div className="grid gap-4 sm:grid-cols-2">
         <StatCard
           label="Wallet count"
@@ -166,18 +158,10 @@ export function IssuerStatusPanel() {
           >
             Merkle roots
           </span>
-          <span className="font-mono text-xs text-muted">From GET /v1/roots</span>
+          <span className="font-mono text-xs text-muted">Current state</span>
         </div>
 
-        {isError ? (
-          <p
-            role="alert"
-            className="mt-4 flex items-start gap-2 font-mono text-xs text-rust"
-          >
-            <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-            {describeError(error)}
-          </p>
-        ) : (
+        {!isError ? (
           <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
             {ROOT_FIELDS.map((field) => {
               const value = roots?.[field.key];
@@ -208,18 +192,9 @@ export function IssuerStatusPanel() {
               );
             })}
           </ul>
-        )}
+        ) : null}
       </section>
 
-      {publishToast ? (
-        <div
-          role="status"
-          aria-live="polite"
-          className="fixed right-6 bottom-6 z-50 rounded-[var(--radius-6)] border border-border-subtle bg-surface-deep px-4 py-3 text-sm text-quill shadow-sm"
-        >
-          {publishToast}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/wallets-credentials-panel.tsx
+++ b/frontend/src/components/dashboard/wallets-credentials-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Check, Plus, Search, Trash, WarningTriangle, Xmark } from "iconoir-react";
-import { useState, type SyntheticEvent } from "react";
+import { Plus, Search, Trash, Xmark } from "iconoir-react";
+import { useEffect, useState, type SyntheticEvent } from "react";
+import { toast } from "sonner";
 
 import { StatusPill } from "@/components/dashboard/status-pill";
 import { Button } from "@/components/ui/button";
@@ -75,11 +76,12 @@ export function WalletsCredentialsPanel() {
   const runRegister = async (normalized: string): Promise<void> => {
     register.reset();
     try {
-      await register.mutateAsync(normalized);
+      const res = await register.mutateAsync(normalized);
       recordWallet(normalized);
       setRegisterInput("");
-    } catch {
-      // error surfaced via register.error
+      toast.success(`Wallet registered — ${res.message}`);
+    } catch (err) {
+      toast.error(describeRegisterError(err));
     }
   };
 
@@ -112,9 +114,10 @@ export function WalletsCredentialsPanel() {
     issue.reset();
     try {
       await issue.mutateAsync({ wallet: activeWallet, jurisdiction: issueJurisdiction || undefined });
+      toast.success("Credential issued");
       credentialQuery.refetch();
-    } catch {
-      // surfaced via issue.error
+    } catch (err) {
+      toast.error(describeError(err).message);
     }
   };
 
@@ -123,9 +126,10 @@ export function WalletsCredentialsPanel() {
     revoke.reset();
     try {
       await revoke.mutateAsync(activeWallet);
+      toast.success("Credential revoked");
       credentialQuery.refetch();
-    } catch {
-      // surfaced via revoke.error
+    } catch (err) {
+      toast.error(describeError(err).message);
     }
   };
 
@@ -179,32 +183,6 @@ export function WalletsCredentialsPanel() {
           <p id="register-help" className="mt-2 font-mono text-xs text-rust">
             Wallet must be 64 hex characters.
           </p>
-        ) : (
-          <p id="register-help" className="mt-2 font-mono text-xs text-muted">
-            Calls <span className="text-quill">POST /v1/wallets</span>.
-          </p>
-        )}
-
-        {register.isSuccess ? (
-          <output
-            className="mt-3 flex items-start gap-2 font-mono text-xs text-forest"
-          >
-            <Check aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-            Wallet registered — {register.data.message}
-          </output>
-        ) : null}
-
-        {register.isError ? (
-          <p
-            role="alert"
-            className="mt-3 flex items-start gap-2 font-mono text-xs text-rust"
-          >
-            <WarningTriangle
-              aria-hidden="true"
-              className="mt-0.5 size-4 shrink-0"
-            />
-            {describeRegisterError(register.error)}
-          </p>
         ) : null}
       </section>
 
@@ -243,11 +221,7 @@ export function WalletsCredentialsPanel() {
           <p id="wallet-help" className="mt-2 font-mono text-xs text-rust">
             Wallet must be 64 hex characters.
           </p>
-        ) : (
-          <p id="wallet-help" className="mt-2 font-mono text-xs text-muted">
-            Calls <span className="text-quill">GET /v1/credentials/&#123;wallet&#125;</span>.
-          </p>
-        )}
+        ) : null}
       </section>
 
       {activeWallet ? (
@@ -260,8 +234,6 @@ export function WalletsCredentialsPanel() {
           onRevoke={onRevoke}
           issuePending={issue.isPending}
           revokePending={revoke.isPending}
-          issueError={issue.error}
-          revokeError={revoke.error}
         />
       ) : null}
 
@@ -331,8 +303,6 @@ interface CredentialCardProps {
   onRevoke: () => void;
   issuePending: boolean;
   revokePending: boolean;
-  issueError: unknown;
-  revokeError: unknown;
 }
 
 function CredentialCard({
@@ -344,11 +314,15 @@ function CredentialCard({
   onRevoke,
   issuePending,
   revokePending,
-  issueError,
-  revokeError,
 }: Readonly<CredentialCardProps>) {
   const { data: credential, isLoading, isError, error } = query;
   const errorInfo = isError ? describeError(error) : null;
+
+  useEffect(() => {
+    if (errorInfo && errorInfo.kind !== "not-found") {
+      toast.error(errorInfo.message);
+    }
+  }, [errorInfo]);
 
   return (
     <section
@@ -376,16 +350,6 @@ function CredentialCard({
 
       {isLoading ? (
         <p className="mt-4 font-mono text-xs text-stone">Loading credential…</p>
-      ) : null}
-
-      {errorInfo && errorInfo.kind !== "not-found" ? (
-        <p
-          role="alert"
-          className="mt-4 flex items-start gap-2 font-mono text-xs text-rust"
-        >
-          <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-          {errorInfo.message}
-        </p>
       ) : null}
 
       {credential ? (
@@ -442,24 +406,6 @@ function CredentialCard({
           </div>
         ) : null}
 
-        {issueError ? (
-          <p
-            role="alert"
-            className="mt-3 flex items-start gap-2 font-mono text-xs text-rust"
-          >
-            <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-            {describeError(issueError).message}
-          </p>
-        ) : null}
-        {revokeError ? (
-          <p
-            role="alert"
-            className="mt-3 flex items-start gap-2 font-mono text-xs text-rust"
-          >
-            <WarningTriangle aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-            {describeError(revokeError).message}
-          </p>
-        ) : null}
       </div>
     </section>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3865,6 +3868,12 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8467,6 +8476,11 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sonner@2.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- Remove all hardcoded API endpoint references (e.g. `GET /api-keys`, `GET /v1/roots`, `POST /v1/wallets`) that were being displayed to users in the dashboard UI
- Replace all inline error and success messages with `sonner` toast notifications for a cleaner UX
- Remove custom hand-rolled toast implementations from `issuer-status-panel` and `audit-log-table` in favor of the centralized `<Toaster>` provider
- Toast styled to match the existing design system (mono font, border-subtle, surface-deep background)

## Test plan
- [ ] Verify toast appears on API key creation success and error
- [ ] Verify toast appears on API key revocation
- [ ] Verify toast appears on publish roots success/error
- [ ] Verify toast appears on wallet registration success/error
- [ ] Verify toast appears on credential issue/revoke
- [ ] Verify toast appears on audit log query error and empty export
- [ ] Verify no endpoint text (GET/POST paths) is visible in any dashboard panel
- [ ] Verify form validation errors (e.g. "Wallet must be 64 hex chars") still show inline