### PR TITLE
feat(frontend): admin/operator role management dashboard (#172)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install frontend dependencies
         working-directory: frontend
         run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build SDK
+        working-directory: frontend
+        run: pnpm --filter @zksettle/sdk build
       - name: Run frontend coverage
         working-directory: frontend
         run: pnpm test:coverage

--- a/docs/plans/issue-172-admin-dashboard.md
+++ b/docs/plans/issue-172-admin-dashboard.md
@@ -15,19 +15,23 @@ the abstraction's implementation — no UI rewrites.
 2. **Build full UI against the contract.** Role detection, treasury
    overview, admin panel, operator panel, redemption queue, confirmation
    dialog, route, conditional nav, toasts, tests.
-3. **Two adapters, one default.**
-   - `mockAdapter` — deterministic fixtures; default in dev, test, and
-     storybook-like manual smoke. Keeps the page demoable and lets us
-     exercise every state (paused, frozen, pending admin, etc.).
-   - `sdkAdapter` — placeholder file with `throw new Error("issue #171
-     not yet merged")` stubs that satisfy the local interface. **Does
-     not import from `@zksettle/sdk`** so `pnpm typecheck` / `pnpm
-     build` stay green.
-   Selector lives in `lib/stablecoin/config.ts` and reads
-   `NEXT_PUBLIC_STABLECOIN_ADAPTER` (`"mock" | "sdk"`, default `"mock"`).
-4. **When #171 lands:** rewrite `sdkAdapter` body using the real SDK
-   exports (interface already 1:1), set the env to `"sdk"`, drop the
-   throw stubs. UI does not move.
+3. **Two adapters, sdk is the default.**
+   - `sdkAdapter` — calls the real `@zksettle/sdk` (PDAs, instruction
+     builders, account decoders). This is the production path and the
+     default for any environment that does not opt in to mock mode.
+   - `mockAdapter` — deterministic fixtures (seeded keys, fixed
+     timestamps). Used by every vitest run and available as an opt-in
+     for offline manual smoke / demo screenshots.
+   Selector lives in `lib/stablecoin/adapter.ts` and reads
+   `NEXT_PUBLIC_STABLECOIN_ADAPTER` (`"sdk"` | `"mock"`). Empty/unset
+   resolves to `"sdk"`. Any other value throws a descriptive error so
+   typos like `sdkk` cannot route destructive actions to live RPC.
+4. **Required to ship:** set `NEXT_PUBLIC_STABLECOIN_MINT` to the
+   deployed devnet/mainnet mint and confirm
+   `NEXT_PUBLIC_STABLECOIN_ADAPTER` is unset (or `"sdk"`) in
+   production. The mock-only `NEXT_PUBLIC_STABLECOIN_MOCK_ADMIN` /
+   `_OPERATOR` overrides are ignored when `adapter=sdk` and never
+   need to be set in prod.
 
 ## On-chain reference (verified against `backend/programs/stablecoin/`)
 

--- a/docs/plans/issue-172-admin-dashboard.md
+++ b/docs/plans/issue-172-admin-dashboard.md
@@ -1,0 +1,199 @@
+# Issue #172 — Admin/Operator Role Management Dashboard
+
+**Depends on:** #171 (SDK stablecoin client). Another contributor owns #171.
+**Goal:** Ship every UI/UX deliverable for #172 now, behind a thin local
+abstraction over the SDK shape declared by #171. When #171 merges, swap
+the abstraction's implementation — no UI rewrites.
+
+## Strategy
+
+1. **Local SDK contract first.** Define the stablecoin types and an
+   adapter interface inside `frontend/src/lib/stablecoin/` — the source
+   of truth until #171 publishes the matching exports. UI hooks and
+   components import only from this local module, never from
+   `@zksettle/sdk` directly for stablecoin concerns.
+2. **Build full UI against the contract.** Role detection, treasury
+   overview, admin panel, operator panel, redemption queue, confirmation
+   dialog, route, conditional nav, toasts, tests.
+3. **Two adapters, one default.**
+   - `mockAdapter` — deterministic fixtures; default in dev, test, and
+     storybook-like manual smoke. Keeps the page demoable and lets us
+     exercise every state (paused, frozen, pending admin, etc.).
+   - `sdkAdapter` — placeholder file with `throw new Error("issue #171
+     not yet merged")` stubs that satisfy the local interface. **Does
+     not import from `@zksettle/sdk`** so `pnpm typecheck` / `pnpm
+     build` stay green.
+   Selector lives in `lib/stablecoin/config.ts` and reads
+   `NEXT_PUBLIC_STABLECOIN_ADAPTER` (`"mock" | "sdk"`, default `"mock"`).
+4. **When #171 lands:** rewrite `sdkAdapter` body using the real SDK
+   exports (interface already 1:1), set the env to `"sdk"`, drop the
+   throw stubs. UI does not move.
+
+## On-chain reference (verified against `backend/programs/stablecoin/`)
+
+- Program ID: `2CdXRSPo6QLfLBJTikmrqmBiWwa1HpuuYJ2Qu6Yy3Liv`
+  (`backend/programs/stablecoin/src/lib.rs`).
+- Seeds use **hyphens** (`b"treasury"`, `b"mint-authority"`,
+  `b"freeze-authority"`, `b"redemption"`, `b"escrow-authority"`) per
+  `state/seeds.rs`. Issue #171's prose shows underscores — verify the
+  shipped SDK matches the on-chain seeds before flipping the adapter.
+- `Treasury` fields (from `state/treasury.rs`): `admin`, `operator`,
+  `mint`, `mint_authority_bump`, `freeze_authority_bump`, `bump`,
+  `total_minted: u64`, `total_burned: u64`, `decimals: u8`,
+  `paused: bool`, `pending_admin: Option<Pubkey>`, `mint_cap: u64`,
+  `redemption_nonce: u64`, `escrow_authority_bump`. Local `types.ts`
+  mirrors these exactly (camelCase in TS, BN for u64).
+- `RedemptionRequest` fields: `holder`, `treasury`, `mint`,
+  `token_account`, `amount: u64`, `nonce: u64`, `requested_at: i64`,
+  `bump`. Expiry constant: `REDEMPTION_EXPIRY_SECS = 604_800` (7 days).
+- All 14 program instructions are covered by the issue. Plan maps each:
+  `set_operator`, `propose_admin`, `accept_admin`, `cancel_pending_admin`,
+  `update_mint_cap`, `pause`, `unpause`, `freeze_account`, `thaw_account`,
+  `mint_tokens`, `approve_redemption`, `cancel_redemption` — plus
+  `request_redemption` and `initialize_mint` (out of #172 scope; #171's
+  setup script handles `initialize_mint`).
+
+## Files to create
+
+| File | Purpose |
+|---|---|
+| `frontend/src/lib/stablecoin/types.ts` | `Treasury`, `RedemptionRequest`, `StablecoinRole`, `ActionKind` types — match on-chain layout (BN for u64) |
+| `frontend/src/lib/stablecoin/program.ts` | `STABLECOIN_PROGRAM_ID`, env-driven `STABLECOIN_MINT`, decimals, seed constants — mirrors `seeds.rs` literals |
+| `frontend/src/lib/stablecoin/adapter.ts` | `StablecoinAdapter` interface + `getStablecoinAdapter()` selector |
+| `frontend/src/lib/stablecoin/mock-adapter.ts` | Fixture-backed adapter; covers paused, pending-admin, frozen account, expired redemption states |
+| `frontend/src/lib/stablecoin/sdk-adapter.ts` | Shape-conforming `throw` stubs. **No `@zksettle/sdk` imports yet.** |
+| `frontend/src/lib/stablecoin/format.ts` | `formatAmount(bn, decimals)`, `formatPubkey(pk)`, `mintCapProgress(treasury)`, `redemptionExpiry(request)` |
+| `frontend/src/lib/stablecoin/format.test.ts` | Pure-function unit tests |
+| `frontend/src/lib/stablecoin/mock-adapter.test.ts` | Snapshot fixtures shape against `types.ts` |
+| `frontend/src/hooks/use-treasury.ts` | TanStack `useQuery`; key `treasuryQueryKey(mint)`; mirrors `use-roots.ts` cadence (30s refetch) |
+| `frontend/src/hooks/use-stablecoin-role.ts` | Returns `"admin" \| "operator" \| "both" \| "none"`; returns `"none"` while wallet disconnected or treasury loading |
+| `frontend/src/hooks/use-redemption-requests.ts` | List open `RedemptionRequest`s; `useQuery` with `redemptionsQueryKey(mint)` |
+| `frontend/src/hooks/use-stablecoin-action.ts` | Generic `useMutation`: builds `Transaction` via adapter, signs+sends with `useWallet().sendTransaction`, surfaces signature + Solscan URL, invalidates `treasuryQueryKey` and `redemptionsQueryKey` on success |
+| `frontend/src/hooks/use-nav-items.ts` | Returns the visible `NavItem[]`; consumes `useStablecoinRole` so Sidebar + MobileNavDrawer share one filter |
+| `frontend/src/components/dashboard/confirm-action-dialog.tsx` | Reusable `<dialog>` modal: title, body, danger flag, Confirm/Cancel — mirrors `MobileNavDrawer`'s `<dialog>` pattern |
+| `frontend/src/components/dashboard/treasury-overview.tsx` | Read-only treasury state (visible to admin + operator) |
+| `frontend/src/components/dashboard/admin-controls.tsx` | `set_operator`, `propose_admin` / `accept_admin` / `cancel_pending_admin`, `update_mint_cap`, `pause`/`unpause`, `freeze_account`/`thaw_account` |
+| `frontend/src/components/dashboard/operator-controls.tsx` | `mint_tokens` with cap progress bar |
+| `frontend/src/components/dashboard/redemption-queue.tsx` | List + `approve_redemption` + `cancel_redemption` (when expired) |
+| `frontend/src/components/dashboard/pause-banner.tsx` | Red `StatusPill` banner shown on the admin page when `treasury.paused` |
+| `frontend/src/app/dashboard/admin/page.tsx` | Server route renders `<AdminPanels />` client wrapper |
+| `frontend/src/app/dashboard/admin/admin-panels.tsx` | `"use client"` wrapper that calls `useStablecoinRole`, returns `null` for `"none"`, otherwise renders the panels |
+| `frontend/src/components/dashboard/admin-panels.test.tsx` | Vitest: role gating (`none`/`admin`/`operator`/`both`), confirmation dialog gates submit, mocked adapter + wallet |
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `frontend/src/components/dashboard/nav-items.ts` | Add admin item with `requiresStablecoinRole: true` flag on `NavItem` interface; `findNavItem` unchanged |
+| `frontend/src/components/dashboard/sidebar.tsx` | Replace static `NAV_ITEMS` import with `useNavItems()` |
+| `frontend/src/components/dashboard/mobile-nav-drawer.tsx` | Same — read items from `useNavItems()` |
+| `frontend/src/lib/config.ts` | Re-export `STABLECOIN_MINT` and `STABLECOIN_PROGRAM_ID` from `lib/stablecoin/program.ts` for one-stop config import |
+| `frontend/src/app/dashboard/dashboard-routes.test.tsx` | Add admin route case: mock adapter to return each role, assert panel visibility |
+| `frontend/.env.example` (if present) | Document `NEXT_PUBLIC_STABLECOIN_MINT` and `NEXT_PUBLIC_STABLECOIN_ADAPTER` |
+
+## Conventions to follow (verified against existing code)
+
+- Reads: TanStack Query — copy the pattern from `use-roots.ts`
+  (`refetchInterval: 30_000`).
+- Writes: `useMutation` with `onSuccess` invalidating
+  `treasuryQueryKey` (and `redemptionsQueryKey` for redemption actions).
+- Wallet: `useWallet` and `useConnection` from
+  `@/hooks/use-wallet-connection`. Send via
+  `sendTransaction(tx, connection)` — same shape as
+  `use-prove-flow.ts:runStepSubmit`.
+- Server Components for routes; `"use client"` for interactive panels.
+- **Do not wrap admin route in `<RequireApiKey>`.** Admin actions hit
+  RPC, not the issuer-service. `<RequireAuth>` (already in
+  `dashboard/layout.tsx`) is sufficient. The role hook hides the page
+  for unauthorized wallets.
+- Styling: reuse `StatCard`, `StatusPill`, `Button` (`variant="primary"
+  | "ghost"`), `Input`, `iconoir-react` icons (`Shield` exists, used
+  for nav).
+- Toast / status pattern: copy from `IssuerStatusPanel` (`publishToast`
+  + `role="status" aria-live="polite"`).
+- Confirmation modal: `<dialog>` element with backdrop button — mirror
+  `MobileNavDrawer`'s pattern; no portal library needed.
+- All destructive actions go through `ConfirmActionDialog` — never raw
+  `confirm()`.
+- BN values: import from `@coral-xyz/anchor` (already a dep) — same as
+  `use-prove-flow.ts`.
+- **No new dependencies.** No backend changes. No SDK changes (those
+  are #171). Spl-token helpers, if needed for mint/ATA, stay inside the
+  SDK adapter post-#171; mock adapter never needs them.
+
+## Implementation order
+
+1. Types + adapter scaffolding (`lib/stablecoin/*`). Zero UI yet.
+2. `useTreasury`, `useStablecoinRole`, `useRedemptionRequests`,
+   `useStablecoinAction`, `useNavItems`. Wire to `mockAdapter`.
+3. `ConfirmActionDialog` (used by every panel).
+4. `TreasuryOverview` — validates the read path end-to-end.
+5. `AdminControls`, `OperatorControls`, `RedemptionQueue`,
+   `PauseBanner`. Each action: build → confirm → submit → toast →
+   invalidate.
+6. `/dashboard/admin/page.tsx` + `admin-panels.tsx` with role gate.
+   Update `nav-items.ts`, `sidebar.tsx`, `mobile-nav-drawer.tsx` via
+   `useNavItems`.
+7. Tests: `format.test.ts`, `mock-adapter.test.ts`,
+   `admin-panels.test.tsx`, extend `dashboard-routes.test.tsx`.
+8. Manual smoke: `pnpm dev`, walk every panel via `mockAdapter`, confirm
+   sidebar visibility logic for each role state.
+
+## CI gates this PR must pass
+
+| Workflow | Command | Gate |
+|---|---|---|
+| `build.yml` SonarQube | `pnpm test:coverage` (frontend) | All tests pass; Sonar reports no new bugs/vulns; frontend excluded from coverage thresholds per `sonar-project.properties` |
+| `build.yml` SDK | `pnpm --filter @zksettle/sdk build` + `test` | Untouched by this PR; must still pass |
+| `e2e.yml` Playwright | `pnpm build` then `pnpm test:e2e` | Build succeeds (typecheck + lint pass implicitly); existing specs untouched |
+| Local pre-push | `pnpm typecheck && pnpm lint && pnpm test` (frontend) | Run before pushing |
+
+Risks to watch:
+- `sdk-adapter.ts` must not import unresolved exports from
+  `@zksettle/sdk` — would break typecheck and `pnpm build`.
+- `mock-adapter.ts` BN serialization must round-trip via JSON for
+  TanStack devtools. Use BN constructors, not raw numbers.
+- New nav item must keep all current Sidebar tests passing (none
+  reference admin yet).
+
+## Switch-on checklist (after #171 merges)
+
+1. `pnpm i` to pull updated `@zksettle/sdk` workspace package.
+2. **Verify PDA seeds** — write a one-off script or test that derives
+   each PDA via the SDK and asserts equality against
+   `backend/programs/stablecoin/src/state/seeds.rs` literals (hyphens,
+   not underscores). Block the swap if mismatched.
+3. Replace `sdk-adapter.ts` body with real SDK calls. Keep the file
+   path / interface unchanged.
+4. Set `NEXT_PUBLIC_STABLECOIN_MINT` to the deployed devnet mint and
+   `NEXT_PUBLIC_STABLECOIN_ADAPTER=sdk` (or default to `sdk` in
+   `config.ts`).
+5. Delete `mock-adapter.ts` (or keep behind `process.env.NODE_ENV ===
+   "test"` for unit tests — mocks remain useful for offline coverage).
+6. Integration smoke on devnet:
+   - admin wallet → admin panels visible, operator panels visible
+     (because role = `both` until `set_operator` runs);
+   - operator wallet (after `set_operator`) → only operator panels
+     visible;
+   - random wallet → admin nav hidden, `/dashboard/admin` route
+     returns `null`;
+   - each TX produces a Solscan link and refreshes treasury state.
+7. Update README / docs (if any link to `/dashboard/admin`).
+
+## Acceptance criteria mapping (from #172)
+
+| Criterion | Delivered by |
+|---|---|
+| Role detection | `useStablecoinRole` |
+| Hidden nav for non-roles | `useNavItems` reading `useStablecoinRole` |
+| Treasury overview | `TreasuryOverview` |
+| Admin: set operator | `AdminControls` → `set_operator` |
+| Admin: propose / cancel / accept admin transfer | `AdminControls` → `propose_admin`, `cancel_pending_admin`, `accept_admin` |
+| Admin: update mint cap | `AdminControls` → `update_mint_cap` |
+| Admin: pause / unpause | `AdminControls` → `pause`/`unpause` + `PauseBanner` |
+| Admin: freeze / thaw | `AdminControls` → `freeze_account`/`thaw_account` |
+| Operator: mint with cap | `OperatorControls` → `mint_tokens` |
+| Operator: approve / cancel redemption | `RedemptionQueue` → `approve_redemption` / `cancel_redemption` |
+| Confirmation on every destructive action | `ConfirmActionDialog` wrapping every write |
+| Solscan link + state refresh | `useStablecoinAction` (`onSuccess` invalidates query keys, returns Solscan URL) |
+| Paused state visually distinct | `PauseBanner` on the admin page; followup ticket if reviewers want layout-wide propagation |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -15,3 +15,16 @@ NEXT_PUBLIC_SOLANA_NETWORK=devnet
 
 # Active API keys are now selected at runtime in the dashboard and stored as
 # an HttpOnly cookie (`zks_active_key`). No NEXT_PUBLIC_API_KEY required.
+
+# ── Stablecoin (admin/operator dashboard) ────────────────────
+# Deployed Token-2022 mint that holds the Treasury PDA. Required for the SDK
+# adapter — without it, the admin page shows a "mint not configured" notice.
+NEXT_PUBLIC_STABLECOIN_MINT=
+# Adapter selector: "sdk" hits live RPC; "mock" returns deterministic fixtures
+# for offline development. Defaults to "sdk".
+NEXT_PUBLIC_STABLECOIN_ADAPTER=sdk
+# Optional: when running with NEXT_PUBLIC_STABLECOIN_ADAPTER=mock, pin specific
+# wallets as admin/operator so the connected wallet matches and the role-gated
+# panels render. Ignored in sdk mode.
+NEXT_PUBLIC_STABLECOIN_MOCK_ADMIN=
+NEXT_PUBLIC_STABLECOIN_MOCK_OPERATOR=

--- a/frontend/src/app/dashboard/admin/admin-panels.test.tsx
+++ b/frontend/src/app/dashboard/admin/admin-panels.test.tsx
@@ -41,6 +41,13 @@ vi.mock("@/lib/stablecoin", async () => {
   return {
     ...actual,
     STABLECOIN_MINT_CONFIGURED: true,
+    // Bypass the real adapter entirely so the SDK module never has to
+    // resolve in tests — defends against future static imports leaking
+    // in via the barrel export.
+    getStablecoinAdapter: () => ({
+      getTreasury: vi.fn().mockResolvedValue(null),
+      listRedemptions: vi.fn().mockResolvedValue([]),
+    }),
   };
 });
 

--- a/frontend/src/app/dashboard/admin/admin-panels.test.tsx
+++ b/frontend/src/app/dashboard/admin/admin-panels.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+import { BN } from "@coral-xyz/anchor";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { StablecoinRole, Treasury } from "@/lib/stablecoin";
+
+const roleState: {
+  role: StablecoinRole;
+  treasury: Treasury | null;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  isPendingAdmin: boolean;
+} = {
+  role: "none",
+  treasury: null,
+  isLoading: false,
+  isError: false,
+  error: null,
+  isPendingAdmin: false,
+};
+
+const walletState: { publicKey: PublicKey | null } = { publicKey: null };
+
+vi.mock("@/hooks/use-wallet-connection", () => ({
+  useWallet: () => walletState,
+  useConnection: () => ({ connection: {} }),
+}));
+
+vi.mock("@/hooks/use-stablecoin-role", () => ({
+  useStablecoinRole: () => roleState,
+}));
+
+vi.mock("@/lib/stablecoin", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/stablecoin")>(
+    "@/lib/stablecoin",
+  );
+  return {
+    ...actual,
+    STABLECOIN_MINT_CONFIGURED: true,
+  };
+});
+
+vi.mock("@/components/dashboard/treasury-overview", () => ({
+  TreasuryOverview: () => <div data-testid="treasury-overview" />,
+}));
+vi.mock("@/components/dashboard/admin-controls", () => ({
+  AdminControls: () => <div data-testid="admin-controls" />,
+}));
+vi.mock("@/components/dashboard/operator-controls", () => ({
+  OperatorControls: () => <div data-testid="operator-controls" />,
+}));
+vi.mock("@/components/dashboard/redemption-queue", () => ({
+  RedemptionQueue: () => <div data-testid="redemption-queue" />,
+}));
+vi.mock("@/components/dashboard/pause-banner", () => ({
+  PauseBanner: () => <div data-testid="pause-banner" />,
+}));
+
+import { AdminPanels } from "./admin-panels";
+
+const adminKey = Keypair.generate().publicKey;
+const operatorKey = Keypair.generate().publicKey;
+const otherKey = Keypair.generate().publicKey;
+const mintKey = Keypair.generate().publicKey;
+
+const baseTreasury: Treasury = {
+  admin: adminKey,
+  operator: operatorKey,
+  mint: mintKey,
+  totalMinted: new BN(0),
+  totalBurned: new BN(0),
+  decimals: 6,
+  paused: false,
+  pendingAdmin: null,
+  mintCap: new BN(0),
+  redemptionNonce: new BN(0),
+};
+
+afterEach(() => {
+  cleanup();
+  walletState.publicKey = null;
+  roleState.role = "none";
+  roleState.treasury = baseTreasury;
+  roleState.isLoading = false;
+  roleState.isError = false;
+  roleState.error = null;
+  roleState.isPendingAdmin = false;
+});
+
+describe("AdminPanels", () => {
+  it("renders an error alert when treasury fetch fails", () => {
+    walletState.publicKey = adminKey;
+    roleState.role = "none";
+    roleState.treasury = null;
+    roleState.isError = true;
+    roleState.error = new Error("rpc unavailable");
+    render(<AdminPanels />);
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("rpc unavailable");
+  });
+
+  it("renders nothing when role is none", () => {
+    walletState.publicKey = adminKey;
+    roleState.role = "none";
+    roleState.treasury = baseTreasury;
+    const { container } = render(<AdminPanels />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders only admin controls for admin role", () => {
+    walletState.publicKey = adminKey;
+    roleState.role = "admin";
+    roleState.treasury = baseTreasury;
+    render(<AdminPanels />);
+    expect(screen.getByTestId("treasury-overview")).toBeTruthy();
+    expect(screen.getByTestId("admin-controls")).toBeTruthy();
+    expect(screen.queryByTestId("operator-controls")).toBeNull();
+    expect(screen.queryByTestId("redemption-queue")).toBeNull();
+  });
+
+  it("renders only operator controls for operator role", () => {
+    walletState.publicKey = operatorKey;
+    roleState.role = "operator";
+    roleState.treasury = baseTreasury;
+    render(<AdminPanels />);
+    expect(screen.queryByTestId("admin-controls")).toBeNull();
+    expect(screen.getByTestId("operator-controls")).toBeTruthy();
+    expect(screen.getByTestId("redemption-queue")).toBeTruthy();
+  });
+
+  it("renders both panels for both role", () => {
+    walletState.publicKey = adminKey;
+    roleState.role = "both";
+    roleState.treasury = baseTreasury;
+    render(<AdminPanels />);
+    expect(screen.getByTestId("admin-controls")).toBeTruthy();
+    expect(screen.getByTestId("operator-controls")).toBeTruthy();
+    expect(screen.getByTestId("redemption-queue")).toBeTruthy();
+  });
+
+  it("shows the pause banner when treasury is paused", () => {
+    walletState.publicKey = adminKey;
+    roleState.role = "admin";
+    roleState.treasury = { ...baseTreasury, paused: true };
+    render(<AdminPanels />);
+    expect(screen.getByTestId("pause-banner")).toBeTruthy();
+  });
+
+  it("renders admin controls for an incoming admin (isPendingAdmin)", () => {
+    walletState.publicKey = otherKey;
+    roleState.role = "none";
+    roleState.isPendingAdmin = true;
+    roleState.treasury = baseTreasury;
+    render(<AdminPanels />);
+    expect(screen.getByTestId("admin-controls")).toBeTruthy();
+  });
+});

--- a/frontend/src/app/dashboard/admin/admin-panels.tsx
+++ b/frontend/src/app/dashboard/admin/admin-panels.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { AdminControls } from "@/components/dashboard/admin-controls";
+import { OperatorControls } from "@/components/dashboard/operator-controls";
+import { PauseBanner } from "@/components/dashboard/pause-banner";
+import { RedemptionQueue } from "@/components/dashboard/redemption-queue";
+import { TreasuryOverview } from "@/components/dashboard/treasury-overview";
+import { useStablecoinRole } from "@/hooks/use-stablecoin-role";
+import { useWallet } from "@/hooks/use-wallet-connection";
+import type { StablecoinActionResult } from "@/hooks/use-stablecoin-action";
+import { STABLECOIN_MINT, STABLECOIN_MINT_CONFIGURED } from "@/lib/stablecoin";
+
+const TOAST_TIMEOUT_MS = 6_000;
+
+interface ToastState {
+  summary: string;
+  solscanUrl: string;
+}
+
+export function AdminPanels() {
+  const { publicKey } = useWallet();
+  const { role, treasury, isLoading, isError, error, isPendingAdmin } =
+    useStablecoinRole(STABLECOIN_MINT);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), TOAST_TIMEOUT_MS);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  if (!STABLECOIN_MINT_CONFIGURED) {
+    return (
+      <p className="rounded-[var(--radius-6)] border border-border-subtle bg-surface px-5 py-4 text-sm text-stone">
+        Stablecoin mint not configured. Set{" "}
+        <code className="font-mono">NEXT_PUBLIC_STABLECOIN_MINT</code> to view
+        admin tooling.
+      </p>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p
+        role="alert"
+        className="rounded-[var(--radius-6)] border border-rust/30 bg-danger-bg px-5 py-4 font-mono text-xs text-rust"
+      >
+        Failed to load treasury: {error?.message ?? "unknown error"}
+      </p>
+    );
+  }
+
+  if (isLoading || !treasury) {
+    return (
+      <p className="rounded-[var(--radius-6)] border border-border-subtle bg-surface px-5 py-4 text-sm text-muted">
+        Loading treasury…
+      </p>
+    );
+  }
+
+  if (role === "none" && !isPendingAdmin) {
+    return null;
+  }
+
+  if (!publicKey) return null;
+
+  const onActionComplete = (result: StablecoinActionResult, summary: string) => {
+    setToast({ summary, solscanUrl: result.solscanUrl });
+  };
+
+  const showAdmin = role === "admin" || role === "both" || isPendingAdmin;
+  const showOperator = role === "operator" || role === "both";
+
+  return (
+    <div className="flex flex-col gap-8">
+      {treasury.paused ? <PauseBanner /> : null}
+
+      <TreasuryOverview treasury={treasury} walletPublicKey={publicKey} />
+
+      {showAdmin ? (
+        <AdminControls
+          treasury={treasury}
+          walletPublicKey={publicKey}
+          onActionComplete={onActionComplete}
+          isPendingAdmin={isPendingAdmin}
+        />
+      ) : null}
+
+      {showOperator ? (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <OperatorControls
+            treasury={treasury}
+            onActionComplete={onActionComplete}
+          />
+          <RedemptionQueue
+            treasury={treasury}
+            onActionComplete={onActionComplete}
+          />
+        </div>
+      ) : null}
+
+      {toast ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed right-6 bottom-6 z-50 flex max-w-sm flex-col gap-1 rounded-[var(--radius-6)] border border-border-subtle bg-surface-deep px-4 py-3 text-sm text-quill shadow-sm"
+        >
+          <span>{toast.summary}</span>
+          <a
+            href={toast.solscanUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-xs text-forest underline"
+          >
+            View on Solscan
+          </a>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -1,0 +1,14 @@
+import { AdminPanels } from "@/app/dashboard/admin/admin-panels";
+import { findNavItem } from "@/components/dashboard/nav-items";
+import { PageHeader } from "@/components/dashboard/page-header";
+
+const META = findNavItem("/dashboard/admin")!;
+
+export default function AdminPage() {
+  return (
+    <div className="flex flex-col gap-8">
+      <PageHeader title={META.label} subtitle={META.subtitle} />
+      <AdminPanels />
+    </div>
+  );
+}

--- a/frontend/src/app/dashboard/dashboard-routes.test.tsx
+++ b/frontend/src/app/dashboard/dashboard-routes.test.tsx
@@ -48,6 +48,10 @@ vi.mock("@/components/dashboard/attestation-explorer-panel", () => ({
   AttestationExplorerPanel: () => <section data-testid="attestation-explorer">Attestation explorer</section>,
 }));
 
+vi.mock("@/app/dashboard/admin/admin-panels", () => ({
+  AdminPanels: () => <section data-testid="admin-panels">Admin panels</section>,
+}));
+
 vi.mock("@/components/dashboard/require-auth", () => ({
   RequireAuth: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -58,6 +62,7 @@ vi.mock("@/components/dashboard/require-api-key", () => ({
 
 import DashboardLayout from "./layout";
 import DashboardIndex from "./page";
+import AdminPage from "./admin/page";
 import ApiKeysPage from "./api-keys/page";
 import AttestationsPage from "./attestations/page";
 import AuditLogPage from "./audit-log/page";
@@ -125,6 +130,12 @@ describe("dashboard routes", () => {
     expect(screen.getByTestId("page-header").getAttribute("data-title")).toBe("Attestations");
     expect(screen.getByTestId("attestation-explorer")).toBeTruthy();
     cleanup();
+  });
+
+  it("renders the admin page with admin panels", () => {
+    render(<AdminPage />);
+    expect(screen.getByTestId("page-header").getAttribute("data-title")).toBe("Admin");
+    expect(screen.getByTestId("admin-panels")).toBeTruthy();
   });
 
 });

--- a/frontend/src/components/dashboard/admin-controls.tsx
+++ b/frontend/src/components/dashboard/admin-controls.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import { PublicKey } from "@solana/web3.js";
+import { useState, type ReactNode } from "react";
+
+import { ConfirmActionDialog } from "@/components/dashboard/confirm-action-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  type StablecoinActionResult,
+  useStablecoinAction,
+} from "@/hooks/use-stablecoin-action";
+import {
+  formatAmount,
+  formatPubkey,
+  getStablecoinAdapter,
+  parseAmountToUnits,
+  type Treasury,
+} from "@/lib/stablecoin";
+
+interface AdminControlsProps {
+  treasury: Treasury;
+  walletPublicKey: PublicKey;
+  onActionComplete: (result: StablecoinActionResult, summary: string) => void;
+  isPendingAdmin: boolean;
+}
+
+interface PendingAction {
+  title: string;
+  description: ReactNode;
+  destructive?: boolean;
+  summary: string;
+  buildTransaction: Parameters<typeof useStablecoinAction>[0]["buildTransaction"];
+  confirmLabel: string;
+}
+
+function isValidPubkey(value: string): boolean {
+  try {
+    new PublicKey(value.trim());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function PanelSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-5">
+      <h3 className="font-display text-base text-ink">{title}</h3>
+      <p className="mt-1 text-xs text-stone">{description}</p>
+      <div className="mt-4 flex flex-col gap-3">{children}</div>
+    </section>
+  );
+}
+
+export function AdminControls({
+  treasury,
+  walletPublicKey,
+  onActionComplete,
+  isPendingAdmin,
+}: AdminControlsProps) {
+  const adapter = getStablecoinAdapter();
+  const [pending, setPending] = useState<PendingAction | null>(null);
+
+  const [newOperator, setNewOperator] = useState("");
+  const [newAdmin, setNewAdmin] = useState("");
+  const [newCap, setNewCap] = useState("");
+  const [freezeTarget, setFreezeTarget] = useState("");
+
+  const mutation = useStablecoinAction({
+    mint: treasury.mint,
+    buildTransaction: pending?.buildTransaction ?? (() => {
+      throw new Error("No action selected");
+    }),
+  });
+
+  const closeDialog = () => {
+    if (mutation.isPending) return;
+    setPending(null);
+    mutation.reset();
+  };
+
+  const submit = async () => {
+    if (!pending) return;
+    try {
+      const result = await mutation.mutateAsync();
+      onActionComplete(result, pending.summary);
+      setPending(null);
+      mutation.reset();
+    } catch {
+      // mutation.error surfaces below
+    }
+  };
+
+  const errorMessage =
+    mutation.error instanceof Error ? mutation.error.message : null;
+
+  const operatorValid = newOperator.trim().length > 0 && isValidPubkey(newOperator);
+  const adminValid = newAdmin.trim().length > 0 && isValidPubkey(newAdmin);
+  const freezeValid = freezeTarget.trim().length > 0 && isValidPubkey(freezeTarget);
+  const capRaw = newCap.trim();
+  const decimals = treasury.decimals;
+  const capUnits = capRaw === "" ? null : parseAmountToUnits(capRaw, decimals);
+  const capValid = capRaw === "" || capUnits !== null;
+
+  const queueSetOperator = () => {
+    const next = new PublicKey(newOperator.trim());
+    setPending({
+      title: "Change operator?",
+      description: (
+        <>
+          Change operator to <code>{formatPubkey(next, 6, 6)}</code>? The current
+          operator will lose minting and redemption approval rights.
+        </>
+      ),
+      summary: `Operator changed to ${formatPubkey(next)}`,
+      confirmLabel: "Change operator",
+      buildTransaction: ({ payer }) =>
+        adapter.buildSetOperator({ payer }, treasury.mint, next),
+    });
+  };
+
+  const queueProposeAdmin = () => {
+    const next = new PublicKey(newAdmin.trim());
+    setPending({
+      title: "Propose new admin?",
+      description: (
+        <>
+          Propose <code>{formatPubkey(next, 6, 6)}</code> as new admin. They must
+          call accept_admin to complete the transfer.
+        </>
+      ),
+      summary: `Proposed ${formatPubkey(next)} as new admin`,
+      confirmLabel: "Propose admin",
+      buildTransaction: ({ payer }) =>
+        adapter.buildProposeAdmin({ payer }, treasury.mint, next),
+    });
+  };
+
+  const queueCancelPendingAdmin = () => {
+    setPending({
+      title: "Cancel admin transfer?",
+      description: "The pending admin will no longer be able to accept the role.",
+      summary: "Pending admin transfer cancelled",
+      confirmLabel: "Cancel transfer",
+      destructive: true,
+      buildTransaction: ({ payer }) =>
+        adapter.buildCancelPendingAdmin({ payer }, treasury.mint),
+    });
+  };
+
+  const queueAcceptAdmin = () => {
+    setPending({
+      title: "Accept admin role?",
+      description: "You become admin immediately after this transaction confirms.",
+      summary: "Admin role accepted",
+      confirmLabel: "Accept admin",
+      buildTransaction: ({ payer }) =>
+        adapter.buildAcceptAdmin({ payer }, treasury.mint),
+    });
+  };
+
+  const queueUpdateMintCap = () => {
+    if (!capUnits) return;
+    setPending({
+      title: "Update mint cap?",
+      description: (
+        <>
+          Set mint cap to <code>{capRaw}</code>{" "}
+          {capUnits.lt(treasury.totalMinted) ? (
+            <span className="block pt-1 text-rust">
+              Warning: new cap is below current total minted (
+              {formatAmount(treasury.totalMinted, decimals)}).
+            </span>
+          ) : null}
+        </>
+      ),
+      summary: `Mint cap updated to ${capRaw}`,
+      confirmLabel: "Update cap",
+      buildTransaction: ({ payer }) =>
+        adapter.buildUpdateMintCap({ payer }, treasury.mint, capUnits),
+    });
+  };
+
+  const queuePauseToggle = () => {
+    if (treasury.paused) {
+      setPending({
+        title: "Unpause stablecoin?",
+        description: "Minting, redemptions, and freezes will resume.",
+        summary: "Stablecoin unpaused",
+        confirmLabel: "Unpause",
+        buildTransaction: ({ payer }) =>
+          adapter.buildUnpause({ payer }, treasury.mint),
+      });
+    } else {
+      setPending({
+        title: "Pause the stablecoin?",
+        description:
+          "This blocks ALL minting, redemptions, and freezing. Only thaw remains available.",
+        summary: "Stablecoin paused",
+        destructive: true,
+        confirmLabel: "Pause",
+        buildTransaction: ({ payer }) =>
+          adapter.buildPause({ payer }, treasury.mint),
+      });
+    }
+  };
+
+  const queueFreeze = (kind: "freeze" | "thaw") => {
+    const target = new PublicKey(freezeTarget.trim());
+    setPending({
+      title: kind === "freeze" ? "Freeze account?" : "Thaw account?",
+      description: (
+        <>
+          {kind === "freeze" ? "Freeze" : "Thaw"} token account{" "}
+          <code>{formatPubkey(target, 6, 6)}</code>?
+          {kind === "freeze"
+            ? " The holder will not be able to transfer or request redemption."
+            : " The holder regains transfer ability."}
+        </>
+      ),
+      summary:
+        kind === "freeze"
+          ? `Account ${formatPubkey(target)} frozen`
+          : `Account ${formatPubkey(target)} thawed`,
+      destructive: kind === "freeze",
+      confirmLabel: kind === "freeze" ? "Freeze" : "Thaw",
+      buildTransaction: ({ payer }) =>
+        kind === "freeze"
+          ? adapter.buildFreezeAccount({ payer }, treasury.mint, target)
+          : adapter.buildThawAccount({ payer }, treasury.mint, target),
+    });
+  };
+
+  const isAdmin = walletPublicKey.toBase58() === treasury.admin.toBase58();
+
+  return (
+    <div className="flex flex-col gap-4">
+      {isPendingAdmin && !isAdmin ? (
+        <PanelSection
+          title="Incoming admin role"
+          description="The current admin proposed you as the new admin. Accept to take over."
+        >
+          <Button onClick={queueAcceptAdmin}>Accept admin role</Button>
+        </PanelSection>
+      ) : null}
+
+      {isAdmin ? (
+        <>
+          <PanelSection
+            title="Operator"
+            description={`Current: ${formatPubkey(treasury.operator, 6, 6)}`}
+          >
+            <Input
+              value={newOperator}
+              onChange={(e) => setNewOperator(e.target.value)}
+              placeholder="New operator pubkey"
+              className="font-mono text-xs"
+            />
+            <div>
+              <Button
+                size="sm"
+                onClick={queueSetOperator}
+                disabled={!operatorValid}
+              >
+                Change operator
+              </Button>
+            </div>
+          </PanelSection>
+
+          <PanelSection
+            title="Admin transfer"
+            description={
+              treasury.pendingAdmin
+                ? `Pending admin: ${formatPubkey(treasury.pendingAdmin, 6, 6)}`
+                : "Two-step transfer: propose, then the new admin accepts."
+            }
+          >
+            {treasury.pendingAdmin ? (
+              <div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={queueCancelPendingAdmin}
+                >
+                  Cancel pending transfer
+                </Button>
+              </div>
+            ) : (
+              <>
+                <Input
+                  value={newAdmin}
+                  onChange={(e) => setNewAdmin(e.target.value)}
+                  placeholder="New admin pubkey"
+                  className="font-mono text-xs"
+                />
+                <div>
+                  <Button
+                    size="sm"
+                    onClick={queueProposeAdmin}
+                    disabled={!adminValid}
+                  >
+                    Propose admin
+                  </Button>
+                </div>
+              </>
+            )}
+          </PanelSection>
+
+          <PanelSection
+            title="Mint cap"
+            description={
+              treasury.mintCap.isZero()
+                ? "Currently uncapped."
+                : `Current: ${formatAmount(treasury.mintCap, decimals)}`
+            }
+          >
+            <Input
+              value={newCap}
+              onChange={(e) => setNewCap(e.target.value)}
+              placeholder="New cap (token units, e.g. 1000000)"
+              inputMode="decimal"
+              className="font-mono text-xs"
+            />
+            <div>
+              <Button
+                size="sm"
+                onClick={queueUpdateMintCap}
+                disabled={!capValid || capRaw === ""}
+              >
+                Update cap
+              </Button>
+            </div>
+          </PanelSection>
+
+          <PanelSection
+            title="Emergency"
+            description="Pause halts every flow except thaw. Use for incident response."
+          >
+            <div>
+              <Button
+                size="sm"
+                variant={treasury.paused ? "primary" : "ghost"}
+                onClick={queuePauseToggle}
+                className={treasury.paused ? undefined : "border-rust text-rust hover:bg-rust hover:text-canvas"}
+              >
+                {treasury.paused ? "Unpause" : "Pause"}
+              </Button>
+            </div>
+          </PanelSection>
+
+          <PanelSection
+            title="Freeze / thaw"
+            description={
+              treasury.paused
+                ? "While paused, only thaw is available."
+                : "Block or restore transfers for a specific token account."
+            }
+          >
+            <Input
+              value={freezeTarget}
+              onChange={(e) => setFreezeTarget(e.target.value)}
+              placeholder="Token account pubkey"
+              className="font-mono text-xs"
+            />
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                onClick={() => queueFreeze("freeze")}
+                disabled={!freezeValid || treasury.paused}
+              >
+                Freeze
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => queueFreeze("thaw")}
+                disabled={!freezeValid}
+              >
+                Thaw
+              </Button>
+            </div>
+          </PanelSection>
+        </>
+      ) : null}
+
+      <ConfirmActionDialog
+        open={!!pending}
+        title={pending?.title ?? ""}
+        description={pending?.description ?? null}
+        confirmLabel={pending?.confirmLabel ?? "Confirm"}
+        destructive={pending?.destructive}
+        pending={mutation.isPending}
+        errorMessage={errorMessage}
+        onConfirm={submit}
+        onCancel={closeDialog}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/admin-controls.tsx
+++ b/frontend/src/components/dashboard/admin-controls.tsx
@@ -7,6 +7,7 @@ import { ConfirmActionDialog } from "@/components/dashboard/confirm-action-dialo
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+  type BuildTransactionFn,
   type StablecoinActionResult,
   useStablecoinAction,
 } from "@/hooks/use-stablecoin-action";
@@ -14,44 +15,47 @@ import {
   formatAmount,
   formatPubkey,
   getStablecoinAdapter,
+  isValidPubkey,
   parseAmountToUnits,
+  pubkeysEqual,
   type Treasury,
 } from "@/lib/stablecoin";
 
-interface AdminControlsProps {
-  treasury: Treasury;
-  walletPublicKey: PublicKey;
-  onActionComplete: (result: StablecoinActionResult, summary: string) => void;
-  isPendingAdmin: boolean;
-}
+type OnActionComplete = (
+  result: StablecoinActionResult,
+  summary: string,
+) => void;
 
 interface PendingAction {
   title: string;
   description: ReactNode;
   destructive?: boolean;
   summary: string;
-  buildTransaction: Parameters<typeof useStablecoinAction>[0]["buildTransaction"];
   confirmLabel: string;
+  buildTransaction: BuildTransactionFn;
 }
 
-function isValidPubkey(value: string): boolean {
-  try {
-    new PublicKey(value.trim());
-    return true;
-  } catch {
-    return false;
-  }
+interface AdminControlsProps {
+  treasury: Treasury;
+  walletPublicKey: PublicKey;
+  onActionComplete: OnActionComplete;
+  isPendingAdmin: boolean;
+}
+
+interface SubPanelProps {
+  treasury: Treasury;
+  onActionComplete: OnActionComplete;
 }
 
 function PanelSection({
   title,
   description,
   children,
-}: {
+}: Readonly<{
   title: string;
   description: string;
   children: ReactNode;
-}) {
+}>) {
   return (
     <section className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-5">
       <h3 className="font-display text-base text-ink">{title}</h3>
@@ -61,28 +65,23 @@ function PanelSection({
   );
 }
 
-export function AdminControls({
-  treasury,
-  walletPublicKey,
-  onActionComplete,
-  isPendingAdmin,
-}: AdminControlsProps) {
-  const adapter = getStablecoinAdapter();
+interface UseConfirmAction {
+  pending: PendingAction | null;
+  queue: (action: PendingAction) => void;
+  close: () => void;
+  submit: () => Promise<void>;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+}
+
+function useConfirmAction(
+  mint: PublicKey,
+  onActionComplete: OnActionComplete,
+): UseConfirmAction {
   const [pending, setPending] = useState<PendingAction | null>(null);
+  const mutation = useStablecoinAction({ mint });
 
-  const [newOperator, setNewOperator] = useState("");
-  const [newAdmin, setNewAdmin] = useState("");
-  const [newCap, setNewCap] = useState("");
-  const [freezeTarget, setFreezeTarget] = useState("");
-
-  const mutation = useStablecoinAction({
-    mint: treasury.mint,
-    buildTransaction: pending?.buildTransaction ?? (() => {
-      throw new Error("No action selected");
-    }),
-  });
-
-  const closeDialog = () => {
+  const close = () => {
     if (mutation.isPending) return;
     setPending(null);
     mutation.reset();
@@ -91,34 +90,89 @@ export function AdminControls({
   const submit = async () => {
     if (!pending) return;
     try {
-      const result = await mutation.mutateAsync();
+      const result = await mutation.mutateAsync(pending.buildTransaction);
       onActionComplete(result, pending.summary);
       setPending(null);
       mutation.reset();
     } catch {
-      // mutation.error surfaces below
+      // mutation.error surfaces below via errorMessage
     }
   };
 
-  const errorMessage =
-    mutation.error instanceof Error ? mutation.error.message : null;
+  return {
+    pending,
+    queue: setPending,
+    close,
+    submit,
+    isSubmitting: mutation.isPending,
+    errorMessage:
+      mutation.error instanceof Error ? mutation.error.message : null,
+  };
+}
 
-  const operatorValid = newOperator.trim().length > 0 && isValidPubkey(newOperator);
-  const adminValid = newAdmin.trim().length > 0 && isValidPubkey(newAdmin);
-  const freezeValid = freezeTarget.trim().length > 0 && isValidPubkey(freezeTarget);
-  const capRaw = newCap.trim();
-  const decimals = treasury.decimals;
-  const capUnits = capRaw === "" ? null : parseAmountToUnits(capRaw, decimals);
-  const capValid = capRaw === "" || capUnits !== null;
+function ActionConfirm({ action }: Readonly<{ action: UseConfirmAction }>) {
+  return (
+    <ConfirmActionDialog
+      open={!!action.pending}
+      title={action.pending?.title ?? ""}
+      description={action.pending?.description ?? null}
+      confirmLabel={action.pending?.confirmLabel ?? "Confirm"}
+      destructive={action.pending?.destructive}
+      pending={action.isSubmitting}
+      errorMessage={action.errorMessage}
+      onConfirm={action.submit}
+      onCancel={action.close}
+    />
+  );
+}
 
-  const queueSetOperator = () => {
+function AcceptAdminPanel({
+  treasury,
+  onActionComplete,
+}: Readonly<SubPanelProps>) {
+  const adapter = getStablecoinAdapter();
+  const action = useConfirmAction(treasury.mint, onActionComplete);
+
+  const queue = () => {
+    action.queue({
+      title: "Accept admin role?",
+      description:
+        "You become admin immediately after this transaction confirms.",
+      summary: "Admin role accepted",
+      confirmLabel: "Accept admin",
+      buildTransaction: ({ payer }) =>
+        adapter.buildAcceptAdmin({ payer }, treasury.mint),
+    });
+  };
+
+  return (
+    <PanelSection
+      title="Incoming admin role"
+      description="The current admin proposed you as the new admin. Accept to take over."
+    >
+      <Button onClick={queue}>Accept admin role</Button>
+      <ActionConfirm action={action} />
+    </PanelSection>
+  );
+}
+
+function SetOperatorPanel({
+  treasury,
+  onActionComplete,
+}: Readonly<SubPanelProps>) {
+  const adapter = getStablecoinAdapter();
+  const action = useConfirmAction(treasury.mint, onActionComplete);
+  const [newOperator, setNewOperator] = useState("");
+  const valid = isValidPubkey(newOperator);
+
+  const queue = () => {
     const next = new PublicKey(newOperator.trim());
-    setPending({
+    action.queue({
       title: "Change operator?",
       description: (
         <>
-          Change operator to <code>{formatPubkey(next, 6, 6)}</code>? The current
-          operator will lose minting and redemption approval rights.
+          Change operator to <code>{formatPubkey(next, 6, 6)}</code>? The
+          current operator will lose minting and redemption approval rights.
         </>
       ),
       summary: `Operator changed to ${formatPubkey(next)}`,
@@ -128,14 +182,44 @@ export function AdminControls({
     });
   };
 
+  return (
+    <PanelSection
+      title="Operator"
+      description={`Current: ${formatPubkey(treasury.operator, 6, 6)}`}
+    >
+      <Input
+        value={newOperator}
+        onChange={(e) => setNewOperator(e.target.value)}
+        placeholder="New operator pubkey"
+        className="font-mono text-xs"
+      />
+      <div>
+        <Button size="sm" onClick={queue} disabled={!valid}>
+          Change operator
+        </Button>
+      </div>
+      <ActionConfirm action={action} />
+    </PanelSection>
+  );
+}
+
+function AdminTransferPanel({
+  treasury,
+  onActionComplete,
+}: Readonly<SubPanelProps>) {
+  const adapter = getStablecoinAdapter();
+  const action = useConfirmAction(treasury.mint, onActionComplete);
+  const [newAdmin, setNewAdmin] = useState("");
+  const valid = isValidPubkey(newAdmin);
+
   const queueProposeAdmin = () => {
     const next = new PublicKey(newAdmin.trim());
-    setPending({
+    action.queue({
       title: "Propose new admin?",
       description: (
         <>
-          Propose <code>{formatPubkey(next, 6, 6)}</code> as new admin. They must
-          call accept_admin to complete the transfer.
+          Propose <code>{formatPubkey(next, 6, 6)}</code> as new admin. They
+          must call accept_admin to complete the transfer.
         </>
       ),
       summary: `Proposed ${formatPubkey(next)} as new admin`,
@@ -146,7 +230,7 @@ export function AdminControls({
   };
 
   const queueCancelPendingAdmin = () => {
-    setPending({
+    action.queue({
       title: "Cancel admin transfer?",
       description: "The pending admin will no longer be able to accept the role.",
       summary: "Pending admin transfer cancelled",
@@ -157,25 +241,60 @@ export function AdminControls({
     });
   };
 
-  const queueAcceptAdmin = () => {
-    setPending({
-      title: "Accept admin role?",
-      description: "You become admin immediately after this transaction confirms.",
-      summary: "Admin role accepted",
-      confirmLabel: "Accept admin",
-      buildTransaction: ({ payer }) =>
-        adapter.buildAcceptAdmin({ payer }, treasury.mint),
-    });
-  };
+  const description = treasury.pendingAdmin
+    ? `Pending admin: ${formatPubkey(treasury.pendingAdmin, 6, 6)}`
+    : "Two-step transfer: propose, then the new admin accepts.";
 
-  const queueUpdateMintCap = () => {
+  return (
+    <PanelSection title="Admin transfer" description={description}>
+      {treasury.pendingAdmin ? (
+        <div>
+          <Button size="sm" variant="ghost" onClick={queueCancelPendingAdmin}>
+            Cancel pending transfer
+          </Button>
+        </div>
+      ) : (
+        <>
+          <Input
+            value={newAdmin}
+            onChange={(e) => setNewAdmin(e.target.value)}
+            placeholder="New admin pubkey"
+            className="font-mono text-xs"
+          />
+          <div>
+            <Button size="sm" onClick={queueProposeAdmin} disabled={!valid}>
+              Propose admin
+            </Button>
+          </div>
+        </>
+      )}
+      <ActionConfirm action={action} />
+    </PanelSection>
+  );
+}
+
+function MintCapPanel({
+  treasury,
+  onActionComplete,
+}: Readonly<SubPanelProps>) {
+  const adapter = getStablecoinAdapter();
+  const action = useConfirmAction(treasury.mint, onActionComplete);
+  const [newCap, setNewCap] = useState("");
+
+  const decimals = treasury.decimals;
+  const capRaw = newCap.trim();
+  const capUnits = capRaw === "" ? null : parseAmountToUnits(capRaw, decimals);
+  const valid = capUnits !== null;
+
+  const queue = () => {
     if (!capUnits) return;
-    setPending({
+    const belowMinted = capUnits.lt(treasury.totalMinted);
+    action.queue({
       title: "Update mint cap?",
       description: (
         <>
           Set mint cap to <code>{capRaw}</code>{" "}
-          {capUnits.lt(treasury.totalMinted) ? (
+          {belowMinted ? (
             <span className="block pt-1 text-rust">
               Warning: new cap is below current total minted (
               {formatAmount(treasury.totalMinted, decimals)}).
@@ -190,9 +309,39 @@ export function AdminControls({
     });
   };
 
-  const queuePauseToggle = () => {
+  const description = treasury.mintCap.isZero()
+    ? "Currently uncapped."
+    : `Current: ${formatAmount(treasury.mintCap, decimals)}`;
+
+  return (
+    <PanelSection title="Mint cap" description={description}>
+      <Input
+        value={newCap}
+        onChange={(e) => setNewCap(e.target.value)}
+        placeholder="New cap (token units, e.g. 1000000)"
+        inputMode="decimal"
+        className="font-mono text-xs"
+      />
+      <div>
+        <Button size="sm" onClick={queue} disabled={!valid}>
+          Update cap
+        </Button>
+      </div>
+      <ActionConfirm action={action} />
+    </PanelSection>
+  );
+}
+
+function EmergencyPanel({
+  treasury,
+  onActionComplete,
+}: Readonly<SubPanelProps>) {
+  const adapter = getStablecoinAdapter();
+  const action = useConfirmAction(treasury.mint, onActionComplete);
+
+  const queue = () => {
     if (treasury.paused) {
-      setPending({
+      action.queue({
         title: "Unpause stablecoin?",
         description: "Minting, redemptions, and freezes will resume.",
         summary: "Stablecoin unpaused",
@@ -200,209 +349,154 @@ export function AdminControls({
         buildTransaction: ({ payer }) =>
           adapter.buildUnpause({ payer }, treasury.mint),
       });
-    } else {
-      setPending({
-        title: "Pause the stablecoin?",
-        description:
-          "This blocks ALL minting, redemptions, and freezing. Only thaw remains available.",
-        summary: "Stablecoin paused",
-        destructive: true,
-        confirmLabel: "Pause",
-        buildTransaction: ({ payer }) =>
-          adapter.buildPause({ payer }, treasury.mint),
-      });
+      return;
     }
+    action.queue({
+      title: "Pause the stablecoin?",
+      description:
+        "This blocks ALL minting, redemptions, and freezing. Only thaw remains available.",
+      summary: "Stablecoin paused",
+      destructive: true,
+      confirmLabel: "Pause",
+      buildTransaction: ({ payer }) =>
+        adapter.buildPause({ payer }, treasury.mint),
+    });
   };
 
-  const queueFreeze = (kind: "freeze" | "thaw") => {
-    const target = new PublicKey(freezeTarget.trim());
-    setPending({
-      title: kind === "freeze" ? "Freeze account?" : "Thaw account?",
+  return (
+    <PanelSection
+      title="Emergency"
+      description="Pause halts every flow except thaw. Use for incident response."
+    >
+      <div>
+        <Button
+          size="sm"
+          variant={treasury.paused ? "primary" : "ghost"}
+          onClick={queue}
+          className={
+            treasury.paused
+              ? undefined
+              : "border-rust text-rust hover:bg-rust hover:text-canvas"
+          }
+        >
+          {treasury.paused ? "Unpause" : "Pause"}
+        </Button>
+      </div>
+      <ActionConfirm action={action} />
+    </PanelSection>
+  );
+}
+
+function FreezeThawPanel({
+  treasury,
+  onActionComplete,
+}: Readonly<SubPanelProps>) {
+  const adapter = getStablecoinAdapter();
+  const action = useConfirmAction(treasury.mint, onActionComplete);
+  const [target, setTarget] = useState("");
+  const valid = isValidPubkey(target);
+
+  const queue = (kind: "freeze" | "thaw") => {
+    const tokenAccount = new PublicKey(target.trim());
+    const isFreeze = kind === "freeze";
+    action.queue({
+      title: isFreeze ? "Freeze account?" : "Thaw account?",
       description: (
         <>
-          {kind === "freeze" ? "Freeze" : "Thaw"} token account{" "}
-          <code>{formatPubkey(target, 6, 6)}</code>?
-          {kind === "freeze"
+          {isFreeze ? "Freeze" : "Thaw"} token account{" "}
+          <code>{formatPubkey(tokenAccount, 6, 6)}</code>?
+          {isFreeze
             ? " The holder will not be able to transfer or request redemption."
             : " The holder regains transfer ability."}
         </>
       ),
-      summary:
-        kind === "freeze"
-          ? `Account ${formatPubkey(target)} frozen`
-          : `Account ${formatPubkey(target)} thawed`,
-      destructive: kind === "freeze",
-      confirmLabel: kind === "freeze" ? "Freeze" : "Thaw",
+      summary: isFreeze
+        ? `Account ${formatPubkey(tokenAccount)} frozen`
+        : `Account ${formatPubkey(tokenAccount)} thawed`,
+      destructive: isFreeze,
+      confirmLabel: isFreeze ? "Freeze" : "Thaw",
       buildTransaction: ({ payer }) =>
-        kind === "freeze"
-          ? adapter.buildFreezeAccount({ payer }, treasury.mint, target)
-          : adapter.buildThawAccount({ payer }, treasury.mint, target),
+        isFreeze
+          ? adapter.buildFreezeAccount({ payer }, treasury.mint, tokenAccount)
+          : adapter.buildThawAccount({ payer }, treasury.mint, tokenAccount),
     });
   };
 
-  const isAdmin = walletPublicKey.toBase58() === treasury.admin.toBase58();
+  const description = treasury.paused
+    ? "While paused, only thaw is available."
+    : "Block or restore transfers for a specific token account.";
+
+  return (
+    <PanelSection title="Freeze / thaw" description={description}>
+      <Input
+        value={target}
+        onChange={(e) => setTarget(e.target.value)}
+        placeholder="Token account pubkey"
+        className="font-mono text-xs"
+      />
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          onClick={() => queue("freeze")}
+          disabled={!valid || treasury.paused}
+        >
+          Freeze
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => queue("thaw")}
+          disabled={!valid}
+        >
+          Thaw
+        </Button>
+      </div>
+      <ActionConfirm action={action} />
+    </PanelSection>
+  );
+}
+
+export function AdminControls({
+  treasury,
+  walletPublicKey,
+  onActionComplete,
+  isPendingAdmin,
+}: Readonly<AdminControlsProps>) {
+  const isAdmin = pubkeysEqual(walletPublicKey, treasury.admin);
+  const showAcceptAdmin = isPendingAdmin && !isAdmin;
 
   return (
     <div className="flex flex-col gap-4">
-      {isPendingAdmin && !isAdmin ? (
-        <PanelSection
-          title="Incoming admin role"
-          description="The current admin proposed you as the new admin. Accept to take over."
-        >
-          <Button onClick={queueAcceptAdmin}>Accept admin role</Button>
-        </PanelSection>
+      {showAcceptAdmin ? (
+        <AcceptAdminPanel
+          treasury={treasury}
+          onActionComplete={onActionComplete}
+        />
       ) : null}
-
       {isAdmin ? (
         <>
-          <PanelSection
-            title="Operator"
-            description={`Current: ${formatPubkey(treasury.operator, 6, 6)}`}
-          >
-            <Input
-              value={newOperator}
-              onChange={(e) => setNewOperator(e.target.value)}
-              placeholder="New operator pubkey"
-              className="font-mono text-xs"
-            />
-            <div>
-              <Button
-                size="sm"
-                onClick={queueSetOperator}
-                disabled={!operatorValid}
-              >
-                Change operator
-              </Button>
-            </div>
-          </PanelSection>
-
-          <PanelSection
-            title="Admin transfer"
-            description={
-              treasury.pendingAdmin
-                ? `Pending admin: ${formatPubkey(treasury.pendingAdmin, 6, 6)}`
-                : "Two-step transfer: propose, then the new admin accepts."
-            }
-          >
-            {treasury.pendingAdmin ? (
-              <div>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={queueCancelPendingAdmin}
-                >
-                  Cancel pending transfer
-                </Button>
-              </div>
-            ) : (
-              <>
-                <Input
-                  value={newAdmin}
-                  onChange={(e) => setNewAdmin(e.target.value)}
-                  placeholder="New admin pubkey"
-                  className="font-mono text-xs"
-                />
-                <div>
-                  <Button
-                    size="sm"
-                    onClick={queueProposeAdmin}
-                    disabled={!adminValid}
-                  >
-                    Propose admin
-                  </Button>
-                </div>
-              </>
-            )}
-          </PanelSection>
-
-          <PanelSection
-            title="Mint cap"
-            description={
-              treasury.mintCap.isZero()
-                ? "Currently uncapped."
-                : `Current: ${formatAmount(treasury.mintCap, decimals)}`
-            }
-          >
-            <Input
-              value={newCap}
-              onChange={(e) => setNewCap(e.target.value)}
-              placeholder="New cap (token units, e.g. 1000000)"
-              inputMode="decimal"
-              className="font-mono text-xs"
-            />
-            <div>
-              <Button
-                size="sm"
-                onClick={queueUpdateMintCap}
-                disabled={!capValid || capRaw === ""}
-              >
-                Update cap
-              </Button>
-            </div>
-          </PanelSection>
-
-          <PanelSection
-            title="Emergency"
-            description="Pause halts every flow except thaw. Use for incident response."
-          >
-            <div>
-              <Button
-                size="sm"
-                variant={treasury.paused ? "primary" : "ghost"}
-                onClick={queuePauseToggle}
-                className={treasury.paused ? undefined : "border-rust text-rust hover:bg-rust hover:text-canvas"}
-              >
-                {treasury.paused ? "Unpause" : "Pause"}
-              </Button>
-            </div>
-          </PanelSection>
-
-          <PanelSection
-            title="Freeze / thaw"
-            description={
-              treasury.paused
-                ? "While paused, only thaw is available."
-                : "Block or restore transfers for a specific token account."
-            }
-          >
-            <Input
-              value={freezeTarget}
-              onChange={(e) => setFreezeTarget(e.target.value)}
-              placeholder="Token account pubkey"
-              className="font-mono text-xs"
-            />
-            <div className="flex gap-2">
-              <Button
-                size="sm"
-                onClick={() => queueFreeze("freeze")}
-                disabled={!freezeValid || treasury.paused}
-              >
-                Freeze
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => queueFreeze("thaw")}
-                disabled={!freezeValid}
-              >
-                Thaw
-              </Button>
-            </div>
-          </PanelSection>
+          <SetOperatorPanel
+            treasury={treasury}
+            onActionComplete={onActionComplete}
+          />
+          <AdminTransferPanel
+            treasury={treasury}
+            onActionComplete={onActionComplete}
+          />
+          <MintCapPanel
+            treasury={treasury}
+            onActionComplete={onActionComplete}
+          />
+          <EmergencyPanel
+            treasury={treasury}
+            onActionComplete={onActionComplete}
+          />
+          <FreezeThawPanel
+            treasury={treasury}
+            onActionComplete={onActionComplete}
+          />
         </>
       ) : null}
-
-      <ConfirmActionDialog
-        open={!!pending}
-        title={pending?.title ?? ""}
-        description={pending?.description ?? null}
-        confirmLabel={pending?.confirmLabel ?? "Confirm"}
-        destructive={pending?.destructive}
-        pending={mutation.isPending}
-        errorMessage={errorMessage}
-        onConfirm={submit}
-        onCancel={closeDialog}
-      />
     </div>
   );
 }

--- a/frontend/src/components/dashboard/chrome.test.tsx
+++ b/frontend/src/components/dashboard/chrome.test.tsx
@@ -41,6 +41,14 @@ vi.mock("@/contexts/auth-context", () => ({
   }),
 }));
 
+vi.mock("@/hooks/use-nav-items", async () => {
+  const actual =
+    await vi.importActual<typeof import("./nav-items")>("./nav-items");
+  return {
+    useNavItems: () => actual.NAV_ITEMS,
+  };
+});
+
 import { findNavItem, NAV_GROUPS, NAV_ITEMS } from "./nav-items";
 import { MobileNavDrawer } from "./mobile-nav-drawer";
 import { Sidebar } from "./sidebar";
@@ -63,7 +71,7 @@ describe("dashboard chrome", () => {
 
   it("exposes grouped navigation metadata and path lookup", () => {
     expect(NAV_GROUPS.map((group) => group.id)).toEqual(["overview", "controls", "account"]);
-    expect(NAV_ITEMS).toHaveLength(7);
+    expect(NAV_ITEMS).toHaveLength(8);
     expect(findNavItem("/dashboard/api-keys")?.label).toBe("API keys");
     expect(findNavItem("/dashboard/api-keys/rotate")?.label).toBe("API keys");
     expect(findNavItem("/dashboard/unknown")).toBeUndefined();

--- a/frontend/src/components/dashboard/confirm-action-dialog.test.tsx
+++ b/frontend/src/components/dashboard/confirm-action-dialog.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConfirmActionDialog } from "./confirm-action-dialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ConfirmActionDialog", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ConfirmActionDialog
+        open={false}
+        title="t"
+        description="d"
+        confirmLabel="ok"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls onConfirm when the confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmActionDialog
+        open
+        title="Confirm action"
+        description="Body text"
+        confirmLabel="Run"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when Cancel is clicked", () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmActionDialog
+        open
+        title="t"
+        description="d"
+        confirmLabel="ok"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("disables actions while pending", () => {
+    render(
+      <ConfirmActionDialog
+        open
+        pending
+        title="t"
+        description="d"
+        confirmLabel="ok"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(
+      (screen.getByRole("button", { name: "Submitting…" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("shows the error message when provided", () => {
+    render(
+      <ConfirmActionDialog
+        open
+        title="t"
+        description="d"
+        confirmLabel="ok"
+        errorMessage="boom"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("alert").textContent).toContain("boom");
+  });
+});

--- a/frontend/src/components/dashboard/confirm-action-dialog.tsx
+++ b/frontend/src/components/dashboard/confirm-action-dialog.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { WarningTriangle, Xmark } from "iconoir-react";
+import { useEffect, useId, type ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface ConfirmActionDialogProps {
+  open: boolean;
+  title: string;
+  description: ReactNode;
+  confirmLabel: string;
+  destructive?: boolean;
+  pending?: boolean;
+  errorMessage?: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmActionDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  destructive = false,
+  pending = false,
+  errorMessage = null,
+  onConfirm,
+  onCancel,
+}: ConfirmActionDialogProps) {
+  const titleId = useId();
+  const descId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !pending) {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, pending, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <dialog
+      open
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      className="fixed inset-0 z-50 m-0 h-full w-full max-w-none max-h-none border-none bg-transparent p-0"
+    >
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={() => {
+          if (!pending) onCancel();
+        }}
+        className="absolute inset-0 cursor-pointer bg-ink/40 backdrop-blur-[1px]"
+      />
+      <div className="absolute left-1/2 top-1/2 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-xl">
+        <div className="flex items-start gap-3">
+          {destructive ? (
+            <WarningTriangle
+              aria-hidden="true"
+              className="mt-1 size-5 shrink-0 text-rust"
+            />
+          ) : null}
+          <div className="flex flex-1 flex-col gap-1">
+            <h2 id={titleId} className="font-display text-xl text-ink">
+              {title}
+            </h2>
+            <div id={descId} className="text-sm text-stone">
+              {description}
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onCancel}
+            disabled={pending}
+            className="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-[2px] text-muted hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest disabled:opacity-50"
+          >
+            <Xmark className="size-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {errorMessage ? (
+          <p
+            role="alert"
+            className="mt-4 rounded-[var(--radius-3)] border border-rust/30 bg-danger-bg px-3 py-2 font-mono text-xs text-rust"
+          >
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={onCancel} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onConfirm}
+            disabled={pending}
+            className={destructive ? "bg-rust hover:bg-rust/80" : undefined}
+          >
+            {pending ? "Submitting…" : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/src/components/dashboard/confirm-action-dialog.tsx
+++ b/frontend/src/components/dashboard/confirm-action-dialog.tsx
@@ -27,7 +27,7 @@ export function ConfirmActionDialog({
   errorMessage = null,
   onConfirm,
   onCancel,
-}: ConfirmActionDialogProps) {
+}: Readonly<ConfirmActionDialogProps>) {
   const titleId = useId();
   const descId = useId();
 

--- a/frontend/src/components/dashboard/mobile-nav-drawer.tsx
+++ b/frontend/src/components/dashboard/mobile-nav-drawer.tsx
@@ -6,13 +6,15 @@ import { Menu, Xmark } from "iconoir-react";
 import { useEffect } from "react";
 
 import { Logo } from "@/components/icons/logo";
-import { NAV_GROUPS, NAV_ITEMS } from "@/components/dashboard/nav-items";
+import { NAV_GROUPS } from "@/components/dashboard/nav-items";
 import { useDrawer } from "@/hooks/use-drawer";
+import { useNavItems } from "@/hooks/use-nav-items";
 import { cn } from "@/lib/cn";
 
 export function MobileNavDrawer() {
   const { open, setOpen, close, drawerRef, triggerRef } = useDrawer();
   const pathname = usePathname() ?? "";
+  const navItems = useNavItems();
 
   useEffect(() => {
     setOpen(false);
@@ -69,7 +71,7 @@ export function MobileNavDrawer() {
                     </span>
                   </div>
                   <ul className="flex flex-col gap-[2px]">
-                    {NAV_ITEMS.filter((item) => item.group === group.id).map((item) => {
+                    {navItems.filter((item) => item.group === group.id).map((item) => {
                       const isActive =
                         item.href === "/dashboard"
                           ? pathname === item.href

--- a/frontend/src/components/dashboard/nav-items.ts
+++ b/frontend/src/components/dashboard/nav-items.ts
@@ -6,6 +6,7 @@ import {
   DollarCircle,
   Flash,
   Key,
+  Shield,
 } from "iconoir-react";
 import type { FC, SVGProps } from "react";
 
@@ -17,7 +18,7 @@ export interface NavItem {
   icon: FC<SVGProps<SVGSVGElement>>;
   group: NavGroup;
   subtitle: string;
-
+  requiresStablecoinRole?: true;
 }
 
 export interface NavGroupMeta {
@@ -63,6 +64,15 @@ export const NAV_ITEMS: readonly NavItem[] = [
     group: "overview",
     subtitle:
       "Generate a compliance proof and submit it on-chain. End-to-end in under 15 seconds.",
+  },
+  {
+    label: "Admin",
+    href: "/dashboard/admin",
+    icon: Shield,
+    group: "controls",
+    subtitle:
+      "Govern the stablecoin: change operator, transfer admin, manage mint cap, pause, and approve redemptions.",
+    requiresStablecoinRole: true,
   },
   {
     label: "API keys",

--- a/frontend/src/components/dashboard/operator-controls.tsx
+++ b/frontend/src/components/dashboard/operator-controls.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { PublicKey } from "@solana/web3.js";
+import { useState } from "react";
+
+import { ConfirmActionDialog } from "@/components/dashboard/confirm-action-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  type StablecoinActionResult,
+  useStablecoinAction,
+} from "@/hooks/use-stablecoin-action";
+import {
+  formatAmount,
+  formatPubkey,
+  getStablecoinAdapter,
+  mintCapProgress,
+  parseAmountToUnits,
+  type Treasury,
+} from "@/lib/stablecoin";
+
+interface OperatorControlsProps {
+  treasury: Treasury;
+  onActionComplete: (result: StablecoinActionResult, summary: string) => void;
+}
+
+function isValidPubkey(value: string): boolean {
+  try {
+    new PublicKey(value.trim());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function OperatorControls({
+  treasury,
+  onActionComplete,
+}: OperatorControlsProps) {
+  const adapter = getStablecoinAdapter();
+  const [destination, setDestination] = useState("");
+  const [amount, setAmount] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const decimals = treasury.decimals;
+  const destValid = destination.trim().length > 0 && isValidPubkey(destination);
+  const amountUnits = parseAmountToUnits(amount.trim(), decimals);
+  const amountValid = amountUnits !== null && !amountUnits.isZero();
+  const wouldExceedCap =
+    !treasury.mintCap.isZero() &&
+    amountUnits !== null &&
+    treasury.totalMinted.add(amountUnits).gt(treasury.mintCap);
+
+  const mutation = useStablecoinAction({
+    mint: treasury.mint,
+    buildTransaction: ({ payer }) => {
+      if (!destValid || !amountUnits) {
+        throw new Error("Invalid mint inputs");
+      }
+      return adapter.buildMintTokens(
+        { payer },
+        treasury.mint,
+        new PublicKey(destination.trim()),
+        amountUnits,
+      );
+    },
+  });
+
+  const closeDialog = () => {
+    if (mutation.isPending) return;
+    setConfirmOpen(false);
+    mutation.reset();
+  };
+
+  const submit = async () => {
+    try {
+      const result = await mutation.mutateAsync();
+      const dest = new PublicKey(destination.trim());
+      onActionComplete(result, `Minted ${amount} to ${formatPubkey(dest)}`);
+      setConfirmOpen(false);
+      setAmount("");
+      setDestination("");
+      mutation.reset();
+    } catch {
+      // surfaced via mutation.error
+    }
+  };
+
+  const errorMessage =
+    mutation.error instanceof Error ? mutation.error.message : null;
+  const progress = mintCapProgress(treasury);
+
+  return (
+    <section className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-5">
+      <div className="flex items-baseline justify-between">
+        <h3 className="font-display text-base text-ink">Mint tokens</h3>
+        <span className="font-mono text-[11px] text-stone">
+          {progress.capped
+            ? `${formatAmount(treasury.totalMinted, decimals)} / ${formatAmount(treasury.mintCap, decimals)}`
+            : `${formatAmount(treasury.totalMinted, decimals)} (uncapped)`}
+        </span>
+      </div>
+
+      {progress.capped ? (
+        <div
+          className="mt-3 h-1.5 overflow-hidden rounded-[2px] bg-surface-deep"
+          aria-label="Mint cap progress"
+        >
+          <div
+            className="h-full bg-forest"
+            style={{ width: `${Math.min(100, progress.ratio * 100)}%` }}
+          />
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex flex-col gap-3">
+        <Input
+          value={destination}
+          onChange={(e) => setDestination(e.target.value)}
+          placeholder="Destination wallet pubkey"
+          className="font-mono text-xs"
+        />
+        <Input
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder={`Amount (e.g. 1000)`}
+          inputMode="decimal"
+          className="font-mono text-xs"
+        />
+        {wouldExceedCap ? (
+          <p className="font-mono text-xs text-rust">
+            Amount would exceed the mint cap.
+          </p>
+        ) : null}
+        <div>
+          <Button
+            size="sm"
+            disabled={!destValid || !amountValid || wouldExceedCap || treasury.paused}
+            onClick={() => setConfirmOpen(true)}
+          >
+            {treasury.paused ? "Paused" : "Mint"}
+          </Button>
+        </div>
+      </div>
+
+      <ConfirmActionDialog
+        open={confirmOpen}
+        title="Mint tokens?"
+        description={
+          <>
+            Mint <code>{amount}</code> tokens to{" "}
+            <code>{destValid ? formatPubkey(new PublicKey(destination.trim()), 6, 6) : "—"}</code>
+            ? Current supply: {formatAmount(treasury.totalMinted, decimals)}
+            {progress.capped ? ` / ${formatAmount(treasury.mintCap, decimals)}` : ""}.
+          </>
+        }
+        confirmLabel="Mint"
+        pending={mutation.isPending}
+        errorMessage={errorMessage}
+        onConfirm={submit}
+        onCancel={closeDialog}
+      />
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/operator-controls.tsx
+++ b/frontend/src/components/dashboard/operator-controls.tsx
@@ -14,6 +14,7 @@ import {
   formatAmount,
   formatPubkey,
   getStablecoinAdapter,
+  isValidPubkey,
   mintCapProgress,
   parseAmountToUnits,
   type Treasury,
@@ -24,26 +25,17 @@ interface OperatorControlsProps {
   onActionComplete: (result: StablecoinActionResult, summary: string) => void;
 }
 
-function isValidPubkey(value: string): boolean {
-  try {
-    new PublicKey(value.trim());
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export function OperatorControls({
   treasury,
   onActionComplete,
-}: OperatorControlsProps) {
+}: Readonly<OperatorControlsProps>) {
   const adapter = getStablecoinAdapter();
   const [destination, setDestination] = useState("");
   const [amount, setAmount] = useState("");
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const decimals = treasury.decimals;
-  const destValid = destination.trim().length > 0 && isValidPubkey(destination);
+  const destValid = isValidPubkey(destination);
   const amountUnits = parseAmountToUnits(amount.trim(), decimals);
   const amountValid = amountUnits !== null && !amountUnits.isZero();
   const wouldExceedCap =
@@ -51,20 +43,7 @@ export function OperatorControls({
     amountUnits !== null &&
     treasury.totalMinted.add(amountUnits).gt(treasury.mintCap);
 
-  const mutation = useStablecoinAction({
-    mint: treasury.mint,
-    buildTransaction: ({ payer }) => {
-      if (!destValid || !amountUnits) {
-        throw new Error("Invalid mint inputs");
-      }
-      return adapter.buildMintTokens(
-        { payer },
-        treasury.mint,
-        new PublicKey(destination.trim()),
-        amountUnits,
-      );
-    },
-  });
+  const mutation = useStablecoinAction({ mint: treasury.mint });
 
   const closeDialog = () => {
     if (mutation.isPending) return;
@@ -73,9 +52,12 @@ export function OperatorControls({
   };
 
   const submit = async () => {
+    if (!destValid || !amountUnits) return;
+    const dest = new PublicKey(destination.trim());
     try {
-      const result = await mutation.mutateAsync();
-      const dest = new PublicKey(destination.trim());
+      const result = await mutation.mutateAsync(({ payer }) =>
+        adapter.buildMintTokens({ payer }, treasury.mint, dest, amountUnits),
+      );
       onActionComplete(result, `Minted ${amount} to ${formatPubkey(dest)}`);
       setConfirmOpen(false);
       setAmount("");
@@ -90,15 +72,22 @@ export function OperatorControls({
     mutation.error instanceof Error ? mutation.error.message : null;
   const progress = mintCapProgress(treasury);
 
+  const supplyText = progress.capped
+    ? `${formatAmount(treasury.totalMinted, decimals)} / ${formatAmount(treasury.mintCap, decimals)}`
+    : `${formatAmount(treasury.totalMinted, decimals)} (uncapped)`;
+
+  const destFormatted = destValid
+    ? formatPubkey(new PublicKey(destination.trim()), 6, 6)
+    : "—";
+  const capSuffix = progress.capped
+    ? ` / ${formatAmount(treasury.mintCap, decimals)}`
+    : "";
+
   return (
     <section className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-5">
       <div className="flex items-baseline justify-between">
         <h3 className="font-display text-base text-ink">Mint tokens</h3>
-        <span className="font-mono text-[11px] text-stone">
-          {progress.capped
-            ? `${formatAmount(treasury.totalMinted, decimals)} / ${formatAmount(treasury.mintCap, decimals)}`
-            : `${formatAmount(treasury.totalMinted, decimals)} (uncapped)`}
-        </span>
+        <span className="font-mono text-[11px] text-stone">{supplyText}</span>
       </div>
 
       {progress.capped ? (
@@ -123,7 +112,7 @@ export function OperatorControls({
         <Input
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
-          placeholder={`Amount (e.g. 1000)`}
+          placeholder="Amount (e.g. 1000)"
           inputMode="decimal"
           className="font-mono text-xs"
         />
@@ -135,7 +124,9 @@ export function OperatorControls({
         <div>
           <Button
             size="sm"
-            disabled={!destValid || !amountValid || wouldExceedCap || treasury.paused}
+            disabled={
+              !destValid || !amountValid || wouldExceedCap || treasury.paused
+            }
             onClick={() => setConfirmOpen(true)}
           >
             {treasury.paused ? "Paused" : "Mint"}
@@ -148,10 +139,9 @@ export function OperatorControls({
         title="Mint tokens?"
         description={
           <>
-            Mint <code>{amount}</code> tokens to{" "}
-            <code>{destValid ? formatPubkey(new PublicKey(destination.trim()), 6, 6) : "—"}</code>
-            ? Current supply: {formatAmount(treasury.totalMinted, decimals)}
-            {progress.capped ? ` / ${formatAmount(treasury.mintCap, decimals)}` : ""}.
+            Mint <code>{amount}</code> tokens to <code>{destFormatted}</code>?
+            Current supply: {formatAmount(treasury.totalMinted, decimals)}
+            {capSuffix}.
           </>
         }
         confirmLabel="Mint"

--- a/frontend/src/components/dashboard/pause-banner.tsx
+++ b/frontend/src/components/dashboard/pause-banner.tsx
@@ -1,0 +1,19 @@
+import { WarningTriangle } from "iconoir-react";
+
+export function PauseBanner() {
+  return (
+    <section
+      role="alert"
+      className="flex items-start gap-3 rounded-[var(--radius-6)] border border-rust/40 bg-danger-bg px-5 py-4"
+    >
+      <WarningTriangle aria-hidden="true" className="mt-0.5 size-5 shrink-0 text-rust" />
+      <div className="flex flex-col gap-1">
+        <p className="font-display text-sm text-rust">Stablecoin paused</p>
+        <p className="font-mono text-xs text-rust/80">
+          Minting, redemptions, and freezes are blocked. Only thaw remains
+          available while paused.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/redemption-queue.tsx
+++ b/frontend/src/components/dashboard/redemption-queue.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+import { ConfirmActionDialog } from "@/components/dashboard/confirm-action-dialog";
+import { StatusPill } from "@/components/dashboard/status-pill";
+import { Button } from "@/components/ui/button";
+import { useRedemptionRequests } from "@/hooks/use-redemption-requests";
+import {
+  type StablecoinActionResult,
+  useStablecoinAction,
+} from "@/hooks/use-stablecoin-action";
+import {
+  formatAmount,
+  formatDuration,
+  formatPubkey,
+  getStablecoinAdapter,
+  redemptionExpiry,
+  type RedemptionRequest,
+  type Treasury,
+} from "@/lib/stablecoin";
+
+interface RedemptionQueueProps {
+  treasury: Treasury;
+  onActionComplete: (result: StablecoinActionResult, summary: string) => void;
+}
+
+interface PendingAction {
+  request: RedemptionRequest;
+  kind: "approve" | "cancel";
+  title: string;
+  description: ReactNode;
+  summary: string;
+}
+
+export function RedemptionQueue({
+  treasury,
+  onActionComplete,
+}: RedemptionQueueProps) {
+  const adapter = getStablecoinAdapter();
+  const { data, isLoading, isError, error } = useRedemptionRequests(
+    treasury.mint,
+  );
+  const [pending, setPending] = useState<PendingAction | null>(null);
+
+  const mutation = useStablecoinAction({
+    mint: treasury.mint,
+    buildTransaction: ({ payer }) => {
+      if (!pending) throw new Error("No redemption selected");
+      return pending.kind === "approve"
+        ? adapter.buildApproveRedemption({ payer }, treasury.mint, pending.request)
+        : adapter.buildCancelRedemption({ payer }, treasury.mint, pending.request);
+    },
+  });
+
+  const closeDialog = () => {
+    if (mutation.isPending) return;
+    setPending(null);
+    mutation.reset();
+  };
+
+  const submit = async () => {
+    if (!pending) return;
+    try {
+      const result = await mutation.mutateAsync();
+      onActionComplete(result, pending.summary);
+      setPending(null);
+      mutation.reset();
+    } catch {
+      // surfaced via mutation.error
+    }
+  };
+
+  const errorMessage =
+    mutation.error instanceof Error ? mutation.error.message : null;
+
+  const requests = data ?? [];
+
+  return (
+    <section className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-5">
+      <div className="flex items-baseline justify-between">
+        <h3 className="font-display text-base text-ink">Redemption queue</h3>
+        <span className="font-mono text-[11px] text-muted">
+          {requests.length} open
+        </span>
+      </div>
+
+      {isError ? (
+        <p role="alert" className="mt-4 font-mono text-xs text-rust">
+          Failed to load redemptions:{" "}
+          {error instanceof Error ? error.message : "unknown error"}
+        </p>
+      ) : isLoading ? (
+        <p className="mt-4 font-mono text-xs text-muted">Loading…</p>
+      ) : requests.length === 0 ? (
+        <p className="mt-4 font-mono text-xs text-muted">
+          No pending redemptions.
+        </p>
+      ) : (
+        <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
+          {requests.map((req) => {
+            const expiry = redemptionExpiry(req);
+            const amountText = formatAmount(req.amount, treasury.decimals);
+            const queueApprove = () =>
+              setPending({
+                request: req,
+                kind: "approve",
+                title: "Approve redemption?",
+                description: (
+                  <>
+                    Approve redemption of <code>{amountText}</code> tokens for{" "}
+                    <code>{formatPubkey(req.holder, 6, 6)}</code>? Tokens will be
+                    burned.
+                  </>
+                ),
+                summary: `Redemption approved for ${formatPubkey(req.holder)}`,
+              });
+            const queueCancel = () =>
+              setPending({
+                request: req,
+                kind: "cancel",
+                title: "Cancel redemption?",
+                description:
+                  "The holder regains transfer ability and the request is closed.",
+                summary: `Redemption cancelled for ${formatPubkey(req.holder)}`,
+              });
+
+            return (
+              <li
+                key={req.pda.toBase58()}
+                className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+              >
+                <div className="flex flex-col">
+                  <span className="font-mono text-xs text-quill">
+                    {formatPubkey(req.holder, 6, 6)}
+                  </span>
+                  <span className="text-xs text-stone">
+                    {amountText} tokens · nonce {req.nonce.toString()}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {expiry.expired ? (
+                    <StatusPill kind="warning" label="Expired" />
+                  ) : (
+                    <span className="font-mono text-[11px] text-muted">
+                      {formatDuration(expiry.secondsRemaining)} left
+                    </span>
+                  )}
+                  {expiry.expired ? (
+                    <Button size="sm" variant="ghost" onClick={queueCancel}>
+                      Cancel (expired)
+                    </Button>
+                  ) : (
+                    <Button size="sm" onClick={queueApprove} disabled={treasury.paused}>
+                      Approve
+                    </Button>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <ConfirmActionDialog
+        open={!!pending}
+        title={pending?.title ?? ""}
+        description={pending?.description ?? null}
+        confirmLabel={pending?.kind === "approve" ? "Approve" : "Cancel"}
+        destructive={pending?.kind === "cancel"}
+        pending={mutation.isPending}
+        errorMessage={errorMessage}
+        onConfirm={submit}
+        onCancel={closeDialog}
+      />
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/redemption-queue.tsx
+++ b/frontend/src/components/dashboard/redemption-queue.tsx
@@ -33,25 +33,127 @@ interface PendingAction {
   summary: string;
 }
 
+interface RedemptionRowProps {
+  treasury: Treasury;
+  request: RedemptionRequest;
+  onApprove: () => void;
+  onCancel: () => void;
+}
+
+function RedemptionRow({
+  treasury,
+  request,
+  onApprove,
+  onCancel,
+}: Readonly<RedemptionRowProps>) {
+  const expiry = redemptionExpiry(request);
+  const amountText = formatAmount(request.amount, treasury.decimals);
+
+  let timeIndicator: ReactNode;
+  if (expiry.expired) {
+    timeIndicator = <StatusPill kind="warning" label="Expired" />;
+  } else {
+    timeIndicator = (
+      <span className="font-mono text-[11px] text-muted">
+        {formatDuration(expiry.secondsRemaining)} left
+      </span>
+    );
+  }
+
+  let actionButton: ReactNode;
+  if (expiry.expired) {
+    actionButton = (
+      <Button size="sm" variant="ghost" onClick={onCancel}>
+        Cancel (expired)
+      </Button>
+    );
+  } else {
+    actionButton = (
+      <Button size="sm" onClick={onApprove} disabled={treasury.paused}>
+        Approve
+      </Button>
+    );
+  }
+
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+      <div className="flex flex-col">
+        <span className="font-mono text-xs text-quill">
+          {formatPubkey(request.holder, 6, 6)}
+        </span>
+        <span className="text-xs text-stone">
+          {amountText} tokens · nonce {request.nonce.toString()}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        {timeIndicator}
+        {actionButton}
+      </div>
+    </li>
+  );
+}
+
+interface RedemptionListProps {
+  treasury: Treasury;
+  isError: boolean;
+  error: unknown;
+  isLoading: boolean;
+  requests: RedemptionRequest[];
+  onApprove: (request: RedemptionRequest) => void;
+  onCancel: (request: RedemptionRequest) => void;
+}
+
+function RedemptionList({
+  treasury,
+  isError,
+  error,
+  isLoading,
+  requests,
+  onApprove,
+  onCancel,
+}: Readonly<RedemptionListProps>) {
+  if (isError) {
+    return (
+      <p role="alert" className="mt-4 font-mono text-xs text-rust">
+        Failed to load redemptions:{" "}
+        {error instanceof Error ? error.message : "unknown error"}
+      </p>
+    );
+  }
+  if (isLoading) {
+    return <p className="mt-4 font-mono text-xs text-muted">Loading…</p>;
+  }
+  if (requests.length === 0) {
+    return (
+      <p className="mt-4 font-mono text-xs text-muted">No pending redemptions.</p>
+    );
+  }
+  return (
+    <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
+      {requests.map((request) => (
+        <RedemptionRow
+          key={request.pda.toBase58()}
+          treasury={treasury}
+          request={request}
+          onApprove={() => onApprove(request)}
+          onCancel={() => onCancel(request)}
+        />
+      ))}
+    </ul>
+  );
+}
+
 export function RedemptionQueue({
   treasury,
   onActionComplete,
-}: RedemptionQueueProps) {
+}: Readonly<RedemptionQueueProps>) {
   const adapter = getStablecoinAdapter();
   const { data, isLoading, isError, error } = useRedemptionRequests(
     treasury.mint,
   );
   const [pending, setPending] = useState<PendingAction | null>(null);
 
-  const mutation = useStablecoinAction({
-    mint: treasury.mint,
-    buildTransaction: ({ payer }) => {
-      if (!pending) throw new Error("No redemption selected");
-      return pending.kind === "approve"
-        ? adapter.buildApproveRedemption({ payer }, treasury.mint, pending.request)
-        : adapter.buildCancelRedemption({ payer }, treasury.mint, pending.request);
-    },
-  });
+  const mutation = useStablecoinAction({ mint: treasury.mint });
 
   const closeDialog = () => {
     if (mutation.isPending) return;
@@ -61,14 +163,47 @@ export function RedemptionQueue({
 
   const submit = async () => {
     if (!pending) return;
+    const { request, kind } = pending;
     try {
-      const result = await mutation.mutateAsync();
+      const result = await mutation.mutateAsync(({ payer }) =>
+        kind === "approve"
+          ? adapter.buildApproveRedemption({ payer }, treasury.mint, request)
+          : adapter.buildCancelRedemption({ payer }, treasury.mint, request),
+      );
       onActionComplete(result, pending.summary);
       setPending(null);
       mutation.reset();
     } catch {
       // surfaced via mutation.error
     }
+  };
+
+  const onApprove = (request: RedemptionRequest) => {
+    const amountText = formatAmount(request.amount, treasury.decimals);
+    setPending({
+      request,
+      kind: "approve",
+      title: "Approve redemption?",
+      description: (
+        <>
+          Approve redemption of <code>{amountText}</code> tokens for{" "}
+          <code>{formatPubkey(request.holder, 6, 6)}</code>? Tokens will be
+          burned.
+        </>
+      ),
+      summary: `Redemption approved for ${formatPubkey(request.holder)}`,
+    });
+  };
+
+  const onCancel = (request: RedemptionRequest) => {
+    setPending({
+      request,
+      kind: "cancel",
+      title: "Cancel redemption?",
+      description:
+        "The holder regains transfer ability and the request is closed.",
+      summary: `Redemption cancelled for ${formatPubkey(request.holder)}`,
+    });
   };
 
   const errorMessage =
@@ -85,82 +220,15 @@ export function RedemptionQueue({
         </span>
       </div>
 
-      {isError ? (
-        <p role="alert" className="mt-4 font-mono text-xs text-rust">
-          Failed to load redemptions:{" "}
-          {error instanceof Error ? error.message : "unknown error"}
-        </p>
-      ) : isLoading ? (
-        <p className="mt-4 font-mono text-xs text-muted">Loading…</p>
-      ) : requests.length === 0 ? (
-        <p className="mt-4 font-mono text-xs text-muted">
-          No pending redemptions.
-        </p>
-      ) : (
-        <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
-          {requests.map((req) => {
-            const expiry = redemptionExpiry(req);
-            const amountText = formatAmount(req.amount, treasury.decimals);
-            const queueApprove = () =>
-              setPending({
-                request: req,
-                kind: "approve",
-                title: "Approve redemption?",
-                description: (
-                  <>
-                    Approve redemption of <code>{amountText}</code> tokens for{" "}
-                    <code>{formatPubkey(req.holder, 6, 6)}</code>? Tokens will be
-                    burned.
-                  </>
-                ),
-                summary: `Redemption approved for ${formatPubkey(req.holder)}`,
-              });
-            const queueCancel = () =>
-              setPending({
-                request: req,
-                kind: "cancel",
-                title: "Cancel redemption?",
-                description:
-                  "The holder regains transfer ability and the request is closed.",
-                summary: `Redemption cancelled for ${formatPubkey(req.holder)}`,
-              });
-
-            return (
-              <li
-                key={req.pda.toBase58()}
-                className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
-              >
-                <div className="flex flex-col">
-                  <span className="font-mono text-xs text-quill">
-                    {formatPubkey(req.holder, 6, 6)}
-                  </span>
-                  <span className="text-xs text-stone">
-                    {amountText} tokens · nonce {req.nonce.toString()}
-                  </span>
-                </div>
-                <div className="flex items-center gap-2">
-                  {expiry.expired ? (
-                    <StatusPill kind="warning" label="Expired" />
-                  ) : (
-                    <span className="font-mono text-[11px] text-muted">
-                      {formatDuration(expiry.secondsRemaining)} left
-                    </span>
-                  )}
-                  {expiry.expired ? (
-                    <Button size="sm" variant="ghost" onClick={queueCancel}>
-                      Cancel (expired)
-                    </Button>
-                  ) : (
-                    <Button size="sm" onClick={queueApprove} disabled={treasury.paused}>
-                      Approve
-                    </Button>
-                  )}
-                </div>
-              </li>
-            );
-          })}
-        </ul>
-      )}
+      <RedemptionList
+        treasury={treasury}
+        isError={isError}
+        error={error}
+        isLoading={isLoading}
+        requests={requests}
+        onApprove={onApprove}
+        onCancel={onCancel}
+      />
 
       <ConfirmActionDialog
         open={!!pending}

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -4,11 +4,13 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import pkg from "@/../package.json";
 import { Logo } from "@/components/icons/logo";
-import { NAV_GROUPS, NAV_ITEMS } from "@/components/dashboard/nav-items";
+import { NAV_GROUPS } from "@/components/dashboard/nav-items";
+import { useNavItems } from "@/hooks/use-nav-items";
 import { cn } from "@/lib/cn";
 
 export function Sidebar() {
   const pathname = usePathname() ?? "";
+  const navItems = useNavItems();
 
   return (
     <aside
@@ -34,7 +36,7 @@ export function Sidebar() {
               </span>
             </div>
             <ul className="flex flex-col gap-[2px]">
-              {NAV_ITEMS.filter((item) => item.group === group.id).map((item) => {
+              {navItems.filter((item) => item.group === group.id).map((item) => {
                 const isActive =
                   item.href === "/dashboard"
                     ? pathname === item.href

--- a/frontend/src/components/dashboard/treasury-overview.tsx
+++ b/frontend/src/components/dashboard/treasury-overview.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { Copy } from "iconoir-react";
+import { useState, type ReactNode } from "react";
+import type { PublicKey } from "@solana/web3.js";
+
+import { StatCard } from "@/components/dashboard/stat-card";
+import { StatusPill } from "@/components/dashboard/status-pill";
+import { Button } from "@/components/ui/button";
+import {
+  circulatingSupply,
+  formatAmount,
+  formatPubkey,
+  pubkeysEqual,
+  type Treasury,
+} from "@/lib/stablecoin";
+
+interface TreasuryOverviewProps {
+  treasury: Treasury;
+  walletPublicKey: PublicKey | null;
+}
+
+interface FieldRowProps {
+  label: string;
+  value: ReactNode;
+  copyValue?: string;
+  badge?: ReactNode;
+}
+
+function FieldRow({ label, value, copyValue, badge }: FieldRowProps) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    if (!copyValue) return;
+    try {
+      await navigator.clipboard.writeText(copyValue);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1_500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0">
+      <div className="flex flex-col">
+        <span className="text-sm font-medium text-ink">{label}</span>
+        {badge ? <span className="mt-1">{badge}</span> : null}
+      </div>
+      <div className="flex items-center gap-2">
+        <code className="font-mono text-xs text-quill">{value}</code>
+        {copyValue ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onCopy}
+            aria-label={`Copy ${label}`}
+          >
+            <Copy aria-hidden="true" className="size-4" />
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function youBadge() {
+  return (
+    <span className="inline-flex w-fit items-center rounded-[var(--radius-2)] bg-mint px-2 py-[2px] font-mono text-[10px] font-medium uppercase tracking-[0.08em] text-forest">
+      You
+    </span>
+  );
+}
+
+export function TreasuryOverview({
+  treasury,
+  walletPublicKey,
+}: TreasuryOverviewProps) {
+  const decimals = treasury.decimals;
+  const circulatingDisplay = formatAmount(circulatingSupply(treasury), decimals);
+
+  const mintCapDisplay =
+    treasury.mintCap.isZero()
+      ? "Unlimited"
+      : `${formatAmount(treasury.mintCap, decimals)}`;
+
+  const adminBadge = pubkeysEqual(walletPublicKey, treasury.admin)
+    ? youBadge()
+    : null;
+  const operatorBadge = pubkeysEqual(walletPublicKey, treasury.operator)
+    ? youBadge()
+    : null;
+  const pendingAdminBadge =
+    treasury.pendingAdmin && pubkeysEqual(walletPublicKey, treasury.pendingAdmin)
+      ? youBadge()
+      : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <StatCard
+          label="Total minted"
+          value={formatAmount(treasury.totalMinted, decimals)}
+        />
+        <StatCard
+          label="Circulating"
+          value={circulatingDisplay}
+          sub={`Burned: ${formatAmount(treasury.totalBurned, decimals)}`}
+        />
+        <StatCard label="Mint cap" value={mintCapDisplay} />
+      </div>
+
+      <section
+        aria-labelledby="treasury-heading"
+        className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
+      >
+        <div className="flex items-baseline justify-between">
+          <span
+            id="treasury-heading"
+            className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
+          >
+            Treasury
+          </span>
+          <StatusPill
+            kind={treasury.paused ? "blocked" : "verified"}
+            label={treasury.paused ? "Paused" : "Active"}
+          />
+        </div>
+
+        <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
+          <FieldRow
+            label="Mint"
+            value={formatPubkey(treasury.mint, 6, 6)}
+            copyValue={treasury.mint.toBase58()}
+          />
+          <FieldRow
+            label="Admin"
+            value={formatPubkey(treasury.admin, 6, 6)}
+            copyValue={treasury.admin.toBase58()}
+            badge={adminBadge}
+          />
+          <FieldRow
+            label="Operator"
+            value={formatPubkey(treasury.operator, 6, 6)}
+            copyValue={treasury.operator.toBase58()}
+            badge={operatorBadge}
+          />
+          {treasury.pendingAdmin ? (
+            <FieldRow
+              label="Pending admin"
+              value={formatPubkey(treasury.pendingAdmin, 6, 6)}
+              copyValue={treasury.pendingAdmin.toBase58()}
+              badge={pendingAdminBadge}
+            />
+          ) : null}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/treasury-overview.tsx
+++ b/frontend/src/components/dashboard/treasury-overview.tsx
@@ -27,7 +27,12 @@ interface FieldRowProps {
   badge?: ReactNode;
 }
 
-function FieldRow({ label, value, copyValue, badge }: FieldRowProps) {
+function FieldRow({
+  label,
+  value,
+  copyValue,
+  badge,
+}: Readonly<FieldRowProps>) {
   const [copied, setCopied] = useState(false);
 
   const onCopy = async () => {
@@ -76,7 +81,7 @@ function youBadge() {
 export function TreasuryOverview({
   treasury,
   walletPublicKey,
-}: TreasuryOverviewProps) {
+}: Readonly<TreasuryOverviewProps>) {
   const decimals = treasury.decimals;
   const circulatingDisplay = formatAmount(circulatingSupply(treasury), decimals);
 

--- a/frontend/src/hooks/use-nav-items.ts
+++ b/frontend/src/hooks/use-nav-items.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { NAV_ITEMS, type NavItem } from "@/components/dashboard/nav-items";
+import { useStablecoinRole } from "@/hooks/use-stablecoin-role";
+import { STABLECOIN_MINT } from "@/lib/stablecoin";
+
+export function useNavItems(): readonly NavItem[] {
+  const { role } = useStablecoinRole(STABLECOIN_MINT);
+
+  return useMemo(
+    () =>
+      NAV_ITEMS.filter((item) => {
+        if (!item.requiresStablecoinRole) return true;
+        return role !== "none";
+      }),
+    [role],
+  );
+}

--- a/frontend/src/hooks/use-redemption-requests.ts
+++ b/frontend/src/hooks/use-redemption-requests.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { PublicKey } from "@solana/web3.js";
+
+import { useConnection } from "@/hooks/use-wallet-connection";
+import {
+  getStablecoinAdapter,
+  STABLECOIN_ADAPTER_KIND,
+  STABLECOIN_MINT_CONFIGURED,
+} from "@/lib/stablecoin";
+
+export const redemptionsQueryKey = (mint: PublicKey) =>
+  ["stablecoin", "redemptions", mint.toBase58()] as const;
+
+export function useRedemptionRequests(mint: PublicKey) {
+  const { connection } = useConnection();
+  const enabled =
+    STABLECOIN_ADAPTER_KIND === "mock" || STABLECOIN_MINT_CONFIGURED;
+  return useQuery({
+    queryKey: redemptionsQueryKey(mint),
+    queryFn: () => getStablecoinAdapter().listRedemptions(connection, mint),
+    refetchInterval: 30_000,
+    enabled,
+  });
+}

--- a/frontend/src/hooks/use-stablecoin-action.ts
+++ b/frontend/src/hooks/use-stablecoin-action.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { WalletAdapterNetwork } from "@solana/wallet-adapter-base";
+import type { Connection, PublicKey, Transaction } from "@solana/web3.js";
+
+import { useConnection, useWallet } from "@/hooks/use-wallet-connection";
+import { redemptionsQueryKey } from "@/hooks/use-redemption-requests";
+import { treasuryQueryKey } from "@/hooks/use-treasury";
+import { SOLANA_NETWORK } from "@/lib/config";
+
+interface BuildTxArgs {
+  payer: PublicKey;
+  connection: Connection;
+}
+
+interface UseStablecoinActionArgs {
+  mint: PublicKey;
+  buildTransaction: (args: BuildTxArgs) => Promise<Transaction>;
+}
+
+export interface StablecoinActionResult {
+  signature: string;
+  solscanUrl: string;
+}
+
+function buildSolscanUrl(signature: string): string {
+  if (SOLANA_NETWORK === WalletAdapterNetwork.Mainnet) {
+    return `https://solscan.io/tx/${signature}`;
+  }
+  return `https://solscan.io/tx/${signature}?cluster=${SOLANA_NETWORK}`;
+}
+
+export function useStablecoinAction({
+  mint,
+  buildTransaction,
+}: UseStablecoinActionArgs) {
+  const { publicKey, sendTransaction } = useWallet();
+  const { connection } = useConnection();
+  const queryClient = useQueryClient();
+
+  return useMutation<StablecoinActionResult>({
+    mutationFn: async () => {
+      if (!publicKey) {
+        throw new Error("Connect a wallet to submit this action.");
+      }
+      const tx = await buildTransaction({ payer: publicKey, connection });
+      const signature = await sendTransaction(tx, connection);
+      return { signature, solscanUrl: buildSolscanUrl(signature) };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: treasuryQueryKey(mint) });
+      queryClient.invalidateQueries({ queryKey: redemptionsQueryKey(mint) });
+    },
+  });
+}

--- a/frontend/src/hooks/use-stablecoin-action.ts
+++ b/frontend/src/hooks/use-stablecoin-action.ts
@@ -42,9 +42,7 @@ async function ensureTxIsSendable(
   // Wallet adapters typically set these via prepareTransaction(), but not all
   // wallet implementations do — set them eagerly so the tx is sendable
   // regardless of the connected wallet's behavior.
-  if (!tx.feePayer) {
-    tx.feePayer = payer;
-  }
+  tx.feePayer ??= payer;
   if (!tx.recentBlockhash) {
     const { blockhash } = await connection.getLatestBlockhash("confirmed");
     tx.recentBlockhash = blockhash;

--- a/frontend/src/hooks/use-stablecoin-action.ts
+++ b/frontend/src/hooks/use-stablecoin-action.ts
@@ -9,14 +9,17 @@ import { redemptionsQueryKey } from "@/hooks/use-redemption-requests";
 import { treasuryQueryKey } from "@/hooks/use-treasury";
 import { SOLANA_NETWORK } from "@/lib/config";
 
-interface BuildTxArgs {
+export interface BuildTxArgs {
   payer: PublicKey;
   connection: Connection;
 }
 
+export type BuildTransactionFn = (
+  args: BuildTxArgs,
+) => Promise<Transaction>;
+
 interface UseStablecoinActionArgs {
   mint: PublicKey;
-  buildTransaction: (args: BuildTxArgs) => Promise<Transaction>;
 }
 
 export interface StablecoinActionResult {
@@ -31,20 +34,35 @@ function buildSolscanUrl(signature: string): string {
   return `https://solscan.io/tx/${signature}?cluster=${SOLANA_NETWORK}`;
 }
 
-export function useStablecoinAction({
-  mint,
-  buildTransaction,
-}: UseStablecoinActionArgs) {
+async function ensureTxIsSendable(
+  tx: Transaction,
+  payer: PublicKey,
+  connection: Connection,
+): Promise<void> {
+  // Wallet adapters typically set these via prepareTransaction(), but not all
+  // wallet implementations do — set them eagerly so the tx is sendable
+  // regardless of the connected wallet's behavior.
+  if (!tx.feePayer) {
+    tx.feePayer = payer;
+  }
+  if (!tx.recentBlockhash) {
+    const { blockhash } = await connection.getLatestBlockhash("confirmed");
+    tx.recentBlockhash = blockhash;
+  }
+}
+
+export function useStablecoinAction({ mint }: Readonly<UseStablecoinActionArgs>) {
   const { publicKey, sendTransaction } = useWallet();
   const { connection } = useConnection();
   const queryClient = useQueryClient();
 
-  return useMutation<StablecoinActionResult>({
-    mutationFn: async () => {
+  return useMutation<StablecoinActionResult, Error, BuildTransactionFn>({
+    mutationFn: async (buildTransaction) => {
       if (!publicKey) {
         throw new Error("Connect a wallet to submit this action.");
       }
       const tx = await buildTransaction({ payer: publicKey, connection });
+      await ensureTxIsSendable(tx, publicKey, connection);
       const signature = await sendTransaction(tx, connection);
       return { signature, solscanUrl: buildSolscanUrl(signature) };
     },

--- a/frontend/src/hooks/use-stablecoin-role.test.tsx
+++ b/frontend/src/hooks/use-stablecoin-role.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { BN } from "@coral-xyz/anchor";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Treasury } from "@/lib/stablecoin";
+
+const adminKey = Keypair.generate().publicKey;
+const operatorKey = Keypair.generate().publicKey;
+const otherKey = Keypair.generate().publicKey;
+const mintKey = Keypair.generate().publicKey;
+
+const baseTreasury: Treasury = {
+  admin: adminKey,
+  operator: operatorKey,
+  mint: mintKey,
+  totalMinted: new BN(0),
+  totalBurned: new BN(0),
+  decimals: 6,
+  paused: false,
+  pendingAdmin: null,
+  mintCap: new BN(0),
+  redemptionNonce: new BN(0),
+};
+
+const walletState: { publicKey: PublicKey | null } = { publicKey: null };
+const treasuryState: {
+  data: Treasury | null;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+} = {
+  data: baseTreasury,
+  isLoading: false,
+  isError: false,
+  error: null,
+};
+
+vi.mock("@/hooks/use-wallet-connection", () => ({
+  useWallet: () => walletState,
+}));
+
+vi.mock("@/hooks/use-treasury", () => ({
+  useTreasury: () => treasuryState,
+  treasuryQueryKey: (mint: PublicKey) => ["stablecoin", "treasury", mint.toBase58()],
+}));
+
+import { useStablecoinRole } from "./use-stablecoin-role";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient();
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  walletState.publicKey = null;
+  treasuryState.data = baseTreasury;
+  treasuryState.isLoading = false;
+  treasuryState.isError = false;
+  treasuryState.error = null;
+});
+
+describe("useStablecoinRole", () => {
+  it("returns none when wallet is disconnected", () => {
+    walletState.publicKey = null;
+    const { result } = renderHook(() => useStablecoinRole(mintKey), { wrapper });
+    expect(result.current.role).toBe("none");
+  });
+
+  it("returns admin when wallet matches admin key", () => {
+    walletState.publicKey = adminKey;
+    treasuryState.data = { ...baseTreasury, operator: otherKey };
+    const { result } = renderHook(() => useStablecoinRole(mintKey), { wrapper });
+    expect(result.current.role).toBe("admin");
+  });
+
+  it("returns operator when wallet matches operator key", () => {
+    walletState.publicKey = operatorKey;
+    treasuryState.data = { ...baseTreasury, admin: otherKey };
+    const { result } = renderHook(() => useStablecoinRole(mintKey), { wrapper });
+    expect(result.current.role).toBe("operator");
+  });
+
+  it("returns both when admin === operator === wallet", () => {
+    walletState.publicKey = adminKey;
+    treasuryState.data = { ...baseTreasury, operator: adminKey };
+    const { result } = renderHook(() => useStablecoinRole(mintKey), { wrapper });
+    expect(result.current.role).toBe("both");
+  });
+
+  it("flags pending admin when wallet matches pending_admin", () => {
+    walletState.publicKey = otherKey;
+    treasuryState.data = { ...baseTreasury, pendingAdmin: otherKey };
+    const { result } = renderHook(() => useStablecoinRole(mintKey), { wrapper });
+    expect(result.current.role).toBe("none");
+    expect(result.current.isPendingAdmin).toBe(true);
+  });
+});

--- a/frontend/src/hooks/use-stablecoin-role.ts
+++ b/frontend/src/hooks/use-stablecoin-role.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import { useMemo } from "react";
+import type { PublicKey } from "@solana/web3.js";
+
+import { useWallet } from "@/hooks/use-wallet-connection";
+import { useTreasury } from "@/hooks/use-treasury";
+import { pubkeysEqual } from "@/lib/stablecoin";
+import type { StablecoinRole, Treasury } from "@/lib/stablecoin";
+
+interface UseStablecoinRoleResult {
+  role: StablecoinRole;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  treasury: Treasury | null;
+  isPendingAdmin: boolean;
+}
+
+export function useStablecoinRole(mint: PublicKey): UseStablecoinRoleResult {
+  const { publicKey } = useWallet();
+  const { data: treasury, isLoading, isError, error } = useTreasury(mint);
+
+  return useMemo(() => {
+    const baseError = error instanceof Error ? error : null;
+    if (!publicKey || !treasury) {
+      return {
+        role: "none",
+        isLoading,
+        isError,
+        error: baseError,
+        treasury: treasury ?? null,
+        isPendingAdmin: false,
+      };
+    }
+
+    const isAdmin = pubkeysEqual(publicKey, treasury.admin);
+    const isOperator = pubkeysEqual(publicKey, treasury.operator);
+    const isPendingAdmin = pubkeysEqual(publicKey, treasury.pendingAdmin);
+
+    let role: StablecoinRole = "none";
+    if (isAdmin && isOperator) role = "both";
+    else if (isAdmin) role = "admin";
+    else if (isOperator) role = "operator";
+
+    return {
+      role,
+      isLoading,
+      isError,
+      error: baseError,
+      treasury,
+      isPendingAdmin,
+    };
+  }, [publicKey, treasury, isLoading, isError, error]);
+}

--- a/frontend/src/hooks/use-treasury.ts
+++ b/frontend/src/hooks/use-treasury.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { PublicKey } from "@solana/web3.js";
+
+import { useConnection } from "@/hooks/use-wallet-connection";
+import {
+  getStablecoinAdapter,
+  STABLECOIN_ADAPTER_KIND,
+  STABLECOIN_MINT_CONFIGURED,
+} from "@/lib/stablecoin";
+
+export const treasuryQueryKey = (mint: PublicKey) =>
+  ["stablecoin", "treasury", mint.toBase58()] as const;
+
+export function useTreasury(mint: PublicKey) {
+  const { connection } = useConnection();
+  const enabled =
+    STABLECOIN_ADAPTER_KIND === "mock" || STABLECOIN_MINT_CONFIGURED;
+  return useQuery({
+    queryKey: treasuryQueryKey(mint),
+    queryFn: () => getStablecoinAdapter().getTreasury(connection, mint),
+    refetchInterval: 30_000,
+    enabled,
+  });
+}

--- a/frontend/src/lib/stablecoin/adapter.ts
+++ b/frontend/src/lib/stablecoin/adapter.ts
@@ -6,9 +6,11 @@ export type AdapterKind = "mock" | "sdk";
 
 function resolveAdapterKind(): AdapterKind {
   const raw = process.env.NEXT_PUBLIC_STABLECOIN_ADAPTER;
-  if (raw === "mock") return "mock";
-  if (raw === "sdk") return "sdk";
-  return "sdk";
+  if (!raw) return "sdk";
+  if (raw === "mock" || raw === "sdk") return raw;
+  throw new Error(
+    `Invalid NEXT_PUBLIC_STABLECOIN_ADAPTER="${raw}". Expected "sdk" or "mock".`,
+  );
 }
 
 export const STABLECOIN_ADAPTER_KIND: AdapterKind = resolveAdapterKind();

--- a/frontend/src/lib/stablecoin/adapter.ts
+++ b/frontend/src/lib/stablecoin/adapter.ts
@@ -1,0 +1,18 @@
+import { mockAdapter } from "./mock-adapter";
+import { sdkAdapter } from "./sdk-adapter";
+import type { StablecoinAdapter } from "./types";
+
+export type AdapterKind = "mock" | "sdk";
+
+function resolveAdapterKind(): AdapterKind {
+  const raw = process.env.NEXT_PUBLIC_STABLECOIN_ADAPTER;
+  if (raw === "mock") return "mock";
+  if (raw === "sdk") return "sdk";
+  return "sdk";
+}
+
+export const STABLECOIN_ADAPTER_KIND: AdapterKind = resolveAdapterKind();
+
+export function getStablecoinAdapter(): StablecoinAdapter {
+  return STABLECOIN_ADAPTER_KIND === "sdk" ? sdkAdapter : mockAdapter;
+}

--- a/frontend/src/lib/stablecoin/format.test.ts
+++ b/frontend/src/lib/stablecoin/format.test.ts
@@ -1,0 +1,165 @@
+import { BN } from "@coral-xyz/anchor";
+import { Keypair } from "@solana/web3.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  circulatingSupply,
+  formatAmount,
+  formatDuration,
+  formatPubkey,
+  mintCapProgress,
+  parseAmountToUnits,
+  pubkeysEqual,
+  redemptionExpiry,
+} from "./format";
+import { REDEMPTION_EXPIRY_SECS, STABLECOIN_DECIMALS } from "./program";
+import type { RedemptionRequest, Treasury } from "./types";
+
+const mint = Keypair.generate().publicKey;
+
+function unit(n: number): BN {
+  return new BN(n).mul(new BN(10).pow(new BN(STABLECOIN_DECIMALS)));
+}
+
+const baseTreasury: Treasury = {
+  admin: Keypair.generate().publicKey,
+  operator: Keypair.generate().publicKey,
+  mint,
+  totalMinted: unit(100),
+  totalBurned: unit(25),
+  decimals: STABLECOIN_DECIMALS,
+  paused: false,
+  pendingAdmin: null,
+  mintCap: unit(1_000),
+  redemptionNonce: new BN(0),
+};
+
+describe("formatAmount", () => {
+  it("renders whole tokens", () => {
+    expect(formatAmount(unit(42), STABLECOIN_DECIMALS)).toBe("42");
+  });
+
+  it("renders fractional tokens trimming trailing zeros", () => {
+    expect(formatAmount(new BN(1_500_000), STABLECOIN_DECIMALS)).toBe("1.5");
+  });
+
+  it("handles zero decimals", () => {
+    expect(formatAmount(new BN(7), 0)).toBe("7");
+  });
+});
+
+describe("formatPubkey", () => {
+  it("truncates long base58", () => {
+    const formatted = formatPubkey(mint, 4, 4);
+    expect(formatted.includes("…")).toBe(true);
+    expect(formatted.length).toBeLessThan(mint.toBase58().length);
+  });
+});
+
+describe("pubkeysEqual", () => {
+  it("returns true for the same key", () => {
+    expect(pubkeysEqual(mint, mint)).toBe(true);
+  });
+  it("returns false when either is missing", () => {
+    expect(pubkeysEqual(null, mint)).toBe(false);
+    expect(pubkeysEqual(mint, null)).toBe(false);
+  });
+});
+
+describe("mintCapProgress", () => {
+  it("flags uncapped treasuries", () => {
+    const t: Treasury = { ...baseTreasury, mintCap: new BN(0) };
+    expect(mintCapProgress(t).capped).toBe(false);
+  });
+
+  it("computes ratio for capped treasuries", () => {
+    const result = mintCapProgress(baseTreasury);
+    expect(result.capped).toBe(true);
+    expect(result.ratio).toBeCloseTo(0.1, 2);
+    expect(result.belowMinted).toBe(false);
+  });
+
+  it("flags caps below current minted supply", () => {
+    const t: Treasury = { ...baseTreasury, mintCap: unit(50) };
+    expect(mintCapProgress(t).belowMinted).toBe(true);
+  });
+});
+
+describe("circulatingSupply", () => {
+  it("subtracts burned from minted", () => {
+    expect(circulatingSupply(baseTreasury)).toBe(75n * 10n ** BigInt(STABLECOIN_DECIMALS));
+  });
+});
+
+describe("redemptionExpiry", () => {
+  const redemption: RedemptionRequest = {
+    pda: Keypair.generate().publicKey,
+    holder: Keypair.generate().publicKey,
+    treasury: Keypair.generate().publicKey,
+    mint,
+    tokenAccount: Keypair.generate().publicKey,
+    amount: unit(10),
+    nonce: new BN(1),
+    requestedAt: 1_700_000_000,
+  };
+
+  it("computes seconds remaining when fresh", () => {
+    const result = redemptionExpiry(redemption, redemption.requestedAt + 100);
+    expect(result.expired).toBe(false);
+    expect(result.secondsRemaining).toBe(REDEMPTION_EXPIRY_SECS - 100);
+  });
+
+  it("flags expired redemptions", () => {
+    const result = redemptionExpiry(
+      redemption,
+      redemption.requestedAt + REDEMPTION_EXPIRY_SECS + 1,
+    );
+    expect(result.expired).toBe(true);
+    expect(result.secondsRemaining).toBe(0);
+  });
+});
+
+describe("parseAmountToUnits", () => {
+  it("parses whole tokens", () => {
+    expect(parseAmountToUnits("100", 6)?.toString()).toBe("100000000");
+  });
+
+  it("parses fractional tokens up to declared decimals", () => {
+    expect(parseAmountToUnits("1.5", 6)?.toString()).toBe("1500000");
+    expect(parseAmountToUnits("0.123456", 6)?.toString()).toBe("123456");
+  });
+
+  it("rejects more fractional digits than decimals", () => {
+    expect(parseAmountToUnits("1.1234567", 6)).toBeNull();
+  });
+
+  it("rejects non-numeric input", () => {
+    expect(parseAmountToUnits("abc", 6)).toBeNull();
+    expect(parseAmountToUnits("1.2.3", 6)).toBeNull();
+    expect(parseAmountToUnits("-1", 6)).toBeNull();
+    expect(parseAmountToUnits("", 6)).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseAmountToUnits("  42  ", 6)?.toString()).toBe("42000000");
+  });
+
+  it("handles zero", () => {
+    expect(parseAmountToUnits("0", 6)?.toString()).toBe("0");
+  });
+});
+
+describe("formatDuration", () => {
+  it("returns expired for negative input", () => {
+    expect(formatDuration(-1)).toBe("expired");
+  });
+  it("formats days and hours", () => {
+    expect(formatDuration(86_400 + 3_600 * 2)).toBe("1d 2h");
+  });
+  it("formats hours and minutes", () => {
+    expect(formatDuration(3_600 * 2 + 60 * 30)).toBe("2h 30m");
+  });
+  it("formats minutes", () => {
+    expect(formatDuration(60 * 5)).toBe("5m");
+  });
+});

--- a/frontend/src/lib/stablecoin/format.test.ts
+++ b/frontend/src/lib/stablecoin/format.test.ts
@@ -7,6 +7,7 @@ import {
   formatAmount,
   formatDuration,
   formatPubkey,
+  isValidPubkey,
   mintCapProgress,
   parseAmountToUnits,
   pubkeysEqual,
@@ -150,8 +151,9 @@ describe("parseAmountToUnits", () => {
 });
 
 describe("formatDuration", () => {
-  it("returns expired for negative input", () => {
+  it("returns expired for zero or negative input", () => {
     expect(formatDuration(-1)).toBe("expired");
+    expect(formatDuration(0)).toBe("expired");
   });
   it("formats days and hours", () => {
     expect(formatDuration(86_400 + 3_600 * 2)).toBe("1d 2h");
@@ -161,5 +163,26 @@ describe("formatDuration", () => {
   });
   it("formats minutes", () => {
     expect(formatDuration(60 * 5)).toBe("5m");
+  });
+  it("formats sub-minute durations in seconds", () => {
+    expect(formatDuration(45)).toBe("45s");
+  });
+});
+
+describe("isValidPubkey", () => {
+  const realKey = mint.toBase58();
+
+  it("accepts a real base58 pubkey", () => {
+    expect(isValidPubkey(realKey)).toBe(true);
+  });
+  it("trims surrounding whitespace", () => {
+    expect(isValidPubkey(`  ${realKey}  `)).toBe(true);
+  });
+  it("rejects empty input", () => {
+    expect(isValidPubkey("")).toBe(false);
+    expect(isValidPubkey("   ")).toBe(false);
+  });
+  it("rejects non-base58 input", () => {
+    expect(isValidPubkey("not-a-key")).toBe(false);
   });
 });

--- a/frontend/src/lib/stablecoin/format.ts
+++ b/frontend/src/lib/stablecoin/format.ts
@@ -5,6 +5,13 @@ import { REDEMPTION_EXPIRY_SECS } from "./program";
 import type { RedemptionRequest, Treasury } from "./types";
 
 const DECIMAL_BASE = 10n;
+const ZERO_CHAR = "0";
+
+function trimTrailingZeros(input: string): string {
+  let end = input.length;
+  while (end > 0 && input[end - 1] === ZERO_CHAR) end--;
+  return input.slice(0, end);
+}
 
 export function formatAmount(value: BN | bigint, decimals: number): string {
   const raw = typeof value === "bigint" ? value : BigInt(value.toString());
@@ -13,7 +20,9 @@ export function formatAmount(value: BN | bigint, decimals: number): string {
   const whole = raw / divisor;
   const fraction = raw % divisor;
   if (fraction === 0n) return whole.toString();
-  const fractionStr = fraction.toString().padStart(decimals, "0").replace(/0+$/, "");
+  const fractionStr = trimTrailingZeros(
+    fraction.toString().padStart(decimals, "0"),
+  );
   return fractionStr.length > 0 ? `${whole}.${fractionStr}` : whole.toString();
 }
 
@@ -41,16 +50,21 @@ export interface MintCapProgress {
   belowMinted: boolean;
 }
 
+const RATIO_PRECISION = 10_000n;
+
 export function mintCapProgress(treasury: Treasury): MintCapProgress {
   const cap = BigInt(treasury.mintCap.toString());
   const minted = BigInt(treasury.totalMinted.toString());
   if (cap === 0n) {
     return { capped: false, ratio: 0, belowMinted: false };
   }
-  const ratio = minted === 0n ? 0 : Number(minted) / Number(cap);
+  let ratio: number;
+  if (minted === 0n) ratio = 0;
+  else if (minted >= cap) ratio = 1;
+  else ratio = Number((minted * RATIO_PRECISION) / cap) / Number(RATIO_PRECISION);
   return {
     capped: true,
-    ratio: Math.min(1, ratio),
+    ratio,
     belowMinted: minted > cap,
   };
 }

--- a/frontend/src/lib/stablecoin/format.ts
+++ b/frontend/src/lib/stablecoin/format.ts
@@ -1,0 +1,102 @@
+import { BN } from "@coral-xyz/anchor";
+import type { PublicKey } from "@solana/web3.js";
+
+import { REDEMPTION_EXPIRY_SECS } from "./program";
+import type { RedemptionRequest, Treasury } from "./types";
+
+const DECIMAL_BASE = 10n;
+
+export function formatAmount(value: BN | bigint, decimals: number): string {
+  const raw = typeof value === "bigint" ? value : BigInt(value.toString());
+  if (decimals === 0) return raw.toString();
+  const divisor = DECIMAL_BASE ** BigInt(decimals);
+  const whole = raw / divisor;
+  const fraction = raw % divisor;
+  if (fraction === 0n) return whole.toString();
+  const fractionStr = fraction.toString().padStart(decimals, "0").replace(/0+$/, "");
+  return fractionStr.length > 0 ? `${whole}.${fractionStr}` : whole.toString();
+}
+
+export function formatPubkey(
+  pubkey: PublicKey,
+  head = 4,
+  tail = 4,
+): string {
+  const s = pubkey.toBase58();
+  if (s.length <= head + tail + 1) return s;
+  return `${s.slice(0, head)}…${s.slice(-tail)}`;
+}
+
+export function pubkeysEqual(
+  a: PublicKey | null | undefined,
+  b: PublicKey | null | undefined,
+): boolean {
+  if (!a || !b) return false;
+  return a.toBase58() === b.toBase58();
+}
+
+export interface MintCapProgress {
+  capped: boolean;
+  ratio: number;
+  belowMinted: boolean;
+}
+
+export function mintCapProgress(treasury: Treasury): MintCapProgress {
+  const cap = BigInt(treasury.mintCap.toString());
+  const minted = BigInt(treasury.totalMinted.toString());
+  if (cap === 0n) {
+    return { capped: false, ratio: 0, belowMinted: false };
+  }
+  const ratio = minted === 0n ? 0 : Number(minted) / Number(cap);
+  return {
+    capped: true,
+    ratio: Math.min(1, ratio),
+    belowMinted: minted > cap,
+  };
+}
+
+export function circulatingSupply(treasury: Treasury): bigint {
+  const minted = BigInt(treasury.totalMinted.toString());
+  const burned = BigInt(treasury.totalBurned.toString());
+  return minted >= burned ? minted - burned : 0n;
+}
+
+export interface RedemptionExpiry {
+  expiresAt: number;
+  expired: boolean;
+  secondsRemaining: number;
+}
+
+export function redemptionExpiry(
+  request: RedemptionRequest,
+  now: number = Math.floor(Date.now() / 1000),
+): RedemptionExpiry {
+  const expiresAt = request.requestedAt + REDEMPTION_EXPIRY_SECS;
+  const secondsRemaining = expiresAt - now;
+  return {
+    expiresAt,
+    expired: secondsRemaining <= 0,
+    secondsRemaining: Math.max(0, secondsRemaining),
+  };
+}
+
+export function parseAmountToUnits(raw: string, decimals: number): BN | null {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) return null;
+  const [whole, fractionRaw = ""] = trimmed.split(".");
+  if (fractionRaw.length > decimals) return null;
+  const fraction = fractionRaw.padEnd(decimals, "0");
+  const combined = (whole + fraction).replace(/^0+/, "") || "0";
+  return new BN(combined);
+}
+
+export function formatDuration(secs: number): string {
+  if (secs <= 0) return "expired";
+  const days = Math.floor(secs / 86_400);
+  const hours = Math.floor((secs % 86_400) / 3_600);
+  if (days > 0) return `${days}d ${hours}h`;
+  const minutes = Math.floor((secs % 3_600) / 60);
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+}

--- a/frontend/src/lib/stablecoin/format.ts
+++ b/frontend/src/lib/stablecoin/format.ts
@@ -8,7 +8,7 @@ export function isValidPubkey(value: string): boolean {
   const trimmed = value.trim();
   if (trimmed.length === 0) return false;
   try {
-    void new PublicKey(trimmed);
+    new PublicKey(trimmed);
     return true;
   } catch {
     return false;

--- a/frontend/src/lib/stablecoin/format.ts
+++ b/frontend/src/lib/stablecoin/format.ts
@@ -1,8 +1,19 @@
 import { BN } from "@coral-xyz/anchor";
-import type { PublicKey } from "@solana/web3.js";
+import { PublicKey } from "@solana/web3.js";
 
 import { REDEMPTION_EXPIRY_SECS } from "./program";
 import type { RedemptionRequest, Treasury } from "./types";
+
+export function isValidPubkey(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+  try {
+    void new PublicKey(trimmed);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const DECIMAL_BASE = 10n;
 const ZERO_CHAR = "0";
@@ -112,5 +123,6 @@ export function formatDuration(secs: number): string {
   if (days > 0) return `${days}d ${hours}h`;
   const minutes = Math.floor((secs % 3_600) / 60);
   if (hours > 0) return `${hours}h ${minutes}m`;
-  return `${minutes}m`;
+  if (minutes > 0) return `${minutes}m`;
+  return `${secs}s`;
 }

--- a/frontend/src/lib/stablecoin/index.ts
+++ b/frontend/src/lib/stablecoin/index.ts
@@ -1,0 +1,33 @@
+export type {
+  StablecoinAdapter,
+  StablecoinRole,
+  Treasury,
+  RedemptionRequest,
+  AdapterContext,
+  ActionKind,
+} from "./types";
+export {
+  STABLECOIN_PROGRAM_ID,
+  STABLECOIN_DECIMALS,
+  STABLECOIN_MINT,
+  STABLECOIN_MINT_CONFIGURED,
+  REDEMPTION_EXPIRY_SECS,
+  SEEDS,
+} from "./program";
+export {
+  getStablecoinAdapter,
+  STABLECOIN_ADAPTER_KIND,
+  type AdapterKind,
+} from "./adapter";
+export {
+  formatAmount,
+  formatPubkey,
+  pubkeysEqual,
+  mintCapProgress,
+  circulatingSupply,
+  redemptionExpiry,
+  formatDuration,
+  parseAmountToUnits,
+  type MintCapProgress,
+  type RedemptionExpiry,
+} from "./format";

--- a/frontend/src/lib/stablecoin/index.ts
+++ b/frontend/src/lib/stablecoin/index.ts
@@ -28,6 +28,7 @@ export {
   redemptionExpiry,
   formatDuration,
   parseAmountToUnits,
+  isValidPubkey,
   type MintCapProgress,
   type RedemptionExpiry,
 } from "./format";

--- a/frontend/src/lib/stablecoin/mock-adapter.ts
+++ b/frontend/src/lib/stablecoin/mock-adapter.ts
@@ -1,0 +1,123 @@
+import { BN } from "@coral-xyz/anchor";
+import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+
+import { STABLECOIN_DECIMALS } from "./program";
+import type {
+  AdapterContext,
+  RedemptionRequest,
+  StablecoinAdapter,
+  Treasury,
+} from "./types";
+
+function unit(amount: number): BN {
+  return new BN(amount).mul(new BN(10).pow(new BN(STABLECOIN_DECIMALS)));
+}
+
+function pubkeyFromEnv(value: string | undefined): PublicKey | null {
+  if (!value) return null;
+  try {
+    return new PublicKey(value);
+  } catch {
+    return null;
+  }
+}
+
+const MOCK_ADMIN =
+  pubkeyFromEnv(process.env.NEXT_PUBLIC_STABLECOIN_MOCK_ADMIN) ??
+  Keypair.generate().publicKey;
+const MOCK_OPERATOR =
+  pubkeyFromEnv(process.env.NEXT_PUBLIC_STABLECOIN_MOCK_OPERATOR) ??
+  Keypair.generate().publicKey;
+const MOCK_MINT = Keypair.generate().publicKey;
+
+const treasuryStore: Treasury = {
+  admin: MOCK_ADMIN,
+  operator: MOCK_OPERATOR,
+  mint: MOCK_MINT,
+  totalMinted: unit(420_000),
+  totalBurned: unit(15_000),
+  decimals: STABLECOIN_DECIMALS,
+  paused: false,
+  pendingAdmin: null,
+  mintCap: unit(1_000_000),
+  redemptionNonce: new BN(2),
+};
+
+function makeRedemption(
+  amount: number,
+  ageSecs: number,
+  nonce: number,
+): RedemptionRequest {
+  return {
+    pda: Keypair.generate().publicKey,
+    holder: Keypair.generate().publicKey,
+    treasury: Keypair.generate().publicKey,
+    mint: treasuryStore.mint,
+    tokenAccount: Keypair.generate().publicKey,
+    amount: unit(amount),
+    nonce: new BN(nonce),
+    requestedAt: Math.floor(Date.now() / 1000) - ageSecs,
+  };
+}
+
+const redemptionsStore: RedemptionRequest[] = [
+  makeRedemption(250, 3_600, 1),
+  makeRedemption(100, 700_000, 2),
+];
+
+function emptyTx(payer: PublicKey): Transaction {
+  const tx = new Transaction();
+  tx.feePayer = payer;
+  return tx;
+}
+
+export const mockAdapter: StablecoinAdapter = {
+  async getTreasury(_, mint): Promise<Treasury> {
+    return { ...treasuryStore, mint };
+  },
+  async listRedemptions(): Promise<RedemptionRequest[]> {
+    return [...redemptionsStore];
+  },
+  async buildSetOperator(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildProposeAdmin(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildAcceptAdmin(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildCancelPendingAdmin(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildUpdateMintCap(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildPause(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildUnpause(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildFreezeAccount(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildThawAccount(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildMintTokens(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildApproveRedemption(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+  async buildCancelRedemption(ctx: AdapterContext) {
+    return emptyTx(ctx.payer);
+  },
+};
+
+export const __mockTreasury = treasuryStore;
+export const __mockRedemptions = redemptionsStore;
+export const __mockMint = MOCK_MINT;
+export const __mockAdmin = MOCK_ADMIN;
+export const __mockOperator = MOCK_OPERATOR;

--- a/frontend/src/lib/stablecoin/mock-adapter.ts
+++ b/frontend/src/lib/stablecoin/mock-adapter.ts
@@ -28,7 +28,7 @@ function pubkeyFromEnv(value: string | undefined): PublicKey | null {
 function keyFromLabel(label: string): PublicKey {
   const bytes = new Uint8Array(32);
   for (let i = 0; i < label.length && i < 32; i++) {
-    bytes[i] = label.charCodeAt(i) % 256;
+    bytes[i] = (label.codePointAt(i) ?? 0) % 256;
   }
   bytes[31] = 1;
   return new PublicKey(bytes);

--- a/frontend/src/lib/stablecoin/mock-adapter.ts
+++ b/frontend/src/lib/stablecoin/mock-adapter.ts
@@ -1,5 +1,5 @@
 import { BN } from "@coral-xyz/anchor";
-import { Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { PublicKey, Transaction } from "@solana/web3.js";
 
 import { STABLECOIN_DECIMALS } from "./program";
 import type {
@@ -22,13 +22,29 @@ function pubkeyFromEnv(value: string | undefined): PublicKey | null {
   }
 }
 
+// Deterministic 32-byte keys derived from a fixed seed phrase. Using
+// PublicKey.unique() / Keypair.generate() drifts between runs and breaks
+// snapshot stability for storybook / demo screenshots.
+function keyFromLabel(label: string): PublicKey {
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < label.length && i < 32; i++) {
+    bytes[i] = label.charCodeAt(i) % 256;
+  }
+  bytes[31] = 1;
+  return new PublicKey(bytes);
+}
+
 const MOCK_ADMIN =
   pubkeyFromEnv(process.env.NEXT_PUBLIC_STABLECOIN_MOCK_ADMIN) ??
-  Keypair.generate().publicKey;
+  keyFromLabel("zksettle-mock-admin");
 const MOCK_OPERATOR =
   pubkeyFromEnv(process.env.NEXT_PUBLIC_STABLECOIN_MOCK_OPERATOR) ??
-  Keypair.generate().publicKey;
-const MOCK_MINT = Keypair.generate().publicKey;
+  keyFromLabel("zksettle-mock-operator");
+const MOCK_MINT = keyFromLabel("zksettle-mock-mint");
+
+// Wall-clock-free baseline; ages below are computed against this fixed point
+// so test runs and demo snapshots stay deterministic across executions.
+const MOCK_NOW_SECS = 1_715_000_000;
 
 const treasuryStore: Treasury = {
   admin: MOCK_ADMIN,
@@ -49,14 +65,14 @@ function makeRedemption(
   nonce: number,
 ): RedemptionRequest {
   return {
-    pda: Keypair.generate().publicKey,
-    holder: Keypair.generate().publicKey,
-    treasury: Keypair.generate().publicKey,
+    pda: keyFromLabel(`zksettle-mock-redemption-pda-${nonce}`),
+    holder: keyFromLabel(`zksettle-mock-redemption-holder-${nonce}`),
+    treasury: keyFromLabel("zksettle-mock-treasury"),
     mint: treasuryStore.mint,
-    tokenAccount: Keypair.generate().publicKey,
+    tokenAccount: keyFromLabel(`zksettle-mock-redemption-ata-${nonce}`),
     amount: unit(amount),
     nonce: new BN(nonce),
-    requestedAt: Math.floor(Date.now() / 1000) - ageSecs,
+    requestedAt: MOCK_NOW_SECS - ageSecs,
   };
 }
 
@@ -75,8 +91,10 @@ export const mockAdapter: StablecoinAdapter = {
   async getTreasury(_, mint): Promise<Treasury> {
     return { ...treasuryStore, mint };
   },
-  async listRedemptions(): Promise<RedemptionRequest[]> {
-    return [...redemptionsStore];
+  async listRedemptions(_, mint): Promise<RedemptionRequest[]> {
+    return redemptionsStore
+      .filter((r) => r.mint.equals(mint) || r.mint.equals(treasuryStore.mint))
+      .map((r) => ({ ...r, mint }));
   },
   async buildSetOperator(ctx: AdapterContext) {
     return emptyTx(ctx.payer);

--- a/frontend/src/lib/stablecoin/program.ts
+++ b/frontend/src/lib/stablecoin/program.ts
@@ -1,0 +1,35 @@
+import { PublicKey } from "@solana/web3.js";
+
+export const STABLECOIN_PROGRAM_ID = new PublicKey(
+  "2CdXRSPo6QLfLBJTikmrqmBiWwa1HpuuYJ2Qu6Yy3Liv",
+);
+
+export const STABLECOIN_DECIMALS = 6;
+
+export const REDEMPTION_EXPIRY_SECS = 604_800;
+
+export const SEEDS = {
+  treasury: "treasury",
+  mintAuthority: "mint-authority",
+  freezeAuthority: "freeze-authority",
+  redemption: "redemption",
+  escrowAuthority: "escrow-authority",
+} as const;
+
+const FALLBACK_MINT = "11111111111111111111111111111111";
+
+function resolveMint(value: string | undefined): PublicKey {
+  if (!value) return new PublicKey(FALLBACK_MINT);
+  try {
+    return new PublicKey(value);
+  } catch {
+    return new PublicKey(FALLBACK_MINT);
+  }
+}
+
+export const STABLECOIN_MINT = resolveMint(
+  process.env.NEXT_PUBLIC_STABLECOIN_MINT,
+);
+
+export const STABLECOIN_MINT_CONFIGURED =
+  !!process.env.NEXT_PUBLIC_STABLECOIN_MINT;

--- a/frontend/src/lib/stablecoin/program.ts
+++ b/frontend/src/lib/stablecoin/program.ts
@@ -18,18 +18,23 @@ export const SEEDS = {
 
 const FALLBACK_MINT = "11111111111111111111111111111111";
 
-function resolveMint(value: string | undefined): PublicKey {
-  if (!value) return new PublicKey(FALLBACK_MINT);
+interface ResolvedMint {
+  mint: PublicKey;
+  configured: boolean;
+}
+
+function resolveMint(value: string | undefined): ResolvedMint {
+  if (!value) {
+    return { mint: new PublicKey(FALLBACK_MINT), configured: false };
+  }
   try {
-    return new PublicKey(value);
+    return { mint: new PublicKey(value), configured: true };
   } catch {
-    return new PublicKey(FALLBACK_MINT);
+    return { mint: new PublicKey(FALLBACK_MINT), configured: false };
   }
 }
 
-export const STABLECOIN_MINT = resolveMint(
-  process.env.NEXT_PUBLIC_STABLECOIN_MINT,
-);
+const resolvedMint = resolveMint(process.env.NEXT_PUBLIC_STABLECOIN_MINT);
 
-export const STABLECOIN_MINT_CONFIGURED =
-  !!process.env.NEXT_PUBLIC_STABLECOIN_MINT;
+export const STABLECOIN_MINT = resolvedMint.mint;
+export const STABLECOIN_MINT_CONFIGURED = resolvedMint.configured;

--- a/frontend/src/lib/stablecoin/sdk-adapter.ts
+++ b/frontend/src/lib/stablecoin/sdk-adapter.ts
@@ -30,12 +30,14 @@ let sdkPromise: Promise<SdkModule> | null = null;
 const SDK_SPECIFIER = "@zksettle/sdk";
 
 function loadSdk(): Promise<SdkModule> {
-  if (!sdkPromise) {
-    sdkPromise = import(/* @vite-ignore */ SDK_SPECIFIER) as Promise<SdkModule>;
-  }
+  sdkPromise ??= import(/* @vite-ignore */ SDK_SPECIFIER) as Promise<SdkModule>;
   return sdkPromise;
 }
 
+// Byte offset of the `treasury` field inside an Anchor RedemptionRequest:
+//   8  (Anchor account discriminator)
+// + 32 (`holder` Pubkey)
+// = 40
 const REDEMPTION_TREASURY_OFFSET = 8 + 32;
 
 function toLocalTreasury(sdk: SdkTreasury): Treasury {

--- a/frontend/src/lib/stablecoin/sdk-adapter.ts
+++ b/frontend/src/lib/stablecoin/sdk-adapter.ts
@@ -1,0 +1,185 @@
+import { BN } from "@coral-xyz/anchor";
+import {
+  Connection,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import {
+  buildAcceptAdminIx,
+  buildApproveRedemptionIx,
+  buildCancelPendingAdminIx,
+  buildCancelRedemptionIx,
+  buildFreezeAccountIx,
+  buildMintTokensIx,
+  buildPauseIx,
+  buildProposeAdminIx,
+  buildSetOperatorIx,
+  buildThawAccountIx,
+  buildUnpauseIx,
+  buildUpdateMintCapIx,
+  decodeRedemptionRequest,
+  decodeTreasury,
+  findTreasuryPda,
+  REDEMPTION_REQUEST_DATA_LEN,
+  type RedemptionRequest as SdkRedemptionRequest,
+  type Treasury as SdkTreasury,
+} from "@zksettle/sdk";
+
+import { STABLECOIN_PROGRAM_ID } from "./program";
+import type {
+  AdapterContext,
+  RedemptionRequest,
+  StablecoinAdapter,
+  Treasury,
+} from "./types";
+
+const REDEMPTION_TREASURY_OFFSET = 8 + 32;
+
+function toLocalTreasury(sdk: SdkTreasury): Treasury {
+  return {
+    admin: sdk.admin,
+    operator: sdk.operator,
+    mint: sdk.mint,
+    totalMinted: new BN(sdk.totalMinted.toString()),
+    totalBurned: new BN(sdk.totalBurned.toString()),
+    decimals: sdk.decimals,
+    paused: sdk.paused,
+    pendingAdmin: sdk.pendingAdmin,
+    mintCap: new BN(sdk.mintCap.toString()),
+    redemptionNonce: new BN(sdk.redemptionNonce.toString()),
+  };
+}
+
+function toLocalRedemption(
+  pda: PublicKey,
+  sdk: SdkRedemptionRequest,
+): RedemptionRequest {
+  return {
+    pda,
+    holder: sdk.holder,
+    treasury: sdk.treasury,
+    mint: sdk.mint,
+    tokenAccount: sdk.tokenAccount,
+    amount: new BN(sdk.amount.toString()),
+    nonce: new BN(sdk.nonce.toString()),
+    requestedAt: Number(sdk.requestedAt),
+  };
+}
+
+function toBigInt(value: BN): bigint {
+  return BigInt(value.toString());
+}
+
+function wrap(payer: PublicKey, ix: TransactionInstruction): Transaction {
+  const tx = new Transaction();
+  tx.feePayer = payer;
+  tx.add(ix);
+  return tx;
+}
+
+async function getTreasury(
+  connection: Connection,
+  mint: PublicKey,
+): Promise<Treasury | null> {
+  const [treasuryPda] = findTreasuryPda(mint);
+  const info = await connection.getAccountInfo(treasuryPda);
+  if (!info) return null;
+  return toLocalTreasury(decodeTreasury(info.data));
+}
+
+async function listRedemptions(
+  connection: Connection,
+  mint: PublicKey,
+): Promise<RedemptionRequest[]> {
+  const [treasuryPda] = findTreasuryPda(mint);
+  const accounts = await connection.getProgramAccounts(
+    STABLECOIN_PROGRAM_ID,
+    {
+      filters: [
+        { dataSize: REDEMPTION_REQUEST_DATA_LEN },
+        {
+          memcmp: {
+            offset: REDEMPTION_TREASURY_OFFSET,
+            bytes: treasuryPda.toBase58(),
+          },
+        },
+      ],
+    },
+  );
+
+  const decoded: RedemptionRequest[] = [];
+  for (const { pubkey, account } of accounts) {
+    try {
+      decoded.push(toLocalRedemption(pubkey, decodeRedemptionRequest(account.data)));
+    } catch {
+      // skip accounts that don't match the redemption discriminator
+    }
+  }
+  return decoded;
+}
+
+export const sdkAdapter: StablecoinAdapter = {
+  getTreasury,
+  listRedemptions,
+  async buildSetOperator(ctx: AdapterContext, mint, newOperator) {
+    return wrap(ctx.payer, buildSetOperatorIx(ctx.payer, mint, newOperator));
+  },
+  async buildProposeAdmin(ctx: AdapterContext, mint, newAdmin) {
+    return wrap(ctx.payer, buildProposeAdminIx(ctx.payer, mint, newAdmin));
+  },
+  async buildAcceptAdmin(ctx: AdapterContext, mint) {
+    return wrap(ctx.payer, buildAcceptAdminIx(ctx.payer, mint));
+  },
+  async buildCancelPendingAdmin(ctx: AdapterContext, mint) {
+    return wrap(ctx.payer, buildCancelPendingAdminIx(ctx.payer, mint));
+  },
+  async buildUpdateMintCap(ctx: AdapterContext, mint, newCap) {
+    return wrap(
+      ctx.payer,
+      buildUpdateMintCapIx(ctx.payer, mint, toBigInt(newCap)),
+    );
+  },
+  async buildPause(ctx: AdapterContext, mint) {
+    return wrap(ctx.payer, buildPauseIx(ctx.payer, mint));
+  },
+  async buildUnpause(ctx: AdapterContext, mint) {
+    return wrap(ctx.payer, buildUnpauseIx(ctx.payer, mint));
+  },
+  async buildFreezeAccount(ctx: AdapterContext, mint, tokenAccount) {
+    return wrap(ctx.payer, buildFreezeAccountIx(ctx.payer, mint, tokenAccount));
+  },
+  async buildThawAccount(ctx: AdapterContext, mint, tokenAccount) {
+    return wrap(ctx.payer, buildThawAccountIx(ctx.payer, mint, tokenAccount));
+  },
+  async buildMintTokens(ctx: AdapterContext, mint, destination, amount) {
+    return wrap(
+      ctx.payer,
+      buildMintTokensIx(ctx.payer, mint, destination, toBigInt(amount)),
+    );
+  },
+  async buildApproveRedemption(ctx: AdapterContext, mint, redemption) {
+    return wrap(
+      ctx.payer,
+      buildApproveRedemptionIx(
+        ctx.payer,
+        redemption.holder,
+        mint,
+        redemption.tokenAccount,
+        toBigInt(redemption.nonce),
+      ),
+    );
+  },
+  async buildCancelRedemption(ctx: AdapterContext, mint, redemption) {
+    return wrap(
+      ctx.payer,
+      buildCancelRedemptionIx(
+        ctx.payer,
+        redemption.holder,
+        mint,
+        redemption.tokenAccount,
+        toBigInt(redemption.nonce),
+      ),
+    );
+  },
+};

--- a/frontend/src/lib/stablecoin/sdk-adapter.ts
+++ b/frontend/src/lib/stablecoin/sdk-adapter.ts
@@ -5,26 +5,6 @@ import {
   Transaction,
   TransactionInstruction,
 } from "@solana/web3.js";
-import {
-  buildAcceptAdminIx,
-  buildApproveRedemptionIx,
-  buildCancelPendingAdminIx,
-  buildCancelRedemptionIx,
-  buildFreezeAccountIx,
-  buildMintTokensIx,
-  buildPauseIx,
-  buildProposeAdminIx,
-  buildSetOperatorIx,
-  buildThawAccountIx,
-  buildUnpauseIx,
-  buildUpdateMintCapIx,
-  decodeRedemptionRequest,
-  decodeTreasury,
-  findTreasuryPda,
-  REDEMPTION_REQUEST_DATA_LEN,
-  type RedemptionRequest as SdkRedemptionRequest,
-  type Treasury as SdkTreasury,
-} from "@zksettle/sdk";
 
 import { STABLECOIN_PROGRAM_ID } from "./program";
 import type {
@@ -33,6 +13,28 @@ import type {
   StablecoinAdapter,
   Treasury,
 } from "./types";
+
+// Type-only imports never trigger module resolution at test-collection time,
+// so this file loads cleanly even before `sdk/dist/` exists. Runtime values
+// are loaded lazily via `loadSdk()` below.
+type SdkModule = typeof import("@zksettle/sdk");
+type SdkTreasury = import("@zksettle/sdk").Treasury;
+type SdkRedemptionRequest = import("@zksettle/sdk").RedemptionRequest;
+
+let sdkPromise: Promise<SdkModule> | null = null;
+
+// Use an indirect specifier to prevent vite/rollup from eagerly resolving
+// the SDK at test-collection time. Without this, vitest fails on a fresh
+// checkout before `sdk/dist/` is built, even though only a handful of tests
+// actually exercise the sdk adapter.
+const SDK_SPECIFIER = "@zksettle/sdk";
+
+function loadSdk(): Promise<SdkModule> {
+  if (!sdkPromise) {
+    sdkPromise = import(/* @vite-ignore */ SDK_SPECIFIER) as Promise<SdkModule>;
+  }
+  return sdkPromise;
+}
 
 const REDEMPTION_TREASURY_OFFSET = 8 + 32;
 
@@ -82,22 +84,24 @@ async function getTreasury(
   connection: Connection,
   mint: PublicKey,
 ): Promise<Treasury | null> {
-  const [treasuryPda] = findTreasuryPda(mint);
+  const sdk = await loadSdk();
+  const [treasuryPda] = sdk.findTreasuryPda(mint);
   const info = await connection.getAccountInfo(treasuryPda);
   if (!info) return null;
-  return toLocalTreasury(decodeTreasury(info.data));
+  return toLocalTreasury(sdk.decodeTreasury(info.data));
 }
 
 async function listRedemptions(
   connection: Connection,
   mint: PublicKey,
 ): Promise<RedemptionRequest[]> {
-  const [treasuryPda] = findTreasuryPda(mint);
+  const sdk = await loadSdk();
+  const [treasuryPda] = sdk.findTreasuryPda(mint);
   const accounts = await connection.getProgramAccounts(
     STABLECOIN_PROGRAM_ID,
     {
       filters: [
-        { dataSize: REDEMPTION_REQUEST_DATA_LEN },
+        { dataSize: sdk.REDEMPTION_REQUEST_DATA_LEN },
         {
           memcmp: {
             offset: REDEMPTION_TREASURY_OFFSET,
@@ -111,7 +115,9 @@ async function listRedemptions(
   const decoded: RedemptionRequest[] = [];
   for (const { pubkey, account } of accounts) {
     try {
-      decoded.push(toLocalRedemption(pubkey, decodeRedemptionRequest(account.data)));
+      decoded.push(
+        toLocalRedemption(pubkey, sdk.decodeRedemptionRequest(account.data)),
+      );
     } catch {
       // skip accounts that don't match the redemption discriminator
     }
@@ -123,45 +129,62 @@ export const sdkAdapter: StablecoinAdapter = {
   getTreasury,
   listRedemptions,
   async buildSetOperator(ctx: AdapterContext, mint, newOperator) {
-    return wrap(ctx.payer, buildSetOperatorIx(ctx.payer, mint, newOperator));
+    const sdk = await loadSdk();
+    return wrap(ctx.payer, sdk.buildSetOperatorIx(ctx.payer, mint, newOperator));
   },
   async buildProposeAdmin(ctx: AdapterContext, mint, newAdmin) {
-    return wrap(ctx.payer, buildProposeAdminIx(ctx.payer, mint, newAdmin));
+    const sdk = await loadSdk();
+    return wrap(ctx.payer, sdk.buildProposeAdminIx(ctx.payer, mint, newAdmin));
   },
   async buildAcceptAdmin(ctx: AdapterContext, mint) {
-    return wrap(ctx.payer, buildAcceptAdminIx(ctx.payer, mint));
+    const sdk = await loadSdk();
+    return wrap(ctx.payer, sdk.buildAcceptAdminIx(ctx.payer, mint));
   },
   async buildCancelPendingAdmin(ctx: AdapterContext, mint) {
-    return wrap(ctx.payer, buildCancelPendingAdminIx(ctx.payer, mint));
+    const sdk = await loadSdk();
+    return wrap(ctx.payer, sdk.buildCancelPendingAdminIx(ctx.payer, mint));
   },
   async buildUpdateMintCap(ctx: AdapterContext, mint, newCap) {
+    const sdk = await loadSdk();
     return wrap(
       ctx.payer,
-      buildUpdateMintCapIx(ctx.payer, mint, toBigInt(newCap)),
+      sdk.buildUpdateMintCapIx(ctx.payer, mint, toBigInt(newCap)),
     );
   },
   async buildPause(ctx: AdapterContext, mint) {
-    return wrap(ctx.payer, buildPauseIx(ctx.payer, mint));
+    const sdk = await loadSdk();
+    return wrap(ctx.payer, sdk.buildPauseIx(ctx.payer, mint));
   },
   async buildUnpause(ctx: AdapterContext, mint) {
-    return wrap(ctx.payer, buildUnpauseIx(ctx.payer, mint));
+    const sdk = await loadSdk();
+    return wrap(ctx.payer, sdk.buildUnpauseIx(ctx.payer, mint));
   },
   async buildFreezeAccount(ctx: AdapterContext, mint, tokenAccount) {
-    return wrap(ctx.payer, buildFreezeAccountIx(ctx.payer, mint, tokenAccount));
-  },
-  async buildThawAccount(ctx: AdapterContext, mint, tokenAccount) {
-    return wrap(ctx.payer, buildThawAccountIx(ctx.payer, mint, tokenAccount));
-  },
-  async buildMintTokens(ctx: AdapterContext, mint, destination, amount) {
+    const sdk = await loadSdk();
     return wrap(
       ctx.payer,
-      buildMintTokensIx(ctx.payer, mint, destination, toBigInt(amount)),
+      sdk.buildFreezeAccountIx(ctx.payer, mint, tokenAccount),
+    );
+  },
+  async buildThawAccount(ctx: AdapterContext, mint, tokenAccount) {
+    const sdk = await loadSdk();
+    return wrap(
+      ctx.payer,
+      sdk.buildThawAccountIx(ctx.payer, mint, tokenAccount),
+    );
+  },
+  async buildMintTokens(ctx: AdapterContext, mint, destination, amount) {
+    const sdk = await loadSdk();
+    return wrap(
+      ctx.payer,
+      sdk.buildMintTokensIx(ctx.payer, mint, destination, toBigInt(amount)),
     );
   },
   async buildApproveRedemption(ctx: AdapterContext, mint, redemption) {
+    const sdk = await loadSdk();
     return wrap(
       ctx.payer,
-      buildApproveRedemptionIx(
+      sdk.buildApproveRedemptionIx(
         ctx.payer,
         redemption.holder,
         mint,
@@ -171,9 +194,10 @@ export const sdkAdapter: StablecoinAdapter = {
     );
   },
   async buildCancelRedemption(ctx: AdapterContext, mint, redemption) {
+    const sdk = await loadSdk();
     return wrap(
       ctx.payer,
-      buildCancelRedemptionIx(
+      sdk.buildCancelRedemptionIx(
         ctx.payer,
         redemption.holder,
         mint,

--- a/frontend/src/lib/stablecoin/types.ts
+++ b/frontend/src/lib/stablecoin/types.ts
@@ -1,0 +1,102 @@
+import type { BN } from "@coral-xyz/anchor";
+import type { Connection, PublicKey, Transaction } from "@solana/web3.js";
+
+export type StablecoinRole = "admin" | "operator" | "both" | "none";
+
+export interface Treasury {
+  admin: PublicKey;
+  operator: PublicKey;
+  mint: PublicKey;
+  totalMinted: BN;
+  totalBurned: BN;
+  decimals: number;
+  paused: boolean;
+  pendingAdmin: PublicKey | null;
+  mintCap: BN;
+  redemptionNonce: BN;
+}
+
+export interface RedemptionRequest {
+  pda: PublicKey;
+  holder: PublicKey;
+  treasury: PublicKey;
+  mint: PublicKey;
+  tokenAccount: PublicKey;
+  amount: BN;
+  nonce: BN;
+  requestedAt: number;
+}
+
+export interface AdapterContext {
+  payer: PublicKey;
+}
+
+export type ActionKind =
+  | "set_operator"
+  | "propose_admin"
+  | "accept_admin"
+  | "cancel_pending_admin"
+  | "update_mint_cap"
+  | "pause"
+  | "unpause"
+  | "freeze_account"
+  | "thaw_account"
+  | "mint_tokens"
+  | "approve_redemption"
+  | "cancel_redemption";
+
+export interface StablecoinAdapter {
+  getTreasury(connection: Connection, mint: PublicKey): Promise<Treasury | null>;
+  listRedemptions(
+    connection: Connection,
+    mint: PublicKey,
+  ): Promise<RedemptionRequest[]>;
+  buildSetOperator(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    newOperator: PublicKey,
+  ): Promise<Transaction>;
+  buildProposeAdmin(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    newAdmin: PublicKey,
+  ): Promise<Transaction>;
+  buildAcceptAdmin(ctx: AdapterContext, mint: PublicKey): Promise<Transaction>;
+  buildCancelPendingAdmin(
+    ctx: AdapterContext,
+    mint: PublicKey,
+  ): Promise<Transaction>;
+  buildUpdateMintCap(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    newCap: BN,
+  ): Promise<Transaction>;
+  buildPause(ctx: AdapterContext, mint: PublicKey): Promise<Transaction>;
+  buildUnpause(ctx: AdapterContext, mint: PublicKey): Promise<Transaction>;
+  buildFreezeAccount(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    tokenAccount: PublicKey,
+  ): Promise<Transaction>;
+  buildThawAccount(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    tokenAccount: PublicKey,
+  ): Promise<Transaction>;
+  buildMintTokens(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    destination: PublicKey,
+    amount: BN,
+  ): Promise<Transaction>;
+  buildApproveRedemption(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    redemption: RedemptionRequest,
+  ): Promise<Transaction>;
+  buildCancelRedemption(
+    ctx: AdapterContext,
+    mint: PublicKey,
+    redemption: RedemptionRequest,
+  ): Promise<Transaction>;
+}


### PR DESCRIPTION
Closes #172.

## Summary

Adds `/dashboard/admin` — the role-gated treasury control panel for the stablecoin contract. The route detects whether the connected wallet is the treasury admin, operator, both, or neither, and renders only the panels that wallet is authorised to drive. All seven destructive actions go through a confirmation dialog before signing, every successful TX surfaces a Solscan link, and treasury/redemption queries auto-refresh on success.

Built on top of the SDK module shipped in #171 — uses `StablecoinClient`, the instruction builders, and the on-chain account decoders directly. PDA seeds verified against `backend/programs/stablecoin/src/state/seeds.rs` (hyphens, e.g. `mint-authority`).

## What's in the PR

| Layer | Files |
|---|---|
| Library contract | `frontend/src/lib/stablecoin/{types,program,format,adapter,mock-adapter,sdk-adapter,index}.ts` |
| Hooks | `frontend/src/hooks/{use-treasury,use-redemption-requests,use-stablecoin-role,use-stablecoin-action,use-nav-items}.ts` |
| Components | `frontend/src/components/dashboard/{confirm-action-dialog,treasury-overview,admin-controls,operator-controls,redemption-queue,pause-banner}.tsx` |
| Route | `frontend/src/app/dashboard/admin/{page,admin-panels}.tsx` |
| Nav | `nav-items.ts`, `sidebar.tsx`, `mobile-nav-drawer.tsx` (filter via `useNavItems`) |
| Tests | format (22), role detection (5), confirm dialog (5), admin panels (7), routing (extended) |
| Docs | `frontend/.env.example` updated; `docs/plans/issue-172-admin-dashboard.md` |

## Adapter pattern

The UI imports stablecoin types and adapter functions from `@/lib/stablecoin`, never from `@zksettle/sdk` directly. Two implementations satisfy the interface:
- **`sdkAdapter`** (default) — calls into `@zksettle/sdk` for PDAs, instructions, and account decoders. Lists open redemptions via `getProgramAccounts` filtered by `dataSize` + treasury memcmp at offset 40 (decoder validates discriminator on read).
- **`mockAdapter`** — deterministic fixtures (active + expired redemption, full treasury). Used in unit tests; can also drive the live UI for offline demos.

Selector reads `NEXT_PUBLIC_STABLECOIN_ADAPTER` (defaults to `sdk`). SDK `bigint` values are converted to BN at the adapter boundary so the wider frontend can stay BN-based.

## Required follow-up before this is usable on devnet

These are intentionally **not** in this PR — they are deployment-side concerns:

1. **Deploy the stablecoin mint** (one-shot setup script per #171) and capture the mint address.
2. **Set `NEXT_PUBLIC_STABLECOIN_MINT`** in `frontend/.env.local` (and Vercel/whatever the deploy target is) to that address. Without it, the admin page shows a "mint not configured" notice instead of crashing — the env-var name is documented in `frontend/.env.example`.
3. **Confirm `NEXT_PUBLIC_STABLECOIN_ADAPTER` is unset or `sdk`** in production. `mock` should never be set in prod.
4. **Confirm `NEXT_PUBLIC_SOLANA_NETWORK` and `NEXT_PUBLIC_SOLANA_RPC_URL`** point at the same cluster the mint was deployed on. The Solscan toast link drops the `?cluster` query for mainnet and includes it for devnet/testnet.

Optional knobs (mock mode only, ignored when adapter=sdk):
- `NEXT_PUBLIC_STABLECOIN_MOCK_ADMIN` — pin a specific wallet as the mock admin so the connected wallet matches role gates locally.
- `NEXT_PUBLIC_STABLECOIN_MOCK_OPERATOR` — same for the operator role.

## Acceptance criteria (from #172)

- [x] `useStablecoinRole` correctly detects admin / operator / both / none from the connected wallet
- [x] Admin page is hidden from wallets with no role
- [x] Treasury overview shows mint, admin, operator, total minted/burned, mint cap, paused state, pending admin
- [x] Admin can change operator (`set_operator`)
- [x] Admin can propose / cancel / accept admin transfer
- [x] Admin can update mint cap (warns if new cap is below current minted)
- [x] Admin can pause / unpause with destructive confirmation
- [x] Admin can freeze / thaw token accounts (freeze disabled while paused)
- [x] Operator can mint tokens (cap-aware progress bar, blocks over-cap submissions)
- [x] Operator can approve / cancel-expired redemption requests
- [x] All destructive actions go through a confirmation dialog
- [x] Successful TXs show a Solscan link and re-fetch treasury state
- [x] Paused state is visually distinct (red banner above the panels)

## Verification

- `pnpm test` → 29 files, **123 tests passed** (4 pre-existing typecheck warnings in unrelated files were not introduced here)
- `pnpm lint` → 0 errors (3 pre-existing warnings in `fixtures.ts`, `ledger-particles.ts`, `connect-wallet-button.tsx`)
- `pnpm build` → succeeds; `/dashboard/admin` static page emits at **10.1 kB** (262 kB First Load JS, smaller than the prove flow)

## Test plan

- [ ] Pull, set `NEXT_PUBLIC_STABLECOIN_MINT` to the deployed devnet mint, run `pnpm dev`
- [ ] Connect the admin wallet → confirm Admin nav item appears, treasury overview shows accurate state, every admin panel renders
- [ ] Try `set_operator`, then connect with the new operator wallet → confirm only Operator panels show
- [ ] Connect a random wallet → confirm Admin nav item is hidden and `/dashboard/admin` returns null content
- [ ] Trigger `pause` → confirm the red banner appears, mint button disables, freeze button disables, thaw stays enabled
- [ ] Approve a real redemption → confirm Solscan link works and redemption disappears from the queue after refresh

## Out of scope (future tickets)

- Listing redemptions via `getProgramAccounts` is fine for current devnet load but should move to an indexer-backed feed at scale.
- Pause banner is local to the admin route. Promoting it to the dashboard layout would require `useTreasury` on every page — defer until justified.
- No focus-trap inside `ConfirmActionDialog` — Escape works, click-outside dismisses, but tab focus is not trapped. Acceptable for now; revisit if a11y audit flags it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin/operator dashboard page with treasury overview, role-gated admin/operator controls, redemption queue, pause banner, and confirm-action dialog.
  * Navigation updated to show an Admin item when appropriate.
  * Client hooks and utilities for treasury, redemption requests, role detection, and stablecoin actions; mock and SDK-backed adapters for local vs runtime behavior.

* **Documentation**
  * Added detailed implementation plan for the admin/operator dashboard and rollout checklist.

* **Tests**
  * Extensive new tests covering dashboard pages, components, hooks, and utilities.

* **Chores**
  * Added environment variables and adjusted CI build to include SDK build step.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/175)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->