### PR TITLE
Pre-allocate merkle tree, idempotent devnet setup, new program IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ INDEXER_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_ga
 # ── Issuer Service ───────────────────────────────────────────
 RPC_URL=http://127.0.0.1:8899
 KEYPAIR_PATH=~/.config/solana/id.json
+# Alternative to KEYPAIR_PATH for cloud deployments (JSON byte array, e.g. [1,2,3,...]):
+# ISSUER_KEYPAIR=
 PROGRAM_ID=zkSet11ezkSet11ezkSet11ezkSet11ezkSet11ezkS
 ROTATION_INTERVAL_SECS=43200
 LISTEN_ADDR=127.0.0.1:3000

--- a/backend/Anchor.toml
+++ b/backend/Anchor.toml
@@ -7,12 +7,12 @@ skip-lint = true
 
 
 [programs.devnet]
-zksettle = "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo"
-stablecoin = "2CdXRSPo6QLfLBJTikmrqmBiWwa1HpuuYJ2Qu6Yy3Liv"
+zksettle = "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
+stablecoin = "8UCELgX3D64aWPJcJre7AtuoSre5eWjHdAFsRUkeqCMe"
 
 [programs.localnet]
-zksettle = "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo"
-stablecoin = "2CdXRSPo6QLfLBJTikmrqmBiWwa1HpuuYJ2Qu6Yy3Liv"
+zksettle = "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
+stablecoin = "8UCELgX3D64aWPJcJre7AtuoSre5eWjHdAFsRUkeqCMe"
 
 [provider]
 cluster = "devnet"

--- a/backend/programs/stablecoin/src/lib.rs
+++ b/backend/programs/stablecoin/src/lib.rs
@@ -12,7 +12,7 @@ pub use instructions::*;
 
 pub const EVENT_VERSION: u8 = 1;
 
-declare_id!("2CdXRSPo6QLfLBJTikmrqmBiWwa1HpuuYJ2Qu6Yy3Liv");
+declare_id!("8UCELgX3D64aWPJcJre7AtuoSre5eWjHdAFsRUkeqCMe");
 
 #[program]
 pub mod stablecoin {

--- a/backend/programs/zksettle/src/error.rs
+++ b/backend/programs/zksettle/src/error.rs
@@ -73,6 +73,10 @@ pub enum ZkSettleError {
     BubblegumTreeMismatch,
     #[msg("Bubblegum create_tree_config or mint CPI failed")]
     BubblegumCpiFailed,
+    #[msg("Pre-allocated merkle tree account is too small for configured depth/buffer")]
+    MerkleTreeTooSmall,
+    #[msg("Pre-allocated merkle tree account is not owned by SPL account compression")]
+    MerkleTreeWrongOwner,
     #[msg("Trailing Bubblegum account count is invalid for remaining_accounts split")]
     BubblegumTailInvalid,
     #[msg("Bubblegum leaf owner does not match settlement recipient")]
@@ -163,6 +167,8 @@ mod tests {
             ZkSettleError::BubblegumTreeNotConfigured as u32,
             ZkSettleError::BubblegumTreeMismatch as u32,
             ZkSettleError::BubblegumCpiFailed as u32,
+            ZkSettleError::MerkleTreeTooSmall as u32,
+            ZkSettleError::MerkleTreeWrongOwner as u32,
             ZkSettleError::BubblegumTailInvalid as u32,
             ZkSettleError::BubblegumLeafOwnerMismatch as u32,
             ZkSettleError::MintHookMismatch as u32,

--- a/backend/programs/zksettle/src/instructions/init_attestation_tree.rs
+++ b/backend/programs/zksettle/src/instructions/init_attestation_tree.rs
@@ -1,7 +1,6 @@
 //! One-time Bubblegum + concurrent merkle tree setup for ADR-019 attestation cNFTs.
 
 use anchor_lang::prelude::*;
-use anchor_lang::system_program::{self, CreateAccount};
 
 use crate::constants::{BUBBLEGUM_MAX_BUFFER_SIZE, BUBBLEGUM_MAX_DEPTH};
 use crate::error::ZkSettleError;
@@ -69,21 +68,18 @@ pub fn init_handler(ctx: Context<InitAttestationTree>) -> Result<()> {
         ZkSettleError::BubblegumCpiFailed
     );
 
-    let space = bubblegum_merkle_tree_account_size();
-    let lamports = Rent::get()?.minimum_balance(space);
-
-    system_program::create_account(
-        CpiContext::new(
-            ctx.accounts.system_program.to_account_info(),
-            CreateAccount {
-                from: ctx.accounts.authority.to_account_info(),
-                to: ctx.accounts.merkle_tree.to_account_info(),
-            },
-        ),
-        lamports,
-        space as u64,
-        &SPL_ACCOUNT_COMPRESSION_ID,
-    )?;
+    // Merkle tree account must be pre-allocated client-side (>10KB exceeds
+    // inner-instruction realloc limit).
+    let tree_info = ctx.accounts.merkle_tree.to_account_info();
+    let expected_space = bubblegum_merkle_tree_account_size();
+    require!(
+        tree_info.data_len() >= expected_space,
+        ZkSettleError::MerkleTreeTooSmall
+    );
+    require!(
+        *tree_info.owner == SPL_ACCOUNT_COMPRESSION_ID,
+        ZkSettleError::MerkleTreeWrongOwner
+    );
 
     let bump = ctx.bumps.tree_creator;
     let seeds: &[&[u8]] = &[BUBBLEGUM_TREE_CREATOR_SEED, &[bump]];

--- a/backend/programs/zksettle/src/lib.rs
+++ b/backend/programs/zksettle/src/lib.rs
@@ -17,7 +17,7 @@ use light_sdk::derive_light_cpi_signer;
 
 pub use instructions::*;
 
-declare_id!("AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo");
+declare_id!("2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk");
 
 /// Light Protocol CPI signer derived from the program ID.
 ///
@@ -26,7 +26,7 @@ declare_id!("AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo");
 /// that require a string literal, so the value cannot be extracted into a
 /// shared `const`. Update both sites together.
 pub const LIGHT_CPI_SIGNER: CpiSigner =
-    derive_light_cpi_signer!("AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo");
+    derive_light_cpi_signer!("2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk");
 
 #[program]
 pub mod zksettle {

--- a/scripts/devnet-hook/package-lock.json
+++ b/scripts/devnet-hook/package-lock.json
@@ -1108,20 +1108,6 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",

--- a/scripts/devnet-hook/setup.ts
+++ b/scripts/devnet-hook/setup.ts
@@ -43,7 +43,7 @@ import * as path from "path";
 import idlJson from "../../sdk/src/idl/zksettle.json";
 
 const ZKSETTLE_PROGRAM_ID = new PublicKey(
-  "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo"
+  "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
 );
 
 const MPL_BUBBLEGUM_ID = new PublicKey(

--- a/scripts/devnet-hook/setup.ts
+++ b/scripts/devnet-hook/setup.ts
@@ -37,10 +37,10 @@ import {
   sendAndConfirmTransaction,
 } from "@solana/web3.js";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 import idlJson from "../../sdk/src/idl/zksettle.json";
+import { loadWallet } from "../lib/benchmark-utils";
 
 const ZKSETTLE_PROGRAM_ID = new PublicKey(
   "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
@@ -79,13 +79,6 @@ interface DevnetState {
   merkleTreeSecret: number[];
 }
 
-function loadWallet(): Keypair {
-  const walletPath =
-    process.env.ANCHOR_WALLET ||
-    path.join(os.homedir(), ".config/solana/id.json");
-  const raw = JSON.parse(fs.readFileSync(walletPath, "utf-8"));
-  return Keypair.fromSecretKey(Uint8Array.from(raw));
-}
 
 function findPda(seeds: Buffer[], programId: PublicKey): [PublicKey, number] {
   return PublicKey.findProgramAddressSync(seeds, programId);

--- a/scripts/devnet-hook/setup.ts
+++ b/scripts/devnet-hook/setup.ts
@@ -182,20 +182,25 @@ async function main() {
   const testSanctionsRoot = Buffer.alloc(32, 10);
   const testJurisdictionRoot = Buffer.alloc(32, 11);
 
-  const registerSig = await program.methods
-    .registerIssuer(
-      Array.from(testMerkleRoot),
-      Array.from(testSanctionsRoot),
-      Array.from(testJurisdictionRoot)
-    )
-    .accounts({
-      authority: wallet.publicKey,
-      issuer: issuerPda,
-      systemProgram: SystemProgram.programId,
-    })
-    .rpc();
-  console.log(`Issuer registered: ${issuerPda.toBase58()}`);
-  console.log(`  tx: ${registerSig}`);
+  const issuerInfo = await connection.getAccountInfo(issuerPda);
+  if (issuerInfo) {
+    console.log(`Issuer PDA already exists: ${issuerPda.toBase58()} — skipping register`);
+  } else {
+    const registerSig = await program.methods
+      .registerIssuer(
+        Array.from(testMerkleRoot),
+        Array.from(testSanctionsRoot),
+        Array.from(testJurisdictionRoot)
+      )
+      .accounts({
+        authority: wallet.publicKey,
+        issuer: issuerPda,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+    console.log(`Issuer registered: ${issuerPda.toBase58()}`);
+    console.log(`  tx: ${registerSig}`);
+  }
 
   // --- Step 4: init_extra_account_meta_list ---
   const [extraMetaPda] = findPda(
@@ -210,43 +215,87 @@ async function main() {
   //   [8] bubblegum_program: literal BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY
   const extras = buildExtraAccountMetas(wallet.publicKey);
 
-  const initMetaSig = await program.methods
-    .initExtraAccountMetaList(extras)
-    .accounts({
-      authority: wallet.publicKey,
-      issuer: issuerPda,
-      mint: mintKeypair.publicKey,
-      extraAccountMetaList: extraMetaPda,
-      systemProgram: SystemProgram.programId,
-    })
-    .rpc();
-  console.log(`Extra account meta list initialized: ${extraMetaPda.toBase58()}`);
-  console.log(`  tx: ${initMetaSig}`);
+  const extraMetaInfo = await connection.getAccountInfo(extraMetaPda);
+  if (extraMetaInfo) {
+    console.log(`Extra account meta list already exists: ${extraMetaPda.toBase58()} — skipping init`);
+  } else {
+    const initMetaSig = await program.methods
+      .initExtraAccountMetaList(extras)
+      .accounts({
+        authority: wallet.publicKey,
+        issuer: issuerPda,
+        mint: mintKeypair.publicKey,
+        extraAccountMetaList: extraMetaPda,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+    console.log(`Extra account meta list initialized: ${extraMetaPda.toBase58()}`);
+    console.log(`  tx: ${initMetaSig}`);
+  }
 
   // --- Step 5: init_attestation_tree ---
-  const merkleTreeKp = Keypair.generate();
   const [registryPda] = findPda([BUBBLEGUM_REGISTRY_SEED], ZKSETTLE_PROGRAM_ID);
-  const [treeCreatorPda] = findPda([BUBBLEGUM_TREE_CREATOR_SEED], ZKSETTLE_PROGRAM_ID);
-  const [treeConfigKey] = treeConfigPda(merkleTreeKp.publicKey);
+  const registryInfo = await connection.getAccountInfo(registryPda);
+  let merkleTreeKp: Keypair;
+  if (registryInfo) {
+    // Registry already on-chain — load keypair from previous state file.
+    const prev = loadState();
+    if (!prev) throw new Error("Registry PDA exists but no devnet-state.json found to recover merkle tree keypair");
+    merkleTreeKp = Keypair.fromSecretKey(Uint8Array.from(prev.merkleTreeSecret));
+    console.log(`Attestation tree registry already exists: ${registryPda.toBase58()} — skipping init`);
+  } else {
+    // Pre-allocate the merkle tree account client-side (>10KB exceeds the
+    // inner-instruction realloc limit on mainnet/devnet).
+    merkleTreeKp = Keypair.generate();
+    const [treeCreatorPda] = findPda([BUBBLEGUM_TREE_CREATOR_SEED], ZKSETTLE_PROGRAM_ID);
+    const [treeConfigKey] = treeConfigPda(merkleTreeKp.publicKey);
 
-  const initTreeSig = await program.methods
-    .initAttestationTree()
-    .accounts({
-      authority: wallet.publicKey,
-      issuer: issuerPda,
-      registry: registryPda,
-      merkleTree: merkleTreeKp.publicKey,
-      treeConfig: treeConfigKey,
-      treeCreator: treeCreatorPda,
-      bubblegumProgram: MPL_BUBBLEGUM_ID,
-      compressionProgram: SPL_ACCOUNT_COMPRESSION_ID,
-      logWrapper: SPL_NOOP_ID,
-      systemProgram: SystemProgram.programId,
-    })
-    .signers([merkleTreeKp])
-    .rpc();
-  console.log(`Attestation tree initialized: ${merkleTreeKp.publicKey.toBase58()}`);
-  console.log(`  tx: ${initTreeSig}`);
+    // HEADER_SIZE_V1 (2 + 54) + size_of::<ConcurrentMerkleTree<14, 64>>()
+    // = 56 + (8 + 8 + 4 + 32 + 32*14 + (32+32)*64*14 + 32*64)
+    // = 31800 bytes. Must match bubblegum_merkle_tree_account_size() in Rust.
+    // If BUBBLEGUM_MAX_DEPTH (14) or BUBBLEGUM_MAX_BUFFER_SIZE (64) change,
+    // recompute this value.
+    const MERKLE_TREE_ACCOUNT_SIZE = 31800;
+    const treeRent = await connection.getMinimumBalanceForRentExemption(
+      MERKLE_TREE_ACCOUNT_SIZE
+    );
+    const createTreeAccTx = new Transaction().add(
+      SystemProgram.createAccount({
+        fromPubkey: wallet.publicKey,
+        newAccountPubkey: merkleTreeKp.publicKey,
+        space: MERKLE_TREE_ACCOUNT_SIZE,
+        lamports: treeRent,
+        programId: SPL_ACCOUNT_COMPRESSION_ID,
+      })
+    );
+    const createTreeSig = await sendAndConfirmTransaction(
+      connection,
+      createTreeAccTx,
+      [wallet, merkleTreeKp],
+      { commitment: "confirmed" }
+    );
+    console.log(`Merkle tree account created: ${merkleTreeKp.publicKey.toBase58()}`);
+    console.log(`  tx: ${createTreeSig}`);
+
+    const initTreeSig = await program.methods
+      .initAttestationTree()
+      .accounts({
+        authority: wallet.publicKey,
+        issuer: issuerPda,
+        registry: registryPda,
+        merkleTree: merkleTreeKp.publicKey,
+        treeConfig: treeConfigKey,
+        treeCreator: treeCreatorPda,
+        bubblegumProgram: MPL_BUBBLEGUM_ID,
+        compressionProgram: SPL_ACCOUNT_COMPRESSION_ID,
+        logWrapper: SPL_NOOP_ID,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([merkleTreeKp])
+      .rpc();
+    console.log(`Attestation tree initialized: ${merkleTreeKp.publicKey.toBase58()}`);
+    console.log(`  tx: ${initTreeSig}`);
+  }
 
   // --- Step 6: Create ATAs ---
   const recipient = Keypair.generate();

--- a/scripts/devnet-hook/transfer.ts
+++ b/scripts/devnet-hook/transfer.ts
@@ -23,10 +23,10 @@ import {
 } from "@solana/web3.js";
 import * as crypto from "crypto";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 
 import idlJson from "../../sdk/src/idl/zksettle.json";
+import { loadWallet } from "../lib/benchmark-utils";
 
 const ZKSETTLE_PROGRAM_ID = new PublicKey(
   "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
@@ -64,13 +64,7 @@ interface DevnetState {
   merkleTreeSecret: number[];
 }
 
-function loadWallet(): Keypair {
-  const walletPath =
-    process.env.ANCHOR_WALLET ||
-    path.join(os.homedir(), ".config/solana/id.json");
-  const raw = JSON.parse(fs.readFileSync(walletPath, "utf-8"));
-  return Keypair.fromSecretKey(Uint8Array.from(raw));
-}
+// loadWallet imported from shared util — single source of truth.
 
 function findPda(seeds: Buffer[], programId: PublicKey): [PublicKey, number] {
   return PublicKey.findProgramAddressSync(seeds, programId);

--- a/scripts/devnet-hook/transfer.ts
+++ b/scripts/devnet-hook/transfer.ts
@@ -29,7 +29,7 @@ import * as path from "path";
 import idlJson from "../../sdk/src/idl/zksettle.json";
 
 const ZKSETTLE_PROGRAM_ID = new PublicKey(
-  "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo"
+  "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
 );
 
 const MPL_BUBBLEGUM_ID = new PublicKey(

--- a/scripts/lib/benchmark-utils.ts
+++ b/scripts/lib/benchmark-utils.ts
@@ -101,6 +101,9 @@ export async function exists(c: Connection, pk: PublicKey): Promise<boolean> {
 }
 
 export function loadWallet(): Keypair {
+  if (process.env.ISSUER_KEYPAIR) {
+    return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(process.env.ISSUER_KEYPAIR)));
+  }
   const p = process.env.ANCHOR_WALLET || path.join(os.homedir(), ".config/solana/id.json");
   return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(fs.readFileSync(p, "utf-8"))));
 }

--- a/scripts/lib/benchmark-utils.ts
+++ b/scripts/lib/benchmark-utils.ts
@@ -19,7 +19,7 @@ import * as path from "path";
 // ---------------------------------------------------------------------------
 
 export const ZKSETTLE_PROGRAM_ID = new PublicKey(
-  "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo"
+  "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
 );
 export const MPL_BUBBLEGUM_ID = new PublicKey(
   "BGUMAp9Gq7iTEuizy4pqaxsTyUCBK68MDfK752saRPUY"

--- a/scripts/stress-test.ts
+++ b/scripts/stress-test.ts
@@ -35,8 +35,8 @@ import {
   TOKEN_2022_PROGRAM_ID,
 } from "@solana/spl-token";
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
+import { loadWallet } from "./lib/benchmark-utils";
 
 interface TransferResult {
   index: number;
@@ -105,13 +105,7 @@ function parseArgs(): {
   };
 }
 
-function loadWallet(): Keypair {
-  const walletPath =
-    process.env.ANCHOR_WALLET ||
-    path.join(os.homedir(), ".config/solana/id.json");
-  const raw = JSON.parse(fs.readFileSync(walletPath, "utf-8"));
-  return Keypair.fromSecretKey(Uint8Array.from(raw));
-}
+// loadWallet imported from shared util — single source of truth.
 
 function percentile(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -113,5 +113,5 @@ When updating, always bump all three simultaneously and run the proof test suite
 ## Program ID
 
 ```text
-AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo
+2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk
 ```

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from "@solana/web3.js";
 
 export const ZKSETTLE_PROGRAM_ID = new PublicKey(
-  "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo"
+  "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk"
 );
 
 export const MPL_BUBBLEGUM_ID = new PublicKey(

--- a/sdk/src/idl/zksettle.json
+++ b/sdk/src/idl/zksettle.json
@@ -1,5 +1,5 @@
 {
-  "address": "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo",
+  "address": "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk",
   "metadata": {
     "name": "zksettle",
     "version": "0.1.0",

--- a/sdk/src/idl/zksettle.ts
+++ b/sdk/src/idl/zksettle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `sdk/src/idl/zksettle.json`.
  */
 export type Zksettle = {
-  "address": "AyZk4CYFAFFJiFC2WqqXY2oq2pgN6vvrWwYbbWz7z7Jo",
+  "address": "2HexcvYg6zvQo6kf1ompmvG78GUKMTW292kp1wDdKzFk",
   "metadata": {
     "name": "zksettle",
     "version": "0.1.0",


### PR DESCRIPTION
## Summary

- **Pre-allocate merkle tree client-side**: `init_attestation_tree` no longer creates the merkle tree account via CPI — it validates a pre-allocated account instead, avoiding the >10KB inner-instruction realloc limit on mainnet/devnet
- **Idempotent devnet setup**: each step checks if its PDA already exists before creating, enabling safe re-runs of `setup.ts`
- **Deduplicate `loadWallet`**: extracted to shared `benchmark-utils.ts` with `ISSUER_KEYPAIR` env var support for cloud deployments
- **New program IDs**: fresh devnet deploy for both zksettle and stablecoin programs

## On-chain changes

- `init_attestation_tree` validates pre-allocated account size and owner instead of CPI `create_account`
- New error variants: `MerkleTreeTooSmall`, `MerkleTreeWrongOwner`

## Script changes

- `setup.ts`: idempotent PDA creation + client-side merkle tree allocation (31800 bytes matching Rust `bubblegum_merkle_tree_account_size()`)
- `transfer.ts`, `stress-test.ts`: import shared `loadWallet` instead of local copy
- `benchmark-utils.ts`: `ISSUER_KEYPAIR` env var (JSON byte array) as alternative to file path

## Cleanup

- Removed extraneous `utf-8-validate` from `package-lock.json`
- Added `ISSUER_KEYPAIR` placeholder to `.env.example`

Closes #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JSON-formatted keypair environment variable configuration
  * Enhanced Merkle tree validation during attestation tree setup with new error checks

* **Chores**
  * Updated blockchain program addresses throughout SDK and deployment scripts
  * Consolidated wallet loading logic across scripts for consistency
  * Improved devnet setup with idempotent initialization and state recovery

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/177)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->