### PR TITLE
feat(frontend,sdk): dashboard UI overhaul, prove flow with issuer registration and batch signing

### DIFF
--- a/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
@@ -9,8 +9,8 @@ use spl_transfer_hook_interface::instruction::ExecuteInstruction;
 use crate::error::ZkSettleError;
 
 use super::{
-    types::{ExtraAccountMetaInput, StagedLightArgs, EXTRA_ACCOUNT_META_LIST_SEED, MAX_HOOK_PROOF_BYTES},
-    CloseHookPayload, InitExtraAccountMetaList, InitHookPayload, ModifyHookPayload,
+    types::{ExtraAccountMetaInput, HookPayload, StagedLightArgs, EXTRA_ACCOUNT_META_LIST_SEED, MAX_HOOK_PROOF_BYTES},
+    CloseHookPayload, InitExtraAccountMetaList, InitHookPayload, ModifyHookPayload, ResizeHookPayload,
 };
 
 pub fn init_hook_payload_handler(
@@ -28,8 +28,45 @@ pub fn init_hook_payload_handler(
     payload.expected_proof_len = expected_proof_len;
     payload.high_water_mark = 0;
     payload.finalized = false;
-    payload.proof_and_witness = vec![0u8; len];
     payload.bump = ctx.bumps.hook_payload;
+    Ok(())
+}
+
+/// Grows the hook-payload account towards its target size. Solana caps
+/// `realloc` at 10 KiB per instruction, so the client may need to call
+/// this multiple times. Once at target size the proof vector is allocated.
+pub fn resize_hook_payload_handler(ctx: Context<ResizeHookPayload>) -> Result<()> {
+    let hook_info = ctx.accounts.hook_payload.to_account_info();
+    let expected = ctx.accounts.hook_payload.expected_proof_len as usize;
+    let target = 8 + HookPayload::BASE_SPACE + expected;
+    let current_len = hook_info.data_len();
+
+    if current_len >= target {
+        return Ok(());
+    }
+
+    let new_len = target.min(current_len + 10_240);
+    let rent = Rent::get()?;
+    let needed = rent.minimum_balance(new_len);
+    let lamports = hook_info.lamports();
+    if needed > lamports {
+        anchor_lang::system_program::transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.to_account_info(),
+                anchor_lang::system_program::Transfer {
+                    from: ctx.accounts.authority.to_account_info(),
+                    to: hook_info.clone(),
+                },
+            ),
+            needed - lamports,
+        )?;
+    }
+    hook_info.realloc(new_len, false)?;
+
+    if new_len >= target {
+        let payload = &mut ctx.accounts.hook_payload;
+        payload.proof_and_witness = vec![0u8; expected];
+    }
     Ok(())
 }
 

--- a/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/handlers.rs
@@ -61,7 +61,7 @@ pub fn resize_hook_payload_handler(ctx: Context<ResizeHookPayload>) -> Result<()
             needed - lamports,
         )?;
     }
-    hook_info.realloc(new_len, false)?;
+    hook_info.realloc(new_len, true)?;
 
     if new_len >= target {
         let payload = &mut ctx.accounts.hook_payload;

--- a/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
@@ -13,7 +13,7 @@ use crate::state::{BubblegumTreeRegistry, Issuer, BUBBLEGUM_REGISTRY_SEED, BUBBL
 
 pub use handlers::{
     close_hook_payload_handler, finalize_hook_payload_handler, init_extra_account_meta_list_handler,
-    init_hook_payload_handler, write_hook_proof_handler,
+    init_hook_payload_handler, resize_hook_payload_handler, write_hook_proof_handler,
 };
 pub use settlement::{execute_hook_handler, settle_hook_handler};
 pub use types::{
@@ -21,12 +21,10 @@ pub use types::{
     HOOK_PAYLOAD_SEED, MAX_HOOK_PROOF_BYTES,
 };
 
-/// Creates the payload PDA with dynamic space based on the actual proof
-/// length. Uses `#[instruction]` to peel `expected_proof_len` from the
-/// `init_hook_payload` instruction data, keeping the PDA under the 10KB
-/// CPI init limit.
+/// Creates the payload PDA with header-only space (BASE_SPACE ≈ 301 bytes).
+/// Follow up with one or more `resize_hook_payload` calls to grow the
+/// account to `BASE_SPACE + expected_proof_len` before writing chunks.
 #[derive(Accounts)]
-#[instruction(expected_proof_len: u32)]
 pub struct InitHookPayload<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
@@ -38,18 +36,37 @@ pub struct InitHookPayload<'info> {
     )]
     pub issuer: Account<'info, Issuer>,
 
-    // Seeded by `authority.key()` alone, not `nullifier_hash`: Token-2022's
-    // Execute entry resolves the payload PDA from TLV `AddressConfig`, which
-    // only sees `ExecuteInstruction` data (amount) and account keys —
-    // nullifier-seeded PDAs are not addressable from the hook path. Trade-off:
-    // one outstanding payload per authority, parallel hook transfers from the
-    // same authority serialize on this PDA.
     #[account(
         init,
         payer = authority,
-        space = 8 + HookPayload::BASE_SPACE + expected_proof_len as usize,
+        space = 8 + HookPayload::BASE_SPACE,
         seeds = [HOOK_PAYLOAD_SEED, authority.key().as_ref()],
         bump,
+    )]
+    pub hook_payload: Account<'info, HookPayload>,
+
+    pub system_program: Program<'info, System>,
+}
+
+/// Grows the payload PDA towards its target size. Solana caps `realloc` at
+/// 10 KiB per instruction, so the client calls this 1–2 times after init.
+#[derive(Accounts)]
+pub struct ResizeHookPayload<'info> {
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    #[account(
+        seeds = [ISSUER_SEED, authority.key().as_ref()],
+        bump = issuer.bump,
+        has_one = authority @ ZkSettleError::UnauthorizedIssuer,
+    )]
+    pub issuer: Account<'info, Issuer>,
+
+    #[account(
+        mut,
+        seeds = [HOOK_PAYLOAD_SEED, authority.key().as_ref()],
+        bump = hook_payload.bump,
+        constraint = !hook_payload.finalized @ ZkSettleError::PayloadAlreadyFinalized,
     )]
     pub hook_payload: Account<'info, HookPayload>,
 

--- a/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
+++ b/backend/programs/zksettle/src/instructions/transfer_hook/mod.rs
@@ -21,7 +21,7 @@ pub use types::{
     HOOK_PAYLOAD_SEED, MAX_HOOK_PROOF_BYTES,
 };
 
-/// Creates the payload PDA with header-only space (BASE_SPACE ≈ 301 bytes).
+/// Creates the payload PDA with header-only space (see `HookPayload::BASE_SPACE`).
 /// Follow up with one or more `resize_hook_payload` calls to grow the
 /// account to `BASE_SPACE + expected_proof_len` before writing chunks.
 #[derive(Accounts)]

--- a/backend/programs/zksettle/src/lib.rs
+++ b/backend/programs/zksettle/src/lib.rs
@@ -104,6 +104,10 @@ pub mod zksettle {
         instructions::transfer_hook::init_hook_payload_handler(ctx, expected_proof_len)
     }
 
+    pub fn resize_hook_payload(ctx: Context<ResizeHookPayload>) -> Result<()> {
+        instructions::transfer_hook::resize_hook_payload_handler(ctx)
+    }
+
     pub fn write_hook_proof(
         ctx: Context<ModifyHookPayload>,
         offset: u32,

--- a/docs/superpowers/plans/2026-05-09-prove-flow-issuer-and-transfer-context.md
+++ b/docs/superpowers/plans/2026-05-09-prove-flow-issuer-and-transfer-context.md
@@ -1,0 +1,575 @@
+# Prove Flow: Issuer Registration & Transfer Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `WalletSendTransactionError` by auto-registering issuer PDA before proof upload, and replace hardcoded mint/recipient/amount with user-provided form inputs.
+
+**Architecture:** Two layers of changes: (1) SDK gets two new browser-compatible functions (`buildRegisterIssuerIx`, `checkIssuerExists`) following the existing `buildInitHookPayloadIx` pattern. (2) Frontend gets form inputs on the IntroCard that flow through `useProveFlow` → proof generation → on-chain submission. The issuer check + auto-register happens inside `runStepSubmit` before `uploadProofChunked`.
+
+**Tech Stack:** TypeScript, @solana/web3.js, @coral-xyz/anchor (browser build), React, Next.js, Sonner (toasts)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `sdk/src/wrap/index.ts` | Modify | Add `buildRegisterIssuerIx` and `checkIssuerExists` |
+| `sdk/src/index.ts` | Modify | Export new functions |
+| `frontend/src/hooks/use-prove-flow.ts` | Modify | Accept `TransferParams`, thread through proof gen + submit, add issuer auto-register |
+| `frontend/src/components/dashboard/prove-flow-panel.tsx` | Modify | Add mint/recipient/amount form to IntroCard, pass to hook |
+
+---
+
+### Task 1: SDK — Add `buildRegisterIssuerIx` and `checkIssuerExists`
+
+**Files:**
+- Modify: `sdk/src/wrap/index.ts`
+- Modify: `sdk/src/index.ts`
+
+- [ ] **Step 1: Add `checkIssuerExists` to `sdk/src/wrap/index.ts`**
+
+Add this function after the `WRITES_PER_TX` constant (line 48), before the `makeProgram` function:
+
+```typescript
+export async function checkIssuerExists(
+  wallet: PublicKey,
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+): Promise<boolean> {
+  const [issuerPda] = findIssuerPda(wallet, programId);
+  const info = await connection.getAccountInfo(issuerPda);
+  return info !== null;
+}
+```
+
+- [ ] **Step 2: Add `buildRegisterIssuerIx` to `sdk/src/wrap/index.ts`**
+
+Add this function right after `checkIssuerExists`:
+
+```typescript
+export async function buildRegisterIssuerIx(
+  wallet: PublicKey,
+  roots: { merkleRoot: Uint8Array; sanctionsRoot: Uint8Array; jurisdictionRoot: Uint8Array },
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+  program?: Program,
+): Promise<TransactionInstruction> {
+  const [issuerPda] = findIssuerPda(wallet, programId);
+  const prog = program ?? await makeProgram(connection);
+
+  return prog.methods
+    .registerIssuer(
+      Array.from(roots.merkleRoot),
+      Array.from(roots.sanctionsRoot),
+      Array.from(roots.jurisdictionRoot),
+    )
+    .accounts({
+      authority: wallet,
+      issuer: issuerPda,
+      systemProgram: SystemProgram.programId,
+    })
+    .instruction();
+}
+```
+
+- [ ] **Step 3: Export new functions from `sdk/src/index.ts`**
+
+Change the existing `wrap/index.js` export block (lines 2-8) to include the new functions:
+
+```typescript
+export {
+  buildInitHookPayloadIx,
+  buildWriteChunkIx,
+  buildFinalizeHookPayloadIx,
+  uploadProofChunked,
+  checkIssuerExists,
+  buildRegisterIssuerIx,
+  CHUNK_SIZE,
+} from "./wrap/index.js";
+```
+
+- [ ] **Step 4: Build SDK and verify no type errors**
+
+Run: `cd /home/mario/zksettle/sdk && pnpm build`
+Expected: Clean build, no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/src/wrap/index.ts sdk/src/index.ts
+git commit -m "feat(sdk): add browser-compatible buildRegisterIssuerIx and checkIssuerExists"
+```
+
+---
+
+### Task 2: Frontend — Accept transfer params in `useProveFlow`
+
+**Files:**
+- Modify: `frontend/src/hooks/use-prove-flow.ts`
+
+- [ ] **Step 1: Add `TransferParams` type and update `UseProveFlowReturn`**
+
+At the top of `use-prove-flow.ts`, after the existing imports (line 26), add:
+
+```typescript
+export interface TransferParams {
+  mint: string;
+  recipient: string;
+  amount: number;
+}
+```
+
+Update `UseProveFlowReturn` (lines 28-37) to change `startFlow` signature:
+
+```typescript
+export interface UseProveFlowReturn {
+  state: FlowState;
+  startFlow: (params: TransferParams) => Promise<void>;
+  startDemo: () => Promise<void>;
+  reset: () => void;
+  canStart: boolean;
+  isRunning: boolean;
+  isDone: boolean;
+  txUrl: string | null;
+}
+```
+
+- [ ] **Step 2: Add `TransferParams` to `LiveFlowContext` and `runStepProofGeneration`**
+
+Update `LiveFlowContext` (around line 271) to include transfer params:
+
+```typescript
+interface LiveFlowContext {
+  dispatch: Dispatch<FlowAction>;
+  walletHex: string;
+  publicKey: PublicKey;
+  connection: Connection;
+  sendTransaction: (tx: Transaction, conn: Connection) => Promise<string>;
+  generate: (inputs: ProofInputs) => Promise<ProofResult>;
+  ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>;
+  derivePrivateKey: () => Promise<string>;
+  transferParams: TransferParams;
+}
+```
+
+Update `runStepProofGeneration` signature to accept `transferParams` instead of using `publicKey` for mint/recipient. Change the function signature (line 129) to:
+
+```typescript
+async function runStepProofGeneration(
+  dispatch: Dispatch<FlowAction>,
+  publicKey: PublicKey,
+  credential: { issued_at: number; wallet: number[]; leaf_index: number; jurisdiction: string; revoked: boolean },
+  paths: Awaited<ReturnType<typeof runStepMerklePaths>>,
+  ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>,
+  generate: (inputs: ProofInputs) => Promise<ProofResult>,
+  transferParams: TransferParams,
+) {
+```
+
+Replace lines 138-146 (the mint/recipient/amount setup) with:
+
+```typescript
+  dispatch({ type: "STEP_RUNNING", step: 3 });
+  const { membership, sanctions, roots, jurisdictionProof, zkPrivateKey } = paths;
+  const { PublicKey: SolPublicKey } = await import("@solana/web3.js");
+  const mintPubkey = new SolPublicKey(transferParams.mint);
+  const recipientPubkey = new SolPublicKey(transferParams.recipient);
+  const mintBytes = mintPubkey.toBytes();
+  const recipientBytes = recipientPubkey.toBytes();
+  const mintLo = toHex(mintBytes.slice(0, 16));
+  const mintHi = toHex(mintBytes.slice(16, 32));
+  const recipientLo = toHex(recipientBytes.slice(0, 16));
+  const recipientHi = toHex(recipientBytes.slice(16, 32));
+  const epoch = String(Math.floor(Date.now() / 1000 / 86400));
+  const amount = String(transferParams.amount);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const credentialExpiry = String(credential.issued_at + CREDENTIAL_VALIDITY_SECS);
+```
+
+- [ ] **Step 3: Update `runStepSubmit` to accept transfer params and auto-register issuer**
+
+Update `runStepSubmit` signature to include `transferParams` and `roots`:
+
+```typescript
+async function runStepSubmit(
+  dispatch: Dispatch<FlowAction>,
+  proofResult: ProofResult,
+  publicKey: PublicKey,
+  connection: Connection,
+  sendTransaction: (tx: Transaction, conn: Connection) => Promise<string>,
+  submitCtx: {
+    zkPrivateKey: string;
+    credentialExpiry: string;
+    jurisdictionProof: { path: string[]; path_indices: number[] };
+    roots: import("@/lib/api/schemas").Roots;
+  },
+  transferParams: TransferParams,
+): Promise<string | undefined> {
+```
+
+Replace the body (lines 200-244) with:
+
+```typescript
+  dispatch({ type: "STEP_RUNNING", step: 4 });
+
+  const start = performance.now();
+  const [{ uploadProofChunked, checkIssuerExists, buildRegisterIssuerIx }, { BN }, { PublicKey: SolPublicKey, Transaction }] = await Promise.all([
+    import("@zksettle/sdk"),
+    import("@coral-xyz/anchor"),
+    import("@solana/web3.js"),
+  ]);
+
+  const hexToBytes = (hex: string): Uint8Array => {
+    const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+    return new Uint8Array(clean.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []);
+  };
+
+  const issuerExists = await checkIssuerExists(publicKey, connection);
+  if (!issuerExists) {
+    const roots = submitCtx.roots;
+    const ix = await buildRegisterIssuerIx(
+      publicKey,
+      {
+        merkleRoot: hexToBytes(roots.membership_root),
+        sanctionsRoot: hexToBytes(roots.sanctions_root),
+        jurisdictionRoot: hexToBytes(roots.jurisdiction_root),
+      },
+      connection,
+    );
+    await sendTransaction(new Transaction().add(ix), connection);
+  }
+
+  const nullifierHex = proofResult.publicInputs[1] ?? "";
+  const nullifierBytes = hexToBytes(nullifierHex);
+
+  const mintPubkey = new SolPublicKey(transferParams.mint);
+  const recipientPubkey = new SolPublicKey(transferParams.recipient);
+
+  const result = await uploadProofChunked(
+    {
+      connection,
+      wallet: publicKey,
+      proof: proofResult.proof,
+      nullifierHash: nullifierBytes,
+      transferContext: {
+        mint: mintPubkey,
+        recipient: recipientPubkey,
+        amount: new BN(transferParams.amount),
+        epoch: Math.floor(Date.now() / 1000 / 86400),
+        privateKey: submitCtx.zkPrivateKey,
+        credentialExpiry: submitCtx.credentialExpiry,
+        jurisdictionPath: submitCtx.jurisdictionProof.path.map((h) =>
+          h.startsWith("0x") ? h : `0x${h}`,
+        ),
+        jurisdictionPathIndices: submitCtx.jurisdictionProof.path_indices,
+      },
+    },
+    (tx) => sendTransaction(tx, connection),
+  );
+
+  const signature = result.finalizeSignature;
+  dispatch({ type: "SET_TX", signature });
+  dispatch({
+    type: "STEP_SUCCESS",
+    step: 4,
+    data: { signature },
+    durationMs: performance.now() - start,
+  });
+  return signature;
+```
+
+- [ ] **Step 4: Update `runLiveFlow` to thread `transferParams`**
+
+Update the `runLiveFlow` function (starting at line 282) to destructure and pass `transferParams`:
+
+```typescript
+async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
+  const { dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey, transferParams } = ctx;
+```
+
+Update the `runStepProofGeneration` call (around line 299) to pass `transferParams`:
+
+```typescript
+  try { step3Result = await runStepProofGeneration(dispatch, publicKey, credential, paths, ensureApi, generate, transferParams); }
+```
+
+Update the `runStepSubmit` call (around line 304) to pass `transferParams` and include `roots` in the context:
+
+```typescript
+  try {
+    txSignature = await runStepSubmit(dispatch, step3Result.proofResult, publicKey, connection, sendTransaction, { ...step3Result, roots: paths.roots }, transferParams);
+  }
+```
+
+- [ ] **Step 5: Update the `useProveFlow` hook to accept and forward `TransferParams`**
+
+Update `runFlow` (around line 339) to accept `TransferParams`:
+
+```typescript
+  const runFlow = useCallback(
+    async (mode: "live" | "demo", params?: TransferParams) => {
+      dispatch({ type: "START_FLOW", mode });
+
+      dispatch({ type: "STEP_RUNNING", step: 0 });
+      if (!connected || !publicKey) {
+        dispatch({ type: "STEP_ERROR", step: 0, error: "Wallet not connected. Please connect your wallet first." });
+        return;
+      }
+      dispatch({ type: "STEP_SUCCESS", step: 0 });
+
+      if (mode === "demo") {
+        try { await runDemoFlow(dispatch, generate); }
+        catch (err) { stepError(dispatch, 3, err, "Proof generation failed"); }
+        return;
+      }
+
+      if (!walletHex || !params) {
+        dispatch({ type: "STEP_ERROR", step: 1, error: "Wallet not resolved." });
+        return;
+      }
+
+      await runLiveFlow({ dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey, transferParams: params });
+    },
+    [connected, publicKey, walletHex, connection, sendTransaction, generate, ensureApi, derivePrivateKey],
+  );
+
+  const startFlow = useCallback((params: TransferParams) => runFlow("live", params), [runFlow]);
+```
+
+- [ ] **Step 6: Verify frontend types compile**
+
+Run: `cd /home/mario/zksettle/frontend && pnpm typecheck`
+Expected: No errors (may have errors in prove-flow-panel.tsx since we changed the `startFlow` signature — that's fixed in Task 3).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/hooks/use-prove-flow.ts
+git commit -m "feat(frontend): thread transfer params through prove flow and auto-register issuer"
+```
+
+---
+
+### Task 3: Frontend — Add form inputs to IntroCard
+
+**Files:**
+- Modify: `frontend/src/components/dashboard/prove-flow-panel.tsx`
+
+- [ ] **Step 1: Add state and validation to `ProveFlowPanel`**
+
+Import `TransferParams` from the hook and add state management. In `ProveFlowPanel` (line 358), add state before the existing `hasStarted` variable:
+
+```typescript
+import { useProveFlow, type TransferParams } from "@/hooks/use-prove-flow";
+```
+
+Inside `ProveFlowPanel`, add state:
+
+```typescript
+  const [transferParams, setTransferParams] = useState<TransferParams>({
+    mint: "",
+    recipient: "",
+    amount: 1000,
+  });
+  const [formError, setFormError] = useState<string | null>(null);
+```
+
+Add a `PublicKey` import at the top of the file for validation:
+
+```typescript
+import { PublicKey as SolPublicKey } from "@solana/web3.js";
+```
+
+Add a validation + start handler inside `ProveFlowPanel`:
+
+```typescript
+  const handleStart = useCallback(() => {
+    if (!transferParams.mint.trim() || !transferParams.recipient.trim()) {
+      setFormError("Mint and recipient addresses are required.");
+      return;
+    }
+    try { new SolPublicKey(transferParams.mint); } catch {
+      setFormError("Invalid mint address.");
+      return;
+    }
+    try { new SolPublicKey(transferParams.recipient); } catch {
+      setFormError("Invalid recipient address.");
+      return;
+    }
+    if (transferParams.amount <= 0) {
+      setFormError("Amount must be greater than zero.");
+      return;
+    }
+    setFormError(null);
+    startFlow(transferParams);
+  }, [transferParams, startFlow]);
+```
+
+Update the IntroCard render to pass `handleStart`:
+
+```tsx
+<IntroCard
+  key="intro"
+  connected={connected}
+  canStart={canStart}
+  onStart={handleStart}
+  onDemo={startDemo}
+  transferParams={transferParams}
+  onTransferParamsChange={setTransferParams}
+  formError={formError}
+/>
+```
+
+- [ ] **Step 2: Update `IntroCard` props and add form fields**
+
+Update the `IntroCard` component props and body. Replace the entire `IntroCard` function (lines 159-221) with:
+
+```tsx
+function IntroCard({
+  connected,
+  canStart,
+  onStart,
+  onDemo,
+  transferParams,
+  onTransferParamsChange,
+  formError,
+}: Readonly<{
+  connected: boolean;
+  canStart: boolean;
+  onStart: () => void;
+  onDemo: () => void;
+  transferParams: TransferParams;
+  onTransferParamsChange: (params: TransferParams) => void;
+  formError: string | null;
+}>) {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -6, transition: { duration: 0.2 } }}
+      className="rounded-[var(--radius-6)] border border-forest/20 bg-surface p-6"
+    >
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="max-w-lg">
+            <div className="flex items-center gap-2">
+              <ShieldCheck className="size-5 text-forest" strokeWidth={1.5} aria-hidden="true" />
+              <h2 className="text-sm font-medium text-ink">
+                End-to-end compliance proof
+              </h2>
+            </div>
+            <p className="mt-2 text-xs leading-relaxed text-stone">
+              This page generates a zero-knowledge proof that your wallet holds a valid issuer
+              credential, is not on the sanctions list, and belongs to a permitted jurisdiction
+              — then submits it on-chain for verification. The entire flow runs in your browser.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Badge variant="default">Noir circuit</Badge>
+              <Badge variant="default">Barretenberg WASM</Badge>
+              <Badge variant="default">Solana devnet</Badge>
+            </div>
+          </div>
+
+          <div className="flex shrink-0 flex-col gap-2">
+            {!connected && (
+              <>
+                <ConnectWalletButton />
+                <p className="text-center text-[11px] text-muted">
+                  Connect a wallet to begin
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+
+        {connected && (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">Mint address</span>
+                <input
+                  type="text"
+                  placeholder="Token mint public key"
+                  value={transferParams.mint}
+                  onChange={(e) => onTransferParamsChange({ ...transferParams, mint: e.target.value })}
+                  className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">Recipient address</span>
+                <input
+                  type="text"
+                  placeholder="Destination wallet public key"
+                  value={transferParams.recipient}
+                  onChange={(e) => onTransferParamsChange({ ...transferParams, recipient: e.target.value })}
+                  className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-1 sm:max-w-[calc(50%-0.375rem)]">
+              <span className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">Amount</span>
+              <input
+                type="number"
+                min={1}
+                value={transferParams.amount}
+                onChange={(e) => onTransferParamsChange({ ...transferParams, amount: Number(e.target.value) || 0 })}
+                className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+              />
+            </label>
+
+            {formError && (
+              <p className="text-xs text-red-500">{formError}</p>
+            )}
+
+            <div className="flex items-center gap-3">
+              <Button onClick={onStart} disabled={!canStart}>
+                <Flash className="size-4" strokeWidth={1.5} aria-hidden="true" />
+                Start proof flow
+              </Button>
+              <Button variant="ghost" size="sm" onClick={onDemo}>
+                <Sparks className="size-4" strokeWidth={1.5} aria-hidden="true" />
+                Run demo
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+    </motion.section>
+  );
+}
+```
+
+- [ ] **Step 3: Add necessary imports**
+
+Add `useState` and `useCallback` to the React import at the top (line 3):
+
+```typescript
+import { useEffect, useRef, useState, useCallback, type ReactNode } from "react";
+```
+
+Add `PublicKey` import (if not already added in Step 1):
+
+```typescript
+import { PublicKey as SolPublicKey } from "@solana/web3.js";
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd /home/mario/zksettle/frontend && pnpm typecheck`
+Expected: No type errors.
+
+- [ ] **Step 5: Visually test in browser**
+
+1. Open `http://localhost:3001/dashboard/prove`
+2. Verify the IntroCard shows mint, recipient, and amount fields when wallet is connected
+3. Verify clicking "Start proof flow" with empty fields shows a validation error
+4. Verify clicking "Run demo" still works without filling in the fields
+5. Verify entering invalid base58 strings shows "Invalid mint/recipient address"
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/dashboard/prove-flow-panel.tsx
+git commit -m "feat(frontend): add mint, recipient, and amount inputs to prove flow IntroCard"
+```

--- a/docs/superpowers/specs/2026-05-09-prove-flow-issuer-and-transfer-context-design.md
+++ b/docs/superpowers/specs/2026-05-09-prove-flow-issuer-and-transfer-context-design.md
@@ -1,0 +1,68 @@
+# Prove Flow: Issuer Registration & Transfer Context Inputs
+
+## Problem
+
+The prove flow fails with `WalletSendTransactionError` at `uploadProofChunked` because:
+
+1. **Missing Issuer PDA** — `initHookPayload` requires an `Issuer` account seeded by the signer's pubkey. If the wallet isn't registered as an issuer, the transaction fails with an account-not-found constraint violation.
+2. **Placeholder transfer context** — `mint` and `recipient` in both proof generation and `transferContext` are hardcoded to the connected wallet's `publicKey`. The mint should be a real stablecoin mint address and the recipient should be the actual transfer destination.
+
+## Design
+
+### 1. SDK: Browser-compatible issuer utilities
+
+Add to `sdk/src/wrap/index.ts`:
+
+**`buildRegisterIssuerIx(wallet, roots, connection, programId?, program?)`**
+- Builds a `registerIssuer` instruction using `loadAnchorBrowser` (no Node deps).
+- Takes `IssuerRoots` (merkle, sanctions, jurisdiction as `Uint8Array[32]`).
+- Returns `TransactionInstruction`.
+
+**`checkIssuerExists(wallet, connection, programId?)`**
+- Derives the issuer PDA via `findIssuerPda`.
+- Calls `connection.getAccountInfo(issuerPda)`.
+- Returns `boolean`.
+
+Both exported from `sdk/src/index.ts`.
+
+### 2. Frontend: Auto-register issuer before proof upload
+
+In `use-prove-flow.ts`, inside `runStepSubmit`, before `uploadProofChunked`:
+
+1. Import `checkIssuerExists` and `buildRegisterIssuerIx` from `@zksettle/sdk`.
+2. Call `checkIssuerExists(publicKey, connection)`.
+3. If `false`, parse the hex roots from `submitCtx.roots` into `Uint8Array[32]`, build and send a `registerIssuer` transaction via `signAndSend`.
+4. Proceed with `uploadProofChunked`.
+
+The roots are already available from step 2 (`runStepMerklePaths` returns `roots`). They need to be threaded through to `runStepSubmit` via `submitCtx`.
+
+### 3. Frontend: Transfer context form inputs
+
+**IntroCard** gets a mini-form with three fields:
+- **Recipient** — Solana address input (required, validated as base58 pubkey)
+- **Mint** — Solana address input (required, validated as base58 pubkey)
+- **Amount** — number input (required, default `1000`)
+
+**Data flow:**
+- `ProveFlowPanel` holds `transferParams` state: `{ recipient: string; mint: string; amount: number }`.
+- `useProveFlow.runFlow` accepts `transferParams` as a parameter.
+- `LiveFlowContext` carries `transferParams` through the pipeline.
+- `runStepProofGeneration` uses `transferParams.mint` and `transferParams.recipient` (parsed as `PublicKey`) instead of `publicKey` for `mintBytes`/`recipientBytes`.
+- `runStepSubmit` uses the same values for `transferContext.mint` and `transferContext.recipient`, and `transferParams.amount` for `transferContext.amount`.
+
+**Validation:** On submit, validate that both addresses are valid base58 Solana public keys. Show inline error if invalid.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `sdk/src/wrap/index.ts` | Add `buildRegisterIssuerIx`, `checkIssuerExists` |
+| `sdk/src/index.ts` | Export new functions |
+| `frontend/src/hooks/use-prove-flow.ts` | Add issuer check + auto-register; accept `transferParams`; use them in proof gen and submit |
+| `frontend/src/components/dashboard/prove-flow-panel.tsx` | Add form inputs to IntroCard; pass `transferParams` to `runFlow` |
+
+## Out of scope
+
+- Persisting transfer params across sessions
+- Token account creation for recipient
+- Querying available mints from chain

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@aztec/bb.js": "3.0.0-nightly.20260102",
+    "@base-ui/react": "^1.4.1",
     "@coral-xyz/anchor": "^0.31.1",
     "@gsap/react": "^2.1.2",
     "@noir-lang/noir_js": "1.0.0-beta.18",
@@ -39,14 +40,17 @@
     "gsap": "^3.15.0",
     "iconoir-react": "^7.11.0",
     "lenis": "^1.3.23",
+    "lucide-react": "^1.14.0",
     "motion": "^12.38.0",
     "next": "15.5.15",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "shadcn": "^4.7.0",
     "shiki": "^4.0.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "three": "^0.184.0",
+    "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,6 +1,10 @@
 @import "lenis/dist/lenis.css" layer(lenis);
 @import "@solana/wallet-adapter-react-ui/styles.css" layer(wallet-adapter);
 @import "tailwindcss";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+
+@custom-variant dark (&:is(.dark *));
 
 @theme {
   --color-canvas: #fafaf7;
@@ -395,4 +399,50 @@ em {
 
 .wallet-adapter-modal-collapse-button svg {
   fill: var(--color-stone) !important;
+}
+
+@theme inline {
+  --font-heading: var(--font-sans);
+  --color-ring: var(--ring);
+  --color-input: var(--input);
+  --color-destructive: var(--destructive);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-accent: var(--accent);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-primary: var(--primary);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-popover: var(--popover);
+  --color-card-foreground: var(--card-foreground);
+  --color-card: var(--card);
+  --color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+}
+
+:root {
+  --background: #fafaf7;
+  --foreground: #1a1917;
+  --card: #f5f3ee;
+  --card-foreground: #1a1917;
+  --popover: #fafaf7;
+  --popover-foreground: #1a1917;
+  --primary: #0c3d2e;
+  --primary-foreground: #fafaf7;
+  --secondary: #f5f3ee;
+  --secondary-foreground: #1a1917;
+  --muted-foreground: #6b6762;
+  --accent: #e8f2ee;
+  --accent-foreground: #0c3d2e;
+  --destructive: #bc2a24;
+  --border: #e8e5df;
+  --input: #e8e5df;
+  --ring: #0c3d2e;
+  --radius: 6px;
 }

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -9,6 +9,7 @@ import { SolflareWalletAdapter } from "@solana/wallet-adapter-solflare";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "sonner";
 
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/contexts/auth-context";
 import { createQueryClient } from "@/lib/api/query-client";
 import { SOLANA_NETWORK, SOLANA_RPC_URL } from "@/lib/config";
@@ -35,7 +36,9 @@ export function Providers({ children }: Readonly<{ children: React.ReactNode }>)
         <WalletModalProvider>
           <QueryClientProvider client={queryClient}>
             <AuthProvider>
+              <TooltipProvider>
               {children}
+              </TooltipProvider>
               <Toaster
                 position="bottom-right"
                 toastOptions={{

--- a/frontend/src/components/dashboard/api-keys-panel.tsx
+++ b/frontend/src/components/dashboard/api-keys-panel.tsx
@@ -248,7 +248,7 @@ export function ApiKeysPanel() {
           recognise it later.
         </p>
 
-        {isLoading ? (
+        {isLoading && (
           <div className="mt-4">
             <Table>
               <TableHeader>
@@ -263,14 +263,18 @@ export function ApiKeysPanel() {
               <TableSkeleton columns={5} rows={3} />
             </Table>
           </div>
-        ) : !isError && keys.length === 0 ? (
+        )}
+
+        {!isLoading && !isError && keys.length === 0 && (
           <EmptyState
             icon={Key}
             title="No keys yet"
             description="Create one above to get started."
             className="mt-4"
           />
-        ) : keys.length > 0 ? (
+        )}
+
+        {!isLoading && keys.length > 0 && (
           <div className="mt-4">
             <Table>
               <TableHeader>
@@ -324,7 +328,7 @@ export function ApiKeysPanel() {
               </TableBody>
             </Table>
           </div>
-        ) : null}
+        )}
       </section>
 
       <Dialog

--- a/frontend/src/components/dashboard/api-keys-panel.tsx
+++ b/frontend/src/components/dashboard/api-keys-panel.tsx
@@ -1,11 +1,32 @@
 "use client";
 
-import { Copy, Trash, WarningTriangle } from "iconoir-react";
-import { useEffect, useRef, useState, type SyntheticEvent } from "react";
+import { Copy, Key, Trash, WarningTriangle } from "iconoir-react";
+import { useEffect, useState, type SyntheticEvent } from "react";
 import { toast } from "sonner";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { EmptyState } from "@/components/dashboard/empty-state";
+import { TableSkeleton } from "@/components/dashboard/table-skeleton";
+import { TruncatedHash } from "@/components/dashboard/truncated-hash";
 import {
   lookupKeyPrefix,
   useApiKeys,
@@ -114,8 +135,6 @@ export function ApiKeysPanel() {
     const created = revealed;
     setRevealed(null);
     if (!created) return;
-    // Activate the new key as the cookie *after* the user dismisses the
-    // reveal — avoids a re-render cascade clobbering the dialog mid-display.
     try {
       await setActiveApiKey(created.api_key);
     } catch {
@@ -171,7 +190,7 @@ export function ApiKeysPanel() {
             Create new key
           </span>
           <p className="text-sm text-stone">
-            Provisions a <span className="font-mono text-ink">zks_…</span> key on the
+            Provisions a <span className="font-mono text-ink">zks_...</span> key on the
             gateway. Default tier:{" "}
             <span className="font-mono text-ink">developer</span> · 1,000 proofs/mo.
           </p>
@@ -197,11 +216,12 @@ export function ApiKeysPanel() {
             size="md"
             disabled={!owner.trim() || createKey.isPending}
           >
-            {createKey.isPending ? "Creating…" : "Create key"}
+            {createKey.isPending ? "Creating..." : "Create key"}
           </Button>
         </form>
-
       </section>
+
+      <Separator />
 
       <section
         aria-labelledby="keys-list-heading"
@@ -216,7 +236,7 @@ export function ApiKeysPanel() {
           </span>
           <div className="flex items-center gap-3 font-mono text-xs text-muted">
             <span>
-              {isLoading ? "loading…" : `${keys.length} active`}
+              {isLoading ? "loading..." : `${keys.length} active`}
             </span>
             <Button variant="ghost" size="sm" onClick={() => refetch()}>
               Refresh
@@ -228,218 +248,166 @@ export function ApiKeysPanel() {
           recognise it later.
         </p>
 
-        {!isError && keys.length === 0 && !isLoading ? (
-          <p className="mt-6 font-mono text-xs text-muted">
-            No keys yet. Create one above to get started.
-          </p>
-        ) : null}
-
-        {keys.length > 0 ? (
-          <table className="mt-4 w-full border-collapse text-left text-sm">
-            <thead>
-              <tr className="border-b border-border-subtle text-[11px] font-medium tracking-[0.08em] text-muted uppercase">
-                <th className="py-2 pr-3 font-medium">Prefix</th>
-                <th className="py-2 pr-3 font-medium">Owner</th>
-                <th className="py-2 pr-3 font-medium">Tier</th>
-                <th className="py-2 pr-3 font-medium">Created</th>
-                <th className="py-2 font-medium"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {keys.map((key) => {
-                const prefix = displayPrefix(key.key_hash);
-                const isActive =
-                  activePrefix !== null && lookupKeyPrefix(key.key_hash) === activePrefix;
-                return (
-                  <tr
-                    key={key.key_hash}
-                    className="border-b border-border-subtle text-quill last:border-b-0"
-                  >
-                    <td className="py-3 pr-3 font-mono text-ink">
-                      {prefix}
-                      {isActive ? (
-                        <span className="ml-2 rounded-full border border-emerald/40 bg-emerald/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-emerald">
-                          active
-                        </span>
-                      ) : null}
-                    </td>
-                    <td className="py-3 pr-3">{key.owner}</td>
-                    <td className="py-3 pr-3 font-mono text-stone">{TIER_LABEL[key.tier]}</td>
-                    <td className="py-3 pr-3 font-mono text-xs text-stone">
-                      {formatDate(key.created_at)}
-                    </td>
-                    <td className="py-3 text-right">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        aria-label={`Revoke key ${prefix}`}
-                        disabled={
-                          deleteKey.isPending && deleteKey.variables === key.key_hash
-                        }
-                        onClick={() => requestRevoke(key)}
-                      >
-                        <Trash aria-hidden="true" className="size-4" />
-                        {deleteKey.isPending && deleteKey.variables === key.key_hash
-                          ? "Revoking…"
-                          : "Revoke"}
-                      </Button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+        {isLoading ? (
+          <div className="mt-4">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Prefix</TableHead>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Owner</TableHead>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Tier</TableHead>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Created</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableSkeleton columns={5} rows={3} />
+            </Table>
+          </div>
+        ) : !isError && keys.length === 0 ? (
+          <EmptyState
+            icon={Key}
+            title="No keys yet"
+            description="Create one above to get started."
+            className="mt-4"
+          />
+        ) : keys.length > 0 ? (
+          <div className="mt-4">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Prefix</TableHead>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Owner</TableHead>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Tier</TableHead>
+                  <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Created</TableHead>
+                  <TableHead />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {keys.map((key) => {
+                  const prefix = displayPrefix(key.key_hash);
+                  const isActive =
+                    activePrefix !== null && lookupKeyPrefix(key.key_hash) === activePrefix;
+                  return (
+                    <TableRow key={key.key_hash} className="text-quill">
+                      <TableCell className="font-mono text-ink">
+                        <div className="flex items-center gap-2">
+                          <TruncatedHash value={key.key_hash} head={8} tail={4} />
+                          {isActive && (
+                            <Badge variant="success">active</Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>{key.owner}</TableCell>
+                      <TableCell className="font-mono text-stone">{TIER_LABEL[key.tier]}</TableCell>
+                      <TableCell className="font-mono text-xs text-stone">
+                        {formatDate(key.created_at)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={`Revoke key ${prefix}`}
+                          disabled={
+                            deleteKey.isPending && deleteKey.variables === key.key_hash
+                          }
+                          onClick={() => requestRevoke(key)}
+                        >
+                          <Trash aria-hidden="true" className="size-4" />
+                          {deleteKey.isPending && deleteKey.variables === key.key_hash
+                            ? "Revoking..."
+                            : "Revoke"}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
         ) : null}
       </section>
 
-      {revealed ? (
-        <RevealKeyDialog
-          created={revealed}
-          copied={copied}
-          onCopy={copyKey}
-          onDismiss={dismissReveal}
-        />
-      ) : null}
+      <Dialog
+        open={revealed !== null}
+        onOpenChange={(open) => {
+          if (!open) void dismissReveal();
+        }}
+      >
+        {revealed && (
+          <DialogContent showCloseButton={false} className="sm:max-w-lg">
+            <DialogHeader>
+              <div className="flex items-start gap-3">
+                <WarningTriangle aria-hidden="true" className="mt-0.5 size-5 shrink-0 text-rust" />
+                <div className="flex flex-col gap-1">
+                  <DialogTitle className="font-display text-xl text-ink">
+                    Copy this key now
+                  </DialogTitle>
+                  <DialogDescription className="text-sm text-stone">
+                    We won&apos;t show it again. Store it in your secret manager before closing
+                    this dialog. After you close this dialog, it will be set as your
+                    active key (stored as an HttpOnly cookie, never visible to JS).
+                  </DialogDescription>
+                </div>
+              </div>
+            </DialogHeader>
 
-      {pendingRevoke ? (
-        <RevokeConfirmDialog
-          target={pendingRevoke}
-          onCancel={() => setPendingRevoke(null)}
-          onConfirm={confirmRevoke}
-        />
-      ) : null}
+            <Separator />
+
+            <div className="flex flex-col gap-2">
+              <span className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">
+                Owner: {revealed.owner} · Tier: {TIER_LABEL[revealed.tier]}
+              </span>
+              <div className="flex items-center gap-2 rounded-[var(--radius-3)] border border-border-subtle bg-canvas p-3">
+                <code className="flex-1 break-all font-mono text-sm text-ink">
+                  {revealed.api_key}
+                </code>
+                <Button variant="ghost" size="sm" onClick={copyKey} aria-label="Copy API key">
+                  <Copy aria-hidden="true" className="size-4" />
+                  {copied ? "Copied" : "Copy"}
+                </Button>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="primary" size="md" onClick={() => void dismissReveal()}>
+                I saved it
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
+
+      <Dialog
+        open={pendingRevoke !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRevoke(null);
+        }}
+      >
+        {pendingRevoke && (
+          <DialogContent showCloseButton={false} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle className="font-display text-xl text-ink">
+                Revoke API key?
+              </DialogTitle>
+              <DialogDescription className="text-sm text-stone">
+                This will permanently revoke{" "}
+                <span className="font-mono text-ink">{displayPrefix(pendingRevoke.key_hash)}</span>{" "}
+                owned by <span className="font-mono text-ink">{pendingRevoke.owner}</span>. This
+                cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+
+            <DialogFooter>
+              <Button variant="ghost" size="md" onClick={() => setPendingRevoke(null)}>
+                Cancel
+              </Button>
+              <Button variant="primary" size="md" onClick={confirmRevoke}>
+                Revoke key
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        )}
+      </Dialog>
     </div>
-  );
-}
-
-interface RevealKeyDialogProps {
-  created: CreatedKey;
-  copied: boolean;
-  onCopy: () => void;
-  onDismiss: () => void;
-}
-
-function RevealKeyDialog({ created, copied, onCopy, onDismiss }: Readonly<RevealKeyDialogProps>) {
-  const ref = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = ref.current;
-    if (!dialog) return;
-    if (!dialog.open) dialog.showModal();
-    return () => {
-      if (dialog.open) dialog.close();
-    };
-  }, []);
-
-  return (
-    <dialog
-      ref={ref}
-      aria-labelledby="reveal-key-heading"
-      onCancel={(event) => {
-        // Esc was pressed. preventDefault stops the browser's native close so
-        // we can dismiss through React state — otherwise the close event would
-        // race with our unmount-driven cleanup.
-        event.preventDefault();
-        onDismiss();
-      }}
-      // No onClose handler: the DOM "close" event also fires from the cleanup
-      // function below (which runs in dev under React Strict Mode's
-      // mount→cleanup→mount cycle). Wiring onClose to onDismiss would set
-      // revealed=null mid-mount and the user would never see the dialog.
-      className="m-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-lg backdrop:bg-ink/40"
-    >
-      <div className="w-full max-w-lg">
-        <div className="flex items-start gap-3">
-          <WarningTriangle aria-hidden="true" className="mt-1 size-5 shrink-0 text-rust" />
-          <div className="flex flex-col gap-1">
-            <h2
-              id="reveal-key-heading"
-              className="font-display text-xl text-ink"
-            >
-              Copy this key now
-            </h2>
-            <p className="text-sm text-stone">
-              We won&apos;t show it again. Store it in your secret manager before closing
-              this dialog. After you close this dialog, it will be set as your
-              active key (stored as an HttpOnly cookie, never visible to JS).
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-5 flex flex-col gap-2">
-          <span className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">
-            Owner: {created.owner} · Tier: {TIER_LABEL[created.tier]}
-          </span>
-          <div className="flex items-center gap-2 rounded-[var(--radius-3)] border border-border-subtle bg-canvas p-3">
-            <code className="flex-1 break-all font-mono text-sm text-ink">
-              {created.api_key}
-            </code>
-            <Button variant="ghost" size="sm" onClick={onCopy} aria-label="Copy API key">
-              <Copy aria-hidden="true" className="size-4" />
-              {copied ? "Copied" : "Copy"}
-            </Button>
-          </div>
-        </div>
-
-        <div className="mt-6 flex justify-end gap-2">
-          <Button variant="primary" size="md" onClick={onDismiss}>
-            I saved it
-          </Button>
-        </div>
-      </div>
-    </dialog>
-  );
-}
-
-interface RevokeConfirmDialogProps {
-  target: ListedKey;
-  onCancel: () => void;
-  onConfirm: () => void;
-}
-
-function RevokeConfirmDialog({ target, onCancel, onConfirm }: Readonly<RevokeConfirmDialogProps>) {
-  const ref = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = ref.current;
-    if (!dialog) return;
-    if (!dialog.open) dialog.showModal();
-    return () => {
-      if (dialog.open) dialog.close();
-    };
-  }, []);
-
-  return (
-    <dialog
-      ref={ref}
-      aria-labelledby="revoke-key-heading"
-      onCancel={(event) => {
-        event.preventDefault();
-        onCancel();
-      }}
-      // See note in RevealKeyDialog: no onClose handler to avoid React Strict
-      // Mode's cleanup-triggered close event clobbering the dialog mid-mount.
-      className="m-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6 shadow-lg backdrop:bg-ink/40"
-    >
-      <div className="w-full max-w-md">
-        <h2 id="revoke-key-heading" className="font-display text-xl text-ink">
-          Revoke API key?
-        </h2>
-        <p className="mt-2 text-sm text-stone">
-          This will permanently revoke{" "}
-          <span className="font-mono text-ink">{displayPrefix(target.key_hash)}</span>{" "}
-          owned by <span className="font-mono text-ink">{target.owner}</span>. This
-          cannot be undone.
-        </p>
-        <div className="mt-6 flex justify-end gap-2">
-          <Button variant="ghost" size="md" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button variant="primary" size="md" onClick={onConfirm}>
-            Revoke key
-          </Button>
-        </div>
-      </div>
-    </dialog>
   );
 }

--- a/frontend/src/components/dashboard/attestation-explorer-panel.tsx
+++ b/frontend/src/components/dashboard/attestation-explorer-panel.tsx
@@ -177,15 +177,50 @@ export function AttestationExplorerPanel() {
         />
       ) : null}
 
-      {/* Loading skeletons */}
-      {activeWallet && status === "loading" ? (
-        <>
-          <ProofCardSkeleton title="Membership proof" />
-          <ProofCardSkeleton title="Sanctions proof" />
-        </>
-      ) : null}
+      <ProofResultsSection
+        activeWallet={activeWallet}
+        status={status}
+        membershipQuery={membershipQuery}
+        sanctionsQuery={sanctionsQuery}
+      />
 
-      {/* Membership proof */}
+      <RecentWalletsSection
+        recent={recent}
+        onPick={pickRecent}
+        onForget={forgetWallet}
+      />
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+function ProofResultsSection({
+  activeWallet,
+  status,
+  membershipQuery,
+  sanctionsQuery,
+}: Readonly<{
+  activeWallet: string | null;
+  status: ComplianceStatus | null;
+  membershipQuery: ReturnType<typeof useMembershipProof>;
+  sanctionsQuery: ReturnType<typeof useSanctionsProof>;
+}>) {
+  if (!activeWallet) return null;
+
+  if (status === "loading") {
+    return (
+      <>
+        <ProofCardSkeleton title="Membership proof" />
+        <ProofCardSkeleton title="Sanctions proof" />
+      </>
+    );
+  }
+
+  return (
+    <>
       {membershipQuery.data ? (
         <ProofCard
           id="membership"
@@ -201,11 +236,10 @@ export function AttestationExplorerPanel() {
         />
       ) : null}
 
-      {activeWallet && membershipQuery.data && sanctionsQuery.data ? (
+      {membershipQuery.data && sanctionsQuery.data ? (
         <Separator className="bg-border-subtle" />
       ) : null}
 
-      {/* Sanctions proof */}
       {sanctionsQuery.data ? (
         <ProofCard
           id="sanctions"
@@ -226,19 +260,9 @@ export function AttestationExplorerPanel() {
           }
         />
       ) : null}
-
-      <RecentWalletsSection
-        recent={recent}
-        onPick={pickRecent}
-        onForget={forgetWallet}
-      />
-    </div>
+    </>
   );
 }
-
-/* ------------------------------------------------------------------ */
-/*  Sub-components                                                     */
-/* ------------------------------------------------------------------ */
 
 function ProofCardSkeleton({ title }: Readonly<{ title: string }>) {
   return (

--- a/frontend/src/components/dashboard/attestation-explorer-panel.tsx
+++ b/frontend/src/components/dashboard/attestation-explorer-panel.tsx
@@ -4,9 +4,22 @@ import { Copy, NavArrowDown, Search, Xmark } from "iconoir-react";
 import { useEffect, useState, type ReactNode, type SyntheticEvent } from "react";
 import { toast } from "sonner";
 
+import { EmptyState } from "@/components/dashboard/empty-state";
 import { StatusPill, type StatusKind } from "@/components/dashboard/status-pill";
+import { TruncatedHash } from "@/components/dashboard/truncated-hash";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { useMembershipProof } from "@/hooks/use-membership-proof";
 import {
   useForgetWallet,
@@ -17,7 +30,6 @@ import { useRoots } from "@/hooks/use-roots";
 import { useSanctionsProof } from "@/hooks/use-sanctions-proof";
 import { ApiError } from "@/lib/api/client";
 import { cn } from "@/lib/cn";
-import { truncateWallet } from "@/lib/format";
 import { isValidWalletHex, normalizeWalletHex } from "@/lib/wallet";
 
 const EMPTY_LEAF = "0".repeat(64);
@@ -70,6 +82,7 @@ function describeProofError(err: unknown): { kind: "not-found" | "auth" | "other
 async function copyToClipboard(text: string) {
   try {
     await navigator.clipboard.writeText(text);
+    toast.success("Copied to clipboard");
   } catch {
     // silent fail
   }
@@ -107,44 +120,42 @@ export function AttestationExplorerPanel() {
   return (
     <div className="flex flex-col gap-6">
       {/* Wallet search */}
-      <section
-        aria-labelledby="search-heading"
-        className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-      >
-        <span
-          id="search-heading"
-          className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-        >
-          Search wallet attestation
-        </span>
-        <p className="mt-1 text-sm text-stone">
-          Paste a 32-byte wallet pubkey as 64 hex chars (with or without{" "}
-          <span className="font-mono">0x</span>).
-        </p>
-
-        <form onSubmit={lookup} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
-          <Input
-            value={walletInput}
-            onChange={(e) => setWalletInput(e.target.value)}
-            placeholder="0x… (64 hex chars)"
-            spellCheck={false}
-            autoComplete="off"
-            aria-invalid={walletInput.length > 0 && !inputValid}
-            aria-describedby="wallet-help"
-            className="font-mono"
-          />
-          <Button type="submit" variant="primary" size="md" disabled={!inputValid}>
-            <Search aria-hidden="true" className="size-4" />
-            Search
-          </Button>
-        </form>
-
-        {walletInput.length > 0 && !inputValid ? (
-          <p id="wallet-help" className="mt-2 font-mono text-xs text-rust">
-            Wallet must be 64 hex characters.
+      <Card className="border-border-subtle bg-surface">
+        <CardHeader>
+          <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+            Search wallet attestation
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-stone">
+            Paste a 32-byte wallet pubkey as 64 hex chars (with or without{" "}
+            <span className="font-mono">0x</span>).
           </p>
-        ) : null}
-      </section>
+
+          <form onSubmit={lookup} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Input
+              value={walletInput}
+              onChange={(e) => setWalletInput(e.target.value)}
+              placeholder="0x... (64 hex chars)"
+              spellCheck={false}
+              autoComplete="off"
+              aria-invalid={walletInput.length > 0 && !inputValid}
+              aria-describedby="wallet-help"
+              className="font-mono"
+            />
+            <Button type="submit" variant="primary" size="md" disabled={!inputValid}>
+              <Search aria-hidden="true" className="size-4" />
+              Search
+            </Button>
+          </form>
+
+          {walletInput.length > 0 && !inputValid ? (
+            <p id="wallet-help" className="mt-2 font-mono text-xs text-rust">
+              Wallet must be 64 hex characters.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
 
       {/* Compliance status */}
       {activeWallet && status ? (
@@ -166,17 +177,32 @@ export function AttestationExplorerPanel() {
         />
       ) : null}
 
+      {/* Loading skeletons */}
+      {activeWallet && status === "loading" ? (
+        <>
+          <ProofCardSkeleton title="Membership proof" />
+          <ProofCardSkeleton title="Sanctions proof" />
+        </>
+      ) : null}
+
       {/* Membership proof */}
       {membershipQuery.data ? (
         <ProofCard
           id="membership"
           title="Membership proof"
+          description="Merkle inclusion proof for wallet membership in the compliance set"
           proof={membershipQuery.data}
           extraFields={
-            <><dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Leaf index</dt>
-            <dd className="font-mono text-sm text-ink">{membershipQuery.data.leaf_index}</dd></>
+            <>
+              <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Leaf index</dt>
+              <dd className="font-mono text-sm text-ink">{membershipQuery.data.leaf_index}</dd>
+            </>
           }
         />
+      ) : null}
+
+      {activeWallet && membershipQuery.data && sanctionsQuery.data ? (
+        <Separator className="bg-border-subtle" />
       ) : null}
 
       {/* Sanctions proof */}
@@ -184,16 +210,19 @@ export function AttestationExplorerPanel() {
         <ProofCard
           id="sanctions"
           title="Sanctions proof"
+          description="Merkle inclusion proof for sanctions screening status"
           proof={sanctionsQuery.data}
           extraFields={
-            <><dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Leaf value</dt>
-            <dd className="flex items-center gap-2 font-mono text-sm text-ink">
-              {sanctionsQuery.data.leaf_value === EMPTY_LEAF ? (
-                <StatusPill kind="verified" label="Empty (not sanctioned)" />
-              ) : (
-                <StatusPill kind="blocked" label="Present (sanctioned)" />
-              )}
-            </dd></>
+            <>
+              <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Leaf value</dt>
+              <dd className="flex items-center gap-2 font-mono text-sm text-ink">
+                {sanctionsQuery.data.leaf_value === EMPTY_LEAF ? (
+                  <StatusPill kind="verified" label="Empty (not sanctioned)" />
+                ) : (
+                  <StatusPill kind="blocked" label="Present (sanctioned)" />
+                )}
+              </dd>
+            </>
           }
         />
       ) : null}
@@ -210,6 +239,35 @@ export function AttestationExplorerPanel() {
 /* ------------------------------------------------------------------ */
 /*  Sub-components                                                     */
 /* ------------------------------------------------------------------ */
+
+function ProofCardSkeleton({ title }: Readonly<{ title: string }>) {
+  return (
+    <Card className="border-border-subtle bg-surface">
+      <CardHeader>
+        <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-y-3 sm:grid-cols-[140px_1fr]">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-4 w-64" />
+
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-4 w-32" />
+
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="h-4 w-48" />
+
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-4 w-12" />
+        </div>
+        <Separator className="my-5 bg-border-subtle" />
+        <Skeleton className="h-4 w-48" />
+      </CardContent>
+    </Card>
+  );
+}
 
 function AttestationStatusSection({
   wallet,
@@ -249,108 +307,135 @@ function AttestationStatusSection({
   }, [membershipRootMatch, sanctionsRootMatch]);
 
   return (
-    <section
-      aria-labelledby="status-heading"
-      className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <span
-            id="status-heading"
-            className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-          >
-            Compliance status
-          </span>
-          <p className="mt-1 font-mono text-sm text-ink break-all">{wallet}</p>
+    <Card className="border-border-subtle bg-surface">
+      <CardHeader>
+        <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+          Compliance status
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <TruncatedHash
+            value={wallet}
+            head={12}
+            tail={12}
+            className="text-sm text-ink"
+          />
+          <StatusPill kind={pill.kind} label={pill.label} />
         </div>
-        <StatusPill kind={pill.kind} label={pill.label} />
-      </div>
 
-      {status === "loading" ? (
-        <p className="mt-4 font-mono text-xs text-stone">Loading proofs…</p>
-      ) : null}
-    </section>
+        {status === "loading" ? (
+          <div className="mt-4 flex items-center gap-3">
+            <Skeleton className="h-3 w-3 rounded-full" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 }
 
 function ProofCard({
   id,
   title,
+  description,
   proof,
   extraFields,
 }: Readonly<{
   id: string;
   title: string;
+  description?: string;
   proof: { wallet: string; path: string[]; path_indices: number[]; root: string };
   extraFields?: ReactNode;
 }>) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <section
-      aria-labelledby={`${id}-heading`}
-      className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-    >
-      <span
-        id={`${id}-heading`}
-        className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-      >
-        {title}
-      </span>
+    <Card className="border-border-subtle bg-surface">
+      <CardHeader>
+        <CardTitle
+          id={`${id}-heading`}
+          className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
+        >
+          {title}
+        </CardTitle>
+        {description ? (
+          <p className="text-xs text-stone">{description}</p>
+        ) : null}
+      </CardHeader>
 
-      <dl className="mt-4 grid gap-y-3 sm:grid-cols-[140px_1fr]">
-        <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Wallet</dt>
-        <dd className="font-mono text-sm text-ink break-all">{proof.wallet}</dd>
+      <CardContent>
+        <dl className="grid gap-y-3 sm:grid-cols-[140px_1fr]">
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Wallet</dt>
+          <dd>
+            <TruncatedHash
+              value={proof.wallet}
+              head={10}
+              tail={10}
+              className="text-sm text-ink"
+            />
+          </dd>
 
-        {extraFields}
+          {extraFields}
 
-        <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Root</dt>
-        <dd className="flex items-center gap-2 font-mono text-sm text-ink break-all">
-          {truncateWallet(proof.root, 10, 10)}
-          <button
-            type="button"
-            onClick={() => copyToClipboard(proof.root)}
-            className="shrink-0 cursor-pointer text-muted hover:text-ink"
-            aria-label="Copy root"
-          >
-            <Copy className="size-3.5" />
-          </button>
-        </dd>
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Root</dt>
+          <dd>
+            <TruncatedHash
+              value={proof.root}
+              head={10}
+              tail={10}
+              className="text-sm text-ink"
+            />
+          </dd>
 
-        <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Tree depth</dt>
-        <dd className="font-mono text-sm text-ink">{proof.path.length}</dd>
-      </dl>
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Tree depth</dt>
+          <dd className="font-mono text-sm text-ink">{proof.path.length}</dd>
+        </dl>
 
-      <div className="mt-5 border-t border-border-subtle pt-4">
+        <Separator className="my-5 bg-border-subtle" />
+
         <button
           type="button"
           onClick={() => setExpanded(!expanded)}
-          className="flex cursor-pointer items-center gap-2 font-mono text-xs text-quill hover:text-ink"
+          className={cn(
+            "flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 font-mono text-xs text-quill transition-colors hover:bg-surface-deep hover:text-ink",
+            expanded && "text-ink",
+          )}
         >
           <NavArrowDown
-            className={cn("size-4 transition-transform", expanded && "rotate-180")}
+            className={cn(
+              "size-4 shrink-0 transition-transform duration-200",
+              expanded && "rotate-180",
+            )}
             aria-hidden="true"
           />
           {expanded ? "Hide" : "Show"} Merkle path ({proof.path.length} levels)
         </button>
 
-        {expanded ? (
-          <div className="mt-3">
-            <MerklePathTable path={proof.path} pathIndices={proof.path_indices} />
-            <div className="mt-3 flex justify-end">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => copyToClipboard(JSON.stringify(proof, null, 2))}
-              >
-                <Copy aria-hidden="true" className="size-3.5" />
-                Copy full proof
-              </Button>
+        <div
+          className={cn(
+            "grid transition-[grid-template-rows] duration-200 ease-in-out",
+            expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
+          )}
+        >
+          <div className="overflow-hidden">
+            <div className="pt-3">
+              <MerklePathTable path={proof.path} pathIndices={proof.path_indices} />
+              <div className="mt-3 flex justify-end">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => copyToClipboard(JSON.stringify(proof, null, 2))}
+                >
+                  <Copy aria-hidden="true" className="size-3.5" />
+                  Copy full proof
+                </Button>
+              </div>
             </div>
           </div>
-        ) : null}
-      </div>
-    </section>
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -364,59 +449,65 @@ function RecentWalletsSection({
   onForget: (wallet: string) => void;
 }>) {
   return (
-    <section
-      aria-labelledby="recent-heading"
-      className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-    >
-      <div className="flex items-baseline justify-between">
-        <span
-          id="recent-heading"
-          className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-        >
-          Recent lookups (this browser)
-        </span>
-        <span className="font-mono text-xs text-muted">{recent.length} stored</span>
-      </div>
+    <Card className="border-border-subtle bg-surface">
+      <CardHeader>
+        <div className="flex items-baseline justify-between">
+          <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+            Recent lookups (this browser)
+          </CardTitle>
+          <span className="font-mono text-xs text-muted">{recent.length} stored</span>
+        </div>
+      </CardHeader>
 
-      {recent.length === 0 ? (
-        <p className="mt-4 font-mono text-xs text-muted">
-          No lookups yet. The last 8 wallets you check will appear here.
-        </p>
-      ) : (
-        <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
-          {recent.map((entry) => (
-            <li
-              key={entry.wallet}
-              className="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0"
-            >
-              <button
-                type="button"
-                onClick={() => onPick(entry.wallet)}
-                className="flex flex-1 cursor-pointer items-center gap-3 text-left font-mono text-sm text-ink hover:text-forest focus-visible:rounded-[2px] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+      <CardContent>
+        {recent.length === 0 ? (
+          <EmptyState
+            icon={Search}
+            title="No lookups yet"
+            description="The last 8 wallets you check will appear here."
+          />
+        ) : (
+          <ul className="flex flex-col divide-y divide-border-subtle">
+            {recent.map((entry) => (
+              <li
+                key={entry.wallet}
+                className="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0"
               >
-                <span>{truncateWallet(entry.wallet, 8, 8)}</span>
-                <span className="font-mono text-[11px] text-muted">
-                  {new Date(entry.lastSeenAt).toLocaleString("en-US", {
-                    month: "short",
-                    day: "2-digit",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </span>
-              </button>
-              <Button
-                variant="ghost"
-                size="sm"
-                aria-label={`Forget ${entry.wallet}`}
-                onClick={() => onForget(entry.wallet)}
-              >
-                <Xmark aria-hidden="true" className="size-4" />
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
+                <button
+                  type="button"
+                  onClick={() => onPick(entry.wallet)}
+                  className="flex flex-1 cursor-pointer items-center gap-3 text-left font-mono text-sm text-ink hover:text-forest focus-visible:rounded-[2px] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+                >
+                  <TruncatedHash
+                    value={entry.wallet}
+                    head={8}
+                    tail={8}
+                    copyable={false}
+                    className="text-sm text-ink pointer-events-none"
+                  />
+                  <span className="font-mono text-[11px] text-muted">
+                    {new Date(entry.lastSeenAt).toLocaleString("en-US", {
+                      month: "short",
+                      day: "2-digit",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                  </span>
+                </button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Forget ${entry.wallet}`}
+                  onClick={() => onForget(entry.wallet)}
+                >
+                  <Xmark aria-hidden="true" className="size-4" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -428,38 +519,40 @@ function MerklePathTable({
   pathIndices: number[];
 }>) {
   return (
-    <div className="overflow-x-auto rounded-[var(--radius-3)] border border-border-subtle">
-      <table className="w-full border-collapse text-left">
-        <thead>
-          <tr className="border-b border-border-subtle">
-            <th className="px-3 py-2 font-mono text-[11px] font-medium tracking-[0.08em] text-muted uppercase">
+    <div className="rounded-md border border-border-subtle">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">
               Level
-            </th>
-            <th className="px-3 py-2 font-mono text-[11px] font-medium tracking-[0.08em] text-muted uppercase">
+            </TableHead>
+            <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">
               Direction
-            </th>
-            <th className="px-3 py-2 font-mono text-[11px] font-medium tracking-[0.08em] text-muted uppercase">
+            </TableHead>
+            <TableHead className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">
               Sibling hash
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {path.map((hash, i) => (
-            <tr
-              key={`${i}-${hash}`}
-              className="border-b border-border-subtle last:border-b-0"
-            >
-              <td className="px-3 py-2 font-mono text-xs text-quill">{i}</td>
-              <td className="px-3 py-2 font-mono text-xs text-quill">
+            <TableRow key={`${i}-${hash}`}>
+              <TableCell className="font-mono text-xs text-quill">{i}</TableCell>
+              <TableCell className="font-mono text-xs text-quill">
                 {pathIndices[i] === 0 ? "L" : "R"}
-              </td>
-              <td className="px-3 py-2 font-mono text-xs text-quill">
-                {truncateWallet(hash, 8, 8)}
-              </td>
-            </tr>
+              </TableCell>
+              <TableCell>
+                <TruncatedHash
+                  value={hash}
+                  head={8}
+                  tail={8}
+                  className="text-xs text-quill"
+                />
+              </TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/frontend/src/components/dashboard/audit-log-table.tsx
+++ b/frontend/src/components/dashboard/audit-log-table.tsx
@@ -1,25 +1,49 @@
 "use client";
 
-import { Refresh } from "iconoir-react";
+import { Download, Refresh, SearchEngine } from "iconoir-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { EmptyState } from "@/components/dashboard/empty-state";
 import { StatusPill } from "@/components/dashboard/status-pill";
+import { TableSkeleton } from "@/components/dashboard/table-skeleton";
+import { TruncatedHash } from "@/components/dashboard/truncated-hash";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { useEvents, type EventsFilters } from "@/hooks/use-events";
 import { ApiError } from "@/lib/api/client";
 import type { EventDto } from "@/lib/api/schemas";
 import { cn } from "@/lib/cn";
 import { exportToCsv, exportToJson } from "@/lib/export";
-import { fmtAmount, fmtCompact, truncateWallet } from "@/lib/format";
+import { fmtAmount, fmtCompact } from "@/lib/format";
 import { isValidWalletHex, normalizeWalletHex } from "@/lib/wallet";
 
 const ROWS_PER_PAGE = 20;
 
 const RANGES = [
   { value: "all", label: "All time", seconds: null },
-  { value: "24h", label: "Last 24h", seconds: 24 * 60 * 60 },
+  { value: "24h", label: "Last 24 h", seconds: 24 * 60 * 60 },
   { value: "7d", label: "Last 7 days", seconds: 7 * 24 * 60 * 60 },
   { value: "30d", label: "Last 30 days", seconds: 30 * 24 * 60 * 60 },
 ] as const;
@@ -37,31 +61,13 @@ function formatDateTime(unixSeconds: number): string {
   }).format(d);
 }
 
-function eventCountStatus(
-  isLoading: boolean,
-  isError: boolean,
-  count: number,
-): string {
-  if (isLoading) return "loading…";
-  if (isError) return "Unavailable";
-  return `${fmtCompact(count)} event${count === 1 ? "" : "s"} loaded`;
-}
-
-function pluralizeEvents(count: number): string {
-  return `Showing ${fmtCompact(count)} event${count === 1 ? "" : "s"}`;
-}
-
 function describeError(err: unknown): string {
   if (err instanceof ApiError) {
-    if (err.status === 401 || err.status === 403) {
+    if (err.status === 401 || err.status === 403)
       return "Not authorized. Select an active API key in the sidebar.";
-    }
-    if (err.status === 502) {
-      return "Indexer is unreachable from the gateway.";
-    }
-    if (err.status === 500) {
+    if (err.status === 502) return "Indexer is unreachable from the gateway.";
+    if (err.status === 500)
       return "Indexer URL not configured (or filter value invalid). Set GATEWAY_INDEXER_URL on the gateway and check filter inputs.";
-    }
     return err.message;
   }
   return err instanceof Error ? err.message : "Unknown error";
@@ -71,8 +77,6 @@ export function AuditLogTable() {
   const [range, setRange] = useState<RangeValue>("30d");
   const [issuerInput, setIssuerInput] = useState("");
   const [recipientInput, setRecipientInput] = useState("");
-  // Committed filter values (only update when blurred / Enter, so we don't
-  // refetch on every keystroke).
   const [issuer, setIssuer] = useState("");
   const [recipient, setRecipient] = useState("");
 
@@ -141,17 +145,30 @@ export function AuditLogTable() {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* Filters */}
       <div className="flex flex-col gap-3 border-b border-border-subtle pb-4">
         <div className="flex flex-wrap items-end gap-3">
-          <FilterSelect
-            label="Range"
-            value={range}
-            onChange={(v) => setRange(v as RangeValue)}
-            options={RANGES.map((r) => ({ value: r.value, label: r.label }))}
-          />
+          <div className="flex flex-col gap-1.5">
+            <span className="font-mono text-[10px] tracking-[0.08em] text-muted uppercase">
+              Range
+            </span>
+            <Select value={range} onValueChange={(v) => setRange(v as RangeValue)}>
+              <SelectTrigger className="w-[140px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RANGES.map((r) => (
+                  <SelectItem key={r.value} value={r.value}>
+                    {r.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
           <HexFilterInput
             label="Issuer"
-            placeholder="64 hex chars"
+            placeholder="64-char hex"
             value={issuerInput}
             invalid={issuerInvalid}
             onChange={setIssuerInput}
@@ -159,106 +176,136 @@ export function AuditLogTable() {
           />
           <HexFilterInput
             label="Recipient"
-            placeholder="64 hex chars"
+            placeholder="64-char hex"
             value={recipientInput}
             invalid={recipientInvalid}
             onChange={setRecipientInput}
             onCommit={commitFilters}
           />
-          <Button variant="ghost" size="sm" onClick={commitFilters}>
-            Apply
-          </Button>
-          <Button variant="ghost" size="sm" onClick={clearFilters}>
-            Clear
-          </Button>
-          <div className="ml-auto flex items-center gap-2">
-            <Button variant="ghost" size="sm" onClick={() => refetch()} disabled={isFetching}>
+
+          <div className="flex items-end gap-1.5">
+            <Button variant="ghost" size="sm" onClick={commitFilters}>
+              Apply
+            </Button>
+            <Button variant="ghost" size="sm" onClick={clearFilters}>
+              Clear
+            </Button>
+          </div>
+
+          <div className="ml-auto flex items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => refetch()}
+              disabled={isFetching}
+            >
               <Refresh aria-hidden="true" className="size-4" />
               Refresh
             </Button>
-            <Button variant="ghost" size="sm" onClick={handleExportCsv}>
-              Export CSV
-            </Button>
-            <Button variant="ghost" size="sm" onClick={handleExportJson}>
-              Export JSON
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-[var(--radius-3)] border border-ink bg-transparent px-3 text-sm font-medium text-ink transition-colors hover:bg-ink hover:text-canvas focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+              >
+                <Download className="size-4" />
+                Export
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={handleExportCsv}>
+                  Export as CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={handleExportJson}>
+                  Export as JSON
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-3 font-mono text-xs text-muted">
-          <span>{eventCountStatus(isLoading, isError, events.length)}</span>
+
+        <div className="font-mono text-xs text-muted">
+          {isLoading
+            ? "Loading…"
+            : isError
+              ? "Unavailable"
+              : `${fmtCompact(events.length)} event${events.length === 1 ? "" : "s"} loaded`}
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-[var(--radius-6)] border border-border-subtle bg-surface">
-        <table className="w-full min-w-[960px] border-collapse text-left">
-          <thead>
-            <tr className="border-b border-border-subtle text-[11px] font-medium tracking-[0.08em] text-muted uppercase">
-              <Th className="pl-5">Time (UTC)</Th>
-              <Th>Status</Th>
-              <Th>Recipient</Th>
-              <Th>Issuer</Th>
-              <Th className="text-right">Amount</Th>
-              <Th>Mint</Th>
-              <Th>Nullifier</Th>
-              <Th className="text-right">Slot</Th>
-              <Th className="pr-5">Tx signature</Th>
-            </tr>
-          </thead>
-          <tbody>
-            {events.map((event) => (
-              <tr
-                key={`${event.slot}-${event.signature}`}
-                className="border-b border-border-subtle text-[13px] text-quill transition-colors last:border-b-0 hover:bg-surface-deep"
-              >
-                <td className="py-3 pr-3 pl-5 font-mono text-stone">
-                  {formatDateTime(event.timestamp)}
-                </td>
-                <td className="py-3 pr-3">
-                  <StatusPill kind="verified" label="Verified" />
-                </td>
-                <td className="py-3 pr-3 font-mono text-ink">
-                  {truncateWallet(event.recipient, 6, 4)}
-                </td>
-                <td className="py-3 pr-3 font-mono text-stone">
-                  {truncateWallet(event.issuer, 4, 4)}
-                </td>
-                <td className="py-3 pr-3 text-right font-mono text-ink">
-                  {fmtAmount(event.amount / 1_000_000)}
-                </td>
-                <td className="py-3 pr-3 font-mono text-stone">
-                  {truncateWallet(event.mint, 4, 4)}
-                </td>
-                <td className="py-3 pr-3 font-mono text-stone">
-                  {truncateWallet(event.nullifier_hash, 6, 4)}
-                </td>
-                <td className="py-3 pr-3 text-right font-mono text-stone">
-                  {fmtCompact(event.slot)}
-                </td>
-                <td className="py-3 pr-5 font-mono text-stone">
-                  {truncateWallet(event.signature, 6, 6)}
-                </td>
-              </tr>
-            ))}
-            {!isLoading && !isError && events.length === 0 ? (
-              <tr>
-                <td colSpan={9} className="py-8 text-center text-sm text-muted">
-                  No events match the current filters.
-                </td>
-              </tr>
-            ) : null}
-            {isLoading ? (
-              <tr>
-                <td colSpan={9} className="py-8 text-center font-mono text-xs text-muted">
-                  Loading events…
-                </td>
-              </tr>
-            ) : null}
-          </tbody>
-        </table>
+      {/* Table */}
+      <div className="rounded-[var(--radius-6)] border border-border-subtle bg-surface">
+        <Table className="min-w-[960px]">
+          <TableHeader>
+            <TableRow className="border-b border-border-subtle hover:bg-transparent">
+              <TableHead className="pl-5 text-[11px]">Time (UTC)</TableHead>
+              <TableHead className="text-[11px]">Status</TableHead>
+              <TableHead className="text-[11px]">Recipient</TableHead>
+              <TableHead className="text-[11px]">Issuer</TableHead>
+              <TableHead className="text-right text-[11px]">Amount</TableHead>
+              <TableHead className="text-[11px]">Mint</TableHead>
+              <TableHead className="text-[11px]">Nullifier</TableHead>
+              <TableHead className="text-right text-[11px]">Slot</TableHead>
+              <TableHead className="pr-5 text-[11px]">Tx signature</TableHead>
+            </TableRow>
+          </TableHeader>
+
+          {isLoading ? (
+            <TableSkeleton columns={9} rows={5} />
+          ) : (
+            <TableBody>
+              {events.map((event) => (
+                <TableRow
+                  key={`${event.slot}-${event.signature}`}
+                  className="border-b border-border-subtle text-[13px] text-quill last:border-b-0"
+                >
+                  <TableCell className="py-3 pl-5 font-mono text-stone">
+                    {formatDateTime(event.timestamp)}
+                  </TableCell>
+                  <TableCell className="py-3">
+                    <StatusPill kind="verified" label="Verified" />
+                  </TableCell>
+                  <TableCell className="py-3 text-ink">
+                    <TruncatedHash value={event.recipient} head={6} tail={4} />
+                  </TableCell>
+                  <TableCell className="py-3 text-stone">
+                    <TruncatedHash value={event.issuer} head={4} tail={4} />
+                  </TableCell>
+                  <TableCell className="py-3 text-right font-mono text-ink">
+                    {fmtAmount(event.amount / 1_000_000)}
+                  </TableCell>
+                  <TableCell className="py-3 text-stone">
+                    <TruncatedHash value={event.mint} head={4} tail={4} />
+                  </TableCell>
+                  <TableCell className="py-3 text-stone">
+                    <TruncatedHash value={event.nullifier_hash} head={6} tail={4} />
+                  </TableCell>
+                  <TableCell className="py-3 text-right font-mono text-stone">
+                    {fmtCompact(event.slot)}
+                  </TableCell>
+                  <TableCell className="py-3 pr-5 text-stone">
+                    <TruncatedHash value={event.signature} head={6} tail={6} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          )}
+        </Table>
+
+        {!isLoading && !isError && events.length === 0 && (
+          <EmptyState
+            icon={SearchEngine}
+            title="No events match the current filters"
+            description="Try adjusting the time range or clearing the wallet filters."
+            action={{ label: "Clear filters", onClick: clearFilters }}
+          />
+        )}
       </div>
 
+      {/* Pagination */}
       <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle pt-4 font-mono text-xs text-muted">
-        <span>{events.length > 0 ? pluralizeEvents(events.length) : ""}</span>
+        <span>
+          {events.length > 0
+            ? `Showing ${fmtCompact(events.length)} event${events.length === 1 ? "" : "s"}`
+            : ""}
+        </span>
         {hasNextPage && (
           <Button
             variant="ghost"
@@ -269,47 +316,11 @@ export function AuditLogTable() {
             {isFetchingNextPage ? "Loading…" : "Load more"}
           </Button>
         )}
-        {!hasNextPage && events.length > 0 && <span>End of results</span>}
+        {!hasNextPage && events.length > 0 && (
+          <span className="text-ghost">End of results</span>
+        )}
       </div>
-
     </div>
-  );
-}
-
-function Th({ children, className }: Readonly<{ children: React.ReactNode; className?: string }>) {
-  return (
-    <th scope="col" className={cn("py-2.5 pr-3 font-medium", className)}>
-      {children}
-    </th>
-  );
-}
-
-function FilterSelect({
-  label,
-  value,
-  onChange,
-  options,
-}: Readonly<{
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  options: readonly { value: string; label: string }[];
-}>) {
-  return (
-    <label className="flex flex-col gap-1.5 text-xs text-stone">
-      <span className="font-mono tracking-[0.08em] text-muted uppercase">{label}</span>
-      <select
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        className="h-10 appearance-none rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 text-sm text-ink transition-colors hover:border-border focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
-      >
-        {options.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
-      </select>
-    </label>
   );
 }
 
@@ -329,8 +340,10 @@ function HexFilterInput({
   onCommit: () => void;
 }>) {
   return (
-    <label className="flex flex-col gap-1.5 text-xs text-stone">
-      <span className="font-mono tracking-[0.08em] text-muted uppercase">{label}</span>
+    <div className="flex flex-col gap-1.5">
+      <span className="font-mono text-[10px] tracking-[0.08em] text-muted uppercase">
+        {label}
+      </span>
       <Input
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -345,8 +358,8 @@ function HexFilterInput({
         spellCheck={false}
         autoComplete="off"
         aria-invalid={invalid}
-        className={cn("w-[220px] font-mono text-sm", invalid && "border-rust")}
+        className={cn("w-[200px] font-mono text-sm", invalid && "border-danger-text")}
       />
-    </label>
+    </div>
   );
 }

--- a/frontend/src/components/dashboard/audit-log-table.tsx
+++ b/frontend/src/components/dashboard/audit-log-table.tsx
@@ -143,6 +143,21 @@ export function AuditLogTable() {
     exportToJson(events, "zksettle-audit-log.json");
   };
 
+  let statusText: string;
+  if (isLoading) {
+    statusText = "Loading…";
+  } else if (isError) {
+    statusText = "Unavailable";
+  } else {
+    const plural = events.length === 1 ? "" : "s";
+    statusText = `${fmtCompact(events.length)} event${plural} loaded`;
+  }
+
+  const paginationText =
+    events.length > 0
+      ? `Showing ${fmtCompact(events.length)} event${events.length === 1 ? "" : "s"}`
+      : "";
+
   return (
     <div className="flex flex-col gap-6">
       {/* Filters */}
@@ -222,11 +237,7 @@ export function AuditLogTable() {
         </div>
 
         <div className="font-mono text-xs text-muted">
-          {isLoading
-            ? "Loading…"
-            : isError
-              ? "Unavailable"
-              : `${fmtCompact(events.length)} event${events.length === 1 ? "" : "s"} loaded`}
+          {statusText}
         </div>
       </div>
 
@@ -301,11 +312,7 @@ export function AuditLogTable() {
 
       {/* Pagination */}
       <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-subtle pt-4 font-mono text-xs text-muted">
-        <span>
-          {events.length > 0
-            ? `Showing ${fmtCompact(events.length)} event${events.length === 1 ? "" : "s"}`
-            : ""}
-        </span>
+        <span>{paginationText}</span>
         {hasNextPage && (
           <Button
             variant="ghost"

--- a/frontend/src/components/dashboard/billing-cards.tsx
+++ b/frontend/src/components/dashboard/billing-cards.tsx
@@ -4,6 +4,8 @@ import { useEffect } from "react";
 import { toast } from "sonner";
 
 import { BillingUsageChart } from "@/components/dashboard/billing-usage-chart";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
 import { useUsage, useUsageHistory } from "@/hooks/use-usage";
 import { TIER_PRICE_CENTS, type Tier } from "@/lib/api/schemas";
 import { fmtCompact } from "@/lib/format";
@@ -62,37 +64,52 @@ export function BillingCards() {
               Current tier
             </span>
             <div className="mt-2 flex items-baseline gap-3">
-              <span className="font-display text-3xl text-ink">
-                {isLoading && "—"}
-                {!isLoading && isError && "Unavailable"}
-                {!isLoading && !isError && TIER_LABEL[tier]}
-              </span>
-              <span className="font-mono text-sm text-stone">
-                {isLoading || isError ? "" : tierPriceLabel(tier, monthlyLimit)}
-              </span>
+              {isLoading ? (
+                <Skeleton className="h-9 w-32" />
+              ) : (
+                <>
+                  <span className="font-display text-3xl text-ink">
+                    {isError ? "Unavailable" : TIER_LABEL[tier]}
+                  </span>
+                  {!isError && (
+                    <span className="font-mono text-sm text-stone">
+                      {tierPriceLabel(tier, monthlyLimit)}
+                    </span>
+                  )}
+                </>
+              )}
             </div>
           </div>
         </div>
 
-        <div className="mt-6 flex flex-col gap-3">
+        <Separator className="my-5" />
+
+        <div className="flex flex-col gap-3">
           <div className="flex items-baseline justify-between font-mono text-xs text-stone">
             <span>
               Used this month ·{" "}
-              <span className="text-ink">
-                {isLoading ? "…" : usedThisMonth.toLocaleString("en-US")}
-              </span>
+              {isLoading ? (
+                <Skeleton className="inline-block h-3.5 w-12 align-middle" />
+              ) : (
+                <span className="text-ink">
+                  {usedThisMonth.toLocaleString("en-US")}
+                </span>
+              )}
             </span>
             <span>
               {monthlyLimit > 0 ? `${usagePct}% of ${fmtCompact(monthlyLimit)}` : "—"}
             </span>
           </div>
-          <progress
-            value={usagePct}
-            max={100}
-            className="h-2 w-full overflow-hidden rounded-full bg-border-subtle [&::-webkit-progress-bar]:bg-border-subtle [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-value]:bg-forest [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:transition-[width] [&::-webkit-progress-value]:duration-500 [&::-webkit-progress-value]:ease-[var(--ease-brand)] [&::-moz-progress-bar]:bg-forest [&::-moz-progress-bar]:rounded-full"
-          >
-            {usagePct}%
-          </progress>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-border-subtle">
+            <div
+              className="h-full rounded-full bg-forest transition-[width] duration-500 ease-[var(--ease-brand)]"
+              style={{ width: `${usagePct}%` }}
+              role="progressbar"
+              aria-valuenow={usagePct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
         </div>
       </section>
 
@@ -115,15 +132,14 @@ export function BillingCards() {
         </div>
         <div className="mt-4">
           {historyLoading ? (
-            <div className="flex h-[200px] items-center justify-center font-mono text-xs text-muted">
-              Loading usage…
+            <div className="flex h-[200px] flex-col justify-between gap-2 py-4">
+              <Skeleton className="h-full w-full" />
             </div>
           ) : (
             <BillingUsageChart data={historyData} />
           )}
         </div>
       </section>
-
     </div>
   );
 }

--- a/frontend/src/components/dashboard/billing-cards.tsx
+++ b/frontend/src/components/dashboard/billing-cards.tsx
@@ -100,16 +100,11 @@ export function BillingCards() {
               {monthlyLimit > 0 ? `${usagePct}% of ${fmtCompact(monthlyLimit)}` : "—"}
             </span>
           </div>
-          <div className="h-2 w-full overflow-hidden rounded-full bg-border-subtle">
-            <div
-              className="h-full rounded-full bg-forest transition-[width] duration-500 ease-[var(--ease-brand)]"
-              style={{ width: `${usagePct}%` }}
-              role="progressbar"
-              aria-valuenow={usagePct}
-              aria-valuemin={0}
-              aria-valuemax={100}
-            />
-          </div>
+          <progress
+            className="h-2 w-full overflow-hidden rounded-full [&]:appearance-none [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-border-subtle [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-forest [&::-webkit-progress-value]:transition-[width] [&::-webkit-progress-value]:duration-500 [&::-webkit-progress-value]:ease-[var(--ease-brand)] [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-forest"
+            value={usagePct}
+            max={100}
+          />
         </div>
       </section>
 

--- a/frontend/src/components/dashboard/empty-state.tsx
+++ b/frontend/src/components/dashboard/empty-state.tsx
@@ -20,7 +20,7 @@ export function EmptyState({
   description,
   action,
   className,
-}: EmptyStateProps) {
+}: Readonly<EmptyStateProps>) {
   return (
     <div
       className={cn(

--- a/frontend/src/components/dashboard/empty-state.tsx
+++ b/frontend/src/components/dashboard/empty-state.tsx
@@ -1,0 +1,45 @@
+import type { FC, SVGProps } from "react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+interface EmptyStateProps {
+  icon: FC<SVGProps<SVGSVGElement>>;
+  title: string;
+  description?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 py-12 text-center",
+        className,
+      )}
+    >
+      <Icon className="size-10 text-ghost" />
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-ink">{title}</p>
+        {description && (
+          <p className="max-w-xs text-[13px] text-stone">{description}</p>
+        )}
+      </div>
+      {action && (
+        <Button variant="ghost" size="sm" onClick={action.onClick} className="mt-1">
+          {action.label}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/issuer-status-panel.tsx
+++ b/frontend/src/components/dashboard/issuer-status-panel.tsx
@@ -179,13 +179,29 @@ export function IssuerStatusPanel() {
           </div>
         </CardHeader>
         <CardContent>
-          {!isError ? (
+          {isError ? null : (
             <ul
               aria-labelledby="roots-heading"
               className="flex flex-col divide-y divide-border-subtle"
             >
               {ROOT_FIELDS.map((field) => {
                 const value = roots?.[field.key];
+                let rootDisplay: React.ReactNode;
+                if (isLoading) {
+                  rootDisplay = <Skeleton className="h-5 w-40" />;
+                } else if (value) {
+                  rootDisplay = (
+                    <TruncatedHash
+                      value={value}
+                      head={10}
+                      tail={8}
+                      className="text-xs text-quill"
+                      copyable
+                    />
+                  );
+                } else {
+                  rootDisplay = <span className="font-mono text-xs text-muted">—</span>;
+                }
                 return (
                   <li
                     key={field.key}
@@ -196,19 +212,7 @@ export function IssuerStatusPanel() {
                       <span className="text-xs text-stone">{field.description}</span>
                     </div>
                     <div className="flex items-center gap-2">
-                      {isLoading ? (
-                        <Skeleton className="h-5 w-40" />
-                      ) : value ? (
-                        <TruncatedHash
-                          value={value}
-                          head={10}
-                          tail={8}
-                          className="text-xs text-quill"
-                          copyable
-                        />
-                      ) : (
-                        <span className="font-mono text-xs text-muted">—</span>
-                      )}
+                      {rootDisplay}
                       {/* Keep the manual copy button for users who prefer an explicit action */}
                       <Button
                         variant="ghost"
@@ -226,7 +230,7 @@ export function IssuerStatusPanel() {
                 );
               })}
             </ul>
-          ) : null}
+          )}
         </CardContent>
       </Card>
 

--- a/frontend/src/components/dashboard/issuer-status-panel.tsx
+++ b/frontend/src/components/dashboard/issuer-status-panel.tsx
@@ -1,16 +1,30 @@
 "use client";
 
-import { Copy, Refresh } from "iconoir-react";
+import { Copy, Refresh, WarningTriangle } from "iconoir-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { StatCard } from "@/components/dashboard/stat-card";
 import { StatusPill } from "@/components/dashboard/status-pill";
+import { TruncatedHash } from "@/components/dashboard/truncated-hash";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useRoots, usePublishRoots } from "@/hooks/use-roots";
 import { ApiError } from "@/lib/api/client";
 import type { Roots } from "@/lib/api/schemas";
-import { fmtCompact, truncateWallet } from "@/lib/format";
+import { cn } from "@/lib/cn";
+import { fmtCompact } from "@/lib/format";
 
 const ROOT_FIELDS: Array<{ key: keyof Pick<Roots, "membership_root" | "sanctions_root" | "jurisdiction_root">; label: string; description: string }> = [
   {
@@ -45,12 +59,6 @@ function statCardValue(
   return format(roots);
 }
 
-function rootDisplayValue(isLoading: boolean, value: string | undefined): string {
-  if (isLoading) return "loading…";
-  if (!value) return "—";
-  return truncateWallet(value, 10, 8);
-}
-
 function describeError(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.status === 401 || err.status === 403) {
@@ -68,6 +76,7 @@ export function IssuerStatusPanel() {
   const { data: roots, isLoading, isError, error, refetch, isFetching } = useRoots();
   const publish = usePublishRoots();
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   useEffect(() => {
     if (isError) toast.error(describeError(error));
@@ -84,6 +93,7 @@ export function IssuerStatusPanel() {
   };
 
   const onPublish = async () => {
+    setConfirmOpen(false);
     try {
       const res = await publish.mutateAsync();
       toast.success(
@@ -105,6 +115,7 @@ export function IssuerStatusPanel() {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* Status bar */}
       <section className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--radius-6)] border border-border-subtle bg-surface px-5 py-4">
         <div className="flex items-center gap-3">
           <StatusPill kind={status.kind} label={status.label} />
@@ -126,7 +137,7 @@ export function IssuerStatusPanel() {
           <Button
             variant="primary"
             size="sm"
-            onClick={onPublish}
+            onClick={() => setConfirmOpen(true)}
             disabled={publish.isPending || isLoading || isError}
           >
             {publish.isPending ? "Publishing…" : "Publish roots"}
@@ -134,67 +145,123 @@ export function IssuerStatusPanel() {
         </div>
       </section>
 
+      <Separator className="bg-border-subtle" />
+
+      {/* Stats */}
       <div className="grid gap-4 sm:grid-cols-2">
         <StatCard
           label="Wallet count"
           value={statCardValue(isLoading, roots, (r) => fmtCompact(r.wallet_count))}
           sub="Credentialed wallets in the membership tree"
+          isLoading={isLoading}
         />
         <StatCard
           label="Last publish"
           value={statCardValue(isLoading, roots, (r) => formatSlot(r.last_publish_slot))}
           sub="Most recent on-chain root commit"
+          isLoading={isLoading}
         />
       </div>
 
-      <section
-        aria-labelledby="roots-heading"
-        className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-      >
-        <div className="flex items-baseline justify-between">
-          <span
-            id="roots-heading"
-            className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-          >
-            Merkle roots
-          </span>
-          <span className="font-mono text-xs text-muted">Current state</span>
-        </div>
+      <Separator className="bg-border-subtle" />
 
-        {!isError ? (
-          <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
-            {ROOT_FIELDS.map((field) => {
-              const value = roots?.[field.key];
-              const display = rootDisplayValue(isLoading, value);
-              return (
-                <li
-                  key={field.key}
-                  className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
-                >
-                  <div className="flex flex-col">
-                    <span className="text-sm font-medium text-ink">{field.label}</span>
-                    <span className="text-xs text-stone">{field.description}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <code className="font-mono text-xs text-quill">{display}</code>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      disabled={!value}
-                      onClick={() => value && copy(value, field.key)}
-                      aria-label={`Copy ${field.label}`}
-                    >
-                      <Copy aria-hidden="true" className="size-4" />
-                      {copiedKey === field.key ? "Copied" : "Copy"}
-                    </Button>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        ) : null}
-      </section>
+      {/* Merkle roots */}
+      <Card className="border-border-subtle bg-surface">
+        <CardHeader>
+          <div className="flex items-baseline justify-between">
+            <CardTitle
+              id="roots-heading"
+              className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
+            >
+              Merkle roots
+            </CardTitle>
+            <span className="font-mono text-xs text-muted">Current state</span>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {!isError ? (
+            <ul
+              aria-labelledby="roots-heading"
+              className="flex flex-col divide-y divide-border-subtle"
+            >
+              {ROOT_FIELDS.map((field) => {
+                const value = roots?.[field.key];
+                return (
+                  <li
+                    key={field.key}
+                    className="flex flex-wrap items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+                  >
+                    <div className="flex flex-col gap-0.5">
+                      <span className="text-sm font-medium text-ink">{field.label}</span>
+                      <span className="text-xs text-stone">{field.description}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {isLoading ? (
+                        <Skeleton className="h-5 w-40" />
+                      ) : value ? (
+                        <TruncatedHash
+                          value={value}
+                          head={10}
+                          tail={8}
+                          className="text-xs text-quill"
+                          copyable
+                        />
+                      ) : (
+                        <span className="font-mono text-xs text-muted">—</span>
+                      )}
+                      {/* Keep the manual copy button for users who prefer an explicit action */}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={!value}
+                        onClick={() => value && copy(value, field.key)}
+                        aria-label={`Copy ${field.label}`}
+                        className={cn(!value && "hidden")}
+                      >
+                        <Copy aria-hidden="true" className="size-4" />
+                        {copiedKey === field.key ? "Copied" : "Copy"}
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+        </CardContent>
+      </Card>
 
+      {/* Publish confirmation dialog */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <WarningTriangle className="size-5 text-forest" aria-hidden="true" />
+              Confirm publish
+            </DialogTitle>
+            <DialogDescription>
+              This will commit the current Merkle roots on-chain. The action cannot be
+              undone — downstream verifiers will immediately start using the new roots.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose
+              className={cn(
+                "inline-flex h-8 cursor-pointer items-center justify-center gap-2 rounded-[var(--radius-3)] border border-ink bg-transparent px-3 text-sm font-medium text-ink transition-colors hover:bg-ink hover:text-canvas",
+              )}
+            >
+              Cancel
+            </DialogClose>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={onPublish}
+              disabled={publish.isPending}
+            >
+              {publish.isPending ? "Publishing…" : "Yes, publish"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/components/dashboard/prove-flow-panel.tsx
+++ b/frontend/src/components/dashboard/prove-flow-panel.tsx
@@ -11,6 +11,7 @@ import {
   Sparks,
 } from "iconoir-react";
 import { AnimatePresence, motion } from "motion/react";
+import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -51,6 +52,7 @@ function CopyButton({ text, label }: Readonly<{ text: string; label: string }>) 
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
+      toast.success("Copied to clipboard");
       setTimeout(() => setCopied(false), 1500);
     } catch {
       /* noop */

--- a/frontend/src/components/dashboard/prove-flow-panel.tsx
+++ b/frontend/src/components/dashboard/prove-flow-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, useCallback, type ReactNode } from "react";
 import {
   Flash,
   ArrowUpRight,
@@ -18,7 +18,8 @@ import { Button } from "@/components/ui/button";
 import { ConnectWalletButton } from "@/components/wallet/connect-wallet-button";
 import { ProofStepCard } from "@/components/dashboard/proof-step-card";
 import { ProveProgressBar } from "@/components/dashboard/prove-progress-bar";
-import { useProveFlow } from "@/hooks/use-prove-flow";
+import { PublicKey as SolPublicKey } from "@solana/web3.js";
+import { useProveFlow, type TransferParams } from "@/hooks/use-prove-flow";
 import { STEPS, type FlowState } from "@/lib/prove-flow";
 import { useWallet } from "@/hooks/use-wallet-connection";
 
@@ -161,11 +162,17 @@ function IntroCard({
   canStart,
   onStart,
   onDemo,
+  transferParams,
+  onTransferParamsChange,
+  formError,
 }: Readonly<{
   connected: boolean;
   canStart: boolean;
   onStart: () => void;
   onDemo: () => void;
+  transferParams: TransferParams;
+  onTransferParamsChange: (params: TransferParams) => void;
+  formError: string | null;
 }>) {
   return (
     <motion.section
@@ -174,29 +181,79 @@ function IntroCard({
       exit={{ opacity: 0, y: -6, transition: { duration: 0.2 } }}
       className="rounded-[var(--radius-6)] border border-forest/20 bg-surface p-6"
     >
-      <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
-        <div className="max-w-lg">
-          <div className="flex items-center gap-2">
-            <ShieldCheck className="size-5 text-forest" strokeWidth={1.5} aria-hidden="true" />
-            <h2 className="text-sm font-medium text-ink">
-              End-to-end compliance proof
-            </h2>
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="max-w-lg">
+            <div className="flex items-center gap-2">
+              <ShieldCheck className="size-5 text-forest" strokeWidth={1.5} aria-hidden="true" />
+              <h2 className="text-sm font-medium text-ink">
+                End-to-end compliance proof
+              </h2>
+            </div>
+            <p className="mt-2 text-xs leading-relaxed text-stone">
+              This page generates a zero-knowledge proof that your wallet holds a valid issuer
+              credential, is not on the sanctions list, and belongs to a permitted jurisdiction
+              — then submits it on-chain for verification. The entire flow runs in your browser.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Badge variant="default">Noir circuit</Badge>
+              <Badge variant="default">Barretenberg WASM</Badge>
+              <Badge variant="default">Solana devnet</Badge>
+            </div>
           </div>
-          <p className="mt-2 text-xs leading-relaxed text-stone">
-            This page generates a zero-knowledge proof that your wallet holds a valid issuer
-            credential, is not on the sanctions list, and belongs to a permitted jurisdiction
-            — then submits it on-chain for verification. The entire flow runs in your browser.
-          </p>
-          <div className="mt-3 flex flex-wrap gap-2">
-            <Badge variant="default">Noir circuit</Badge>
-            <Badge variant="default">Barretenberg WASM</Badge>
-            <Badge variant="default">Solana devnet</Badge>
+
+          <div className="flex shrink-0 flex-col gap-2">
+            {!connected && (
+              <>
+                <ConnectWalletButton />
+                <p className="text-center text-[11px] text-muted">
+                  Connect a wallet to begin
+                </p>
+              </>
+            )}
           </div>
         </div>
 
-        <div className="flex shrink-0 flex-col gap-2">
-          {connected ? (
-            <>
+        {connected && (
+          <>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">Mint address</span>
+                <input
+                  type="text"
+                  placeholder="Token mint public key"
+                  value={transferParams.mint}
+                  onChange={(e) => onTransferParamsChange({ ...transferParams, mint: e.target.value })}
+                  className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">Recipient address</span>
+                <input
+                  type="text"
+                  placeholder="Destination wallet public key"
+                  value={transferParams.recipient}
+                  onChange={(e) => onTransferParamsChange({ ...transferParams, recipient: e.target.value })}
+                  className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-1 sm:max-w-[calc(50%-0.375rem)]">
+              <span className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">Amount</span>
+              <input
+                type="number"
+                min={1}
+                value={transferParams.amount}
+                onChange={(e) => onTransferParamsChange({ ...transferParams, amount: Number(e.target.value) || 0 })}
+                className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+              />
+            </label>
+
+            {formError && (
+              <p className="text-xs text-red-500">{formError}</p>
+            )}
+
+            <div className="flex items-center gap-3">
               <Button onClick={onStart} disabled={!canStart}>
                 <Flash className="size-4" strokeWidth={1.5} aria-hidden="true" />
                 Start proof flow
@@ -205,16 +262,9 @@ function IntroCard({
                 <Sparks className="size-4" strokeWidth={1.5} aria-hidden="true" />
                 Run demo
               </Button>
-            </>
-          ) : (
-            <>
-              <ConnectWalletButton />
-              <p className="text-center text-[11px] text-muted">
-                Connect a wallet to begin
-              </p>
-            </>
-          )}
-        </div>
+            </div>
+          </>
+        )}
       </div>
     </motion.section>
   );
@@ -360,6 +410,34 @@ export function ProveFlowPanel() {
   const { state, startFlow, startDemo, reset, canStart, isRunning, isDone, txUrl } =
     useProveFlow();
 
+  const [transferParams, setTransferParams] = useState<TransferParams>({
+    mint: "",
+    recipient: "",
+    amount: 1000,
+  });
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const handleStart = useCallback(() => {
+    if (!transferParams.mint.trim() || !transferParams.recipient.trim()) {
+      setFormError("Mint and recipient addresses are required.");
+      return;
+    }
+    try { new SolPublicKey(transferParams.mint); } catch {
+      setFormError("Invalid mint address.");
+      return;
+    }
+    try { new SolPublicKey(transferParams.recipient); } catch {
+      setFormError("Invalid recipient address.");
+      return;
+    }
+    if (transferParams.amount <= 0) {
+      setFormError("Amount must be greater than zero.");
+      return;
+    }
+    setFormError(null);
+    startFlow(transferParams);
+  }, [transferParams, startFlow]);
+
   const hasStarted = state.currentStep >= 0;
   const hasError = state.steps.some((s) => s.status === "error");
 
@@ -378,8 +456,11 @@ export function ProveFlowPanel() {
             key="intro"
             connected={connected}
             canStart={canStart}
-            onStart={startFlow}
+            onStart={handleStart}
             onDemo={startDemo}
+            transferParams={transferParams}
+            onTransferParamsChange={setTransferParams}
+            formError={formError}
           />
         )}
 

--- a/frontend/src/components/dashboard/sidebar.tsx
+++ b/frontend/src/components/dashboard/sidebar.tsx
@@ -46,8 +46,8 @@ export function Sidebar() {
                       href={item.href}
                       aria-current={isActive ? "page" : undefined}
                       className={cn(
-                        "relative flex cursor-pointer items-center gap-3 rounded-[var(--radius-3)] px-3 py-2 text-sm transition-colors",
-                        "text-quill hover:text-ink",
+                        "relative flex cursor-pointer items-center gap-3 rounded-[var(--radius-3)] px-3 py-2 text-sm transition-colors duration-150 ease-[var(--ease-brand)]",
+                        "text-quill hover:bg-surface-deep hover:text-ink",
                         "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest",
                         isActive && "bg-surface-deep text-ink",
                       )}

--- a/frontend/src/components/dashboard/stat-card.tsx
+++ b/frontend/src/components/dashboard/stat-card.tsx
@@ -11,7 +11,7 @@ export interface StatCardProps {
   isLoading?: boolean;
 }
 
-export function StatCard({ label, value, sub, className, isLoading }: StatCardProps) {
+export function StatCard({ label, value, sub, className, isLoading }: Readonly<StatCardProps>) {
   return (
     <article
       className={cn(

--- a/frontend/src/components/dashboard/stat-card.tsx
+++ b/frontend/src/components/dashboard/stat-card.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/cn";
 
 export interface StatCardProps {
@@ -7,9 +8,10 @@ export interface StatCardProps {
   value: ReactNode;
   sub?: ReactNode;
   className?: string;
+  isLoading?: boolean;
 }
 
-export function StatCard({ label, value, sub, className }: StatCardProps) {
+export function StatCard({ label, value, sub, className, isLoading }: StatCardProps) {
   return (
     <article
       className={cn(
@@ -20,10 +22,14 @@ export function StatCard({ label, value, sub, className }: StatCardProps) {
       <div className="font-mono text-[10px] font-medium tracking-[0.1em] text-muted uppercase">
         {label}
       </div>
-      <div className="font-display text-[clamp(28px,3vw,44px)] leading-[1.05] tracking-[-0.02em] text-ink">
-        {value}
-      </div>
-      {sub ? <div className="font-mono text-[13px] text-stone">{sub}</div> : null}
+      {isLoading ? (
+        <Skeleton className="h-10 w-24" />
+      ) : (
+        <div className="font-display text-[clamp(28px,3vw,44px)] leading-[1.05] tracking-[-0.02em] text-ink">
+          {value}
+        </div>
+      )}
+      {sub && !isLoading ? <div className="font-mono text-[13px] text-stone">{sub}</div> : null}
     </article>
   );
 }

--- a/frontend/src/components/dashboard/table-skeleton.tsx
+++ b/frontend/src/components/dashboard/table-skeleton.tsx
@@ -5,7 +5,7 @@ interface TableSkeletonProps {
   rows?: number;
 }
 
-export function TableSkeleton({ columns, rows = 5 }: TableSkeletonProps) {
+export function TableSkeleton({ columns, rows = 5 }: Readonly<TableSkeletonProps>) {
   return (
     <tbody>
       {Array.from({ length: rows }, (_, rowIndex) => (
@@ -13,14 +13,19 @@ export function TableSkeleton({ columns, rows = 5 }: TableSkeletonProps) {
           key={rowIndex}
           className="border-b border-border-subtle last:border-b-0"
         >
-          {Array.from({ length: columns }, (_, colIndex) => (
-            <td key={colIndex} className="px-3 py-3 first:pl-5 last:pr-5">
-              <Skeleton
-                className="h-4 w-full"
-                style={{ maxWidth: colIndex === 0 ? 80 : colIndex === 4 ? 60 : 100 }}
-              />
-            </td>
-          ))}
+          {Array.from({ length: columns }, (_, colIndex) => {
+            let maxWidth = 100;
+            if (colIndex === 0) maxWidth = 80;
+            else if (colIndex === 4) maxWidth = 60;
+            return (
+              <td key={colIndex} className="px-3 py-3 first:pl-5 last:pr-5">
+                <Skeleton
+                  className="h-4 w-full"
+                  style={{ maxWidth }}
+                />
+              </td>
+            );
+          })}
         </tr>
       ))}
     </tbody>

--- a/frontend/src/components/dashboard/table-skeleton.tsx
+++ b/frontend/src/components/dashboard/table-skeleton.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface TableSkeletonProps {
+  columns: number;
+  rows?: number;
+}
+
+export function TableSkeleton({ columns, rows = 5 }: TableSkeletonProps) {
+  return (
+    <tbody>
+      {Array.from({ length: rows }, (_, rowIndex) => (
+        <tr
+          key={rowIndex}
+          className="border-b border-border-subtle last:border-b-0"
+        >
+          {Array.from({ length: columns }, (_, colIndex) => (
+            <td key={colIndex} className="px-3 py-3 first:pl-5 last:pr-5">
+              <Skeleton
+                className="h-4 w-full"
+                style={{ maxWidth: colIndex === 0 ? 80 : colIndex === 4 ? 60 : 100 }}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  );
+}

--- a/frontend/src/components/dashboard/top-bar.tsx
+++ b/frontend/src/components/dashboard/top-bar.tsx
@@ -25,7 +25,7 @@ export function TopBar() {
       aria-label="Dashboard top bar"
       className={cn(
         "sticky top-0 z-30 flex h-14 w-full items-center gap-4 bg-canvas/95 px-4 backdrop-blur-sm transition-colors md:px-8",
-        "border-b",
+        "border-b transition-[border-color] duration-200 ease-[var(--ease-brand)]",
         scrolled ? "border-border-subtle" : "border-transparent",
       )}
     >

--- a/frontend/src/components/dashboard/truncated-hash.tsx
+++ b/frontend/src/components/dashboard/truncated-hash.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "iconoir-react";
+import { toast } from "sonner";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/cn";
+
+interface TruncatedHashProps {
+  value: string;
+  head?: number;
+  tail?: number;
+  className?: string;
+  copyable?: boolean;
+}
+
+function truncate(value: string, head: number, tail: number): string {
+  if (value.length <= head + tail + 3) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+export function TruncatedHash({
+  value,
+  head = 6,
+  tail = 4,
+  className,
+  copyable = true,
+}: TruncatedHashProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    toast.success("Copied to clipboard");
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        className={cn(
+          "inline-flex cursor-default items-center gap-1 font-mono",
+          copyable && "cursor-pointer",
+          className,
+        )}
+        onClick={copyable ? handleCopy : undefined}
+      >
+        <span>{truncate(value, head, tail)}</span>
+        {copyable && (
+          <span className="text-ghost transition-colors hover:text-stone">
+            {copied ? (
+              <Check className="size-3 text-emerald" />
+            ) : (
+              <Copy className="size-3" />
+            )}
+          </span>
+        )}
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs break-all font-mono text-[11px]">
+        {value}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/dashboard/truncated-hash.tsx
+++ b/frontend/src/components/dashboard/truncated-hash.tsx
@@ -30,7 +30,7 @@ export function TruncatedHash({
   tail = 4,
   className,
   copyable = true,
-}: TruncatedHashProps) {
+}: Readonly<TruncatedHashProps>) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {

--- a/frontend/src/components/dashboard/wallets-credentials-panel.tsx
+++ b/frontend/src/components/dashboard/wallets-credentials-panel.tsx
@@ -1,12 +1,27 @@
 "use client";
 
-import { Plus, Search, Trash, Xmark } from "iconoir-react";
+import { Clock, Plus, Search, Trash, Xmark } from "iconoir-react";
 import { useEffect, useState, type SyntheticEvent } from "react";
 import { toast } from "sonner";
 
+import { EmptyState } from "@/components/dashboard/empty-state";
 import { StatusPill } from "@/components/dashboard/status-pill";
+import { TruncatedHash } from "@/components/dashboard/truncated-hash";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   useCredential,
   useIssueCredential,
@@ -20,7 +35,7 @@ import {
 import { useRegisterWallet } from "@/hooks/use-register-wallet";
 import { ApiError } from "@/lib/api/client";
 import type { Credential } from "@/lib/api/schemas";
-import { truncateWallet } from "@/lib/format";
+import { cn } from "@/lib/cn";
 import { bytesToHex, isValidWalletHex, normalizeWalletHex } from "@/lib/wallet";
 
 function formatTimestamp(unixSeconds: number): string {
@@ -135,161 +150,180 @@ export function WalletsCredentialsPanel() {
 
   return (
     <div className="flex flex-col gap-6">
-      <section
-        aria-labelledby="register-heading"
-        className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-      >
-        <span
-          id="register-heading"
-          className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-        >
-          Register wallet
-        </span>
-        <p className="mt-1 text-sm text-stone">
-          Add a wallet to the membership tree. Paste a 32-byte pubkey as 64 hex
-          chars (with or without <span className="font-mono">0x</span>).
-        </p>
-
-        <form
-          onSubmit={onRegister}
-          className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center"
-        >
-          <Input
-            value={registerInput}
-            onChange={(e) => {
-              setRegisterInput(e.target.value);
-              register.reset();
-            }}
-            placeholder="0x… (64 hex chars)"
-            spellCheck={false}
-            autoComplete="off"
-            aria-invalid={registerInput.length > 0 && !registerInputValid}
-            aria-describedby="register-help"
-            className="font-mono"
-            disabled={register.isPending}
-          />
-          <Button
-            type="submit"
-            variant="primary"
-            size="md"
-            disabled={!registerInputValid || register.isPending}
+      {/* ── Register wallet ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+            Register wallet
+          </CardTitle>
+          <CardDescription className="text-sm text-stone">
+            Add a wallet to the membership tree. Paste a 32-byte pubkey as 64 hex
+            chars (with or without <span className="font-mono">0x</span>).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            onSubmit={onRegister}
+            className="flex flex-col gap-3 sm:flex-row sm:items-center"
           >
-            <Plus aria-hidden="true" className="size-4" />
-            {register.isPending ? "Registering…" : "Register"}
-          </Button>
-        </form>
+            <Input
+              value={registerInput}
+              onChange={(e) => {
+                setRegisterInput(e.target.value);
+                register.reset();
+              }}
+              placeholder="0x… (64 hex chars)"
+              spellCheck={false}
+              autoComplete="off"
+              aria-invalid={registerInput.length > 0 && !registerInputValid}
+              aria-describedby="register-help"
+              className="font-mono"
+              disabled={register.isPending}
+            />
+            <Button
+              type="submit"
+              variant="primary"
+              size="md"
+              disabled={!registerInputValid || register.isPending}
+            >
+              <Plus aria-hidden="true" className="size-4" />
+              {register.isPending ? "Registering…" : "Register"}
+            </Button>
+          </form>
 
-        {registerInput.length > 0 && !registerInputValid ? (
-          <p id="register-help" className="mt-2 font-mono text-xs text-rust">
-            Wallet must be 64 hex characters.
-          </p>
-        ) : null}
-      </section>
+          {registerInput.length > 0 && !registerInputValid ? (
+            <p id="register-help" className="mt-2 font-mono text-xs text-rust">
+              Wallet must be 64 hex characters.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
 
-      <section
-        aria-labelledby="lookup-heading"
-        className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-      >
-        <span
-          id="lookup-heading"
-          className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-        >
-          Look up wallet credential
-        </span>
-        <p className="mt-1 text-sm text-stone">
-          Paste a 32-byte wallet pubkey as 64 hex chars (with or without <span className="font-mono">0x</span>).
-        </p>
+      <Separator />
 
-        <form onSubmit={lookup} className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
-          <Input
-            value={walletInput}
-            onChange={(e) => setWalletInput(e.target.value)}
-            placeholder="0x… (64 hex chars)"
-            spellCheck={false}
-            autoComplete="off"
-            aria-invalid={walletInput.length > 0 && !inputValid}
-            aria-describedby="wallet-help"
-            className="font-mono"
-          />
-          <Button type="submit" variant="primary" size="md" disabled={!inputValid}>
-            <Search aria-hidden="true" className="size-4" />
-            Look up
-          </Button>
-        </form>
+      {/* ── Look up wallet credential ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+            Look up wallet credential
+          </CardTitle>
+          <CardDescription className="text-sm text-stone">
+            Paste a 32-byte wallet pubkey as 64 hex chars (with or without <span className="font-mono">0x</span>).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={lookup} className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Input
+              value={walletInput}
+              onChange={(e) => setWalletInput(e.target.value)}
+              placeholder="0x… (64 hex chars)"
+              spellCheck={false}
+              autoComplete="off"
+              aria-invalid={walletInput.length > 0 && !inputValid}
+              aria-describedby="wallet-help"
+              className="font-mono"
+            />
+            <Button type="submit" variant="primary" size="md" disabled={!inputValid}>
+              <Search aria-hidden="true" className="size-4" />
+              Look up
+            </Button>
+          </form>
 
-        {walletInput.length > 0 && !inputValid ? (
-          <p id="wallet-help" className="mt-2 font-mono text-xs text-rust">
-            Wallet must be 64 hex characters.
-          </p>
-        ) : null}
-      </section>
+          {walletInput.length > 0 && !inputValid ? (
+            <p id="wallet-help" className="mt-2 font-mono text-xs text-rust">
+              Wallet must be 64 hex characters.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
 
       {activeWallet ? (
-        <CredentialCard
-          wallet={activeWallet}
-          query={credentialQuery}
-          issueJurisdiction={issueJurisdiction}
-          onIssueJurisdictionChange={setIssueJurisdiction}
-          onIssue={onIssue}
-          onRevoke={onRevoke}
-          issuePending={issue.isPending}
-          revokePending={revoke.isPending}
-        />
+        <>
+          <Separator />
+          <CredentialCard
+            wallet={activeWallet}
+            query={credentialQuery}
+            issueJurisdiction={issueJurisdiction}
+            onIssueJurisdictionChange={setIssueJurisdiction}
+            onIssue={onIssue}
+            onRevoke={onRevoke}
+            issuePending={issue.isPending}
+            revokePending={revoke.isPending}
+          />
+        </>
       ) : null}
 
-      <section
-        aria-labelledby="recent-heading"
-        className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-      >
-        <div className="flex items-baseline justify-between">
-          <span
-            id="recent-heading"
-            className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-          >
-            Recent lookups (this browser)
-          </span>
-          <span className="font-mono text-xs text-muted">{recent.length} stored</span>
-        </div>
+      <Separator />
 
-        {recent.length === 0 ? (
-          <p className="mt-4 font-mono text-xs text-muted">
-            No lookups yet. The last 8 wallets you check will appear here.
-          </p>
-        ) : (
-          <ul className="mt-4 flex flex-col divide-y divide-border-subtle">
-            {recent.map((entry) => (
-              <li
-                key={entry.wallet}
-                className="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0"
-              >
-                <button
-                  type="button"
-                  onClick={() => pickRecent(entry.wallet)}
-                  className="flex flex-1 cursor-pointer items-center gap-3 text-left font-mono text-sm text-ink hover:text-forest focus-visible:rounded-[2px] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+      {/* ── Recent lookups ── */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-baseline justify-between">
+            <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+              Recent lookups (this browser)
+            </CardTitle>
+            <span className="font-mono text-xs text-muted">{recent.length} stored</span>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {recent.length === 0 ? (
+            <EmptyState
+              icon={Clock}
+              title="No lookups yet"
+              description="The last 8 wallets you check will appear here."
+              className="py-8"
+            />
+          ) : (
+            <ul className="flex flex-col divide-y divide-border-subtle">
+              {recent.map((entry) => (
+                <li
+                  key={entry.wallet}
+                  className={cn(
+                    "group/recent flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0",
+                    "rounded-[var(--radius-3)] transition-colors",
+                  )}
                 >
-                  <span>{truncateWallet(entry.wallet, 8, 8)}</span>
-                  <span className="font-mono text-[11px] text-muted">
-                    {new Date(entry.lastSeenAt).toLocaleString("en-US", {
-                      month: "short",
-                      day: "2-digit",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </span>
-                </button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  aria-label={`Forget ${entry.wallet}`}
-                  onClick={() => forgetWallet(entry.wallet)}
-                >
-                  <Xmark aria-hidden="true" className="size-4" />
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+                  <button
+                    type="button"
+                    onClick={() => pickRecent(entry.wallet)}
+                    className={cn(
+                      "flex flex-1 cursor-pointer items-center gap-3 text-left",
+                      "rounded-[var(--radius-2)] px-1 py-0.5 -ml-1",
+                      "text-ink transition-colors hover:bg-surface-deep hover:text-forest",
+                      "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest",
+                    )}
+                  >
+                    <TruncatedHash
+                      value={entry.wallet}
+                      head={8}
+                      tail={8}
+                      copyable={false}
+                      className="text-sm"
+                    />
+                    <span className="font-mono text-[11px] text-muted">
+                      {new Date(entry.lastSeenAt).toLocaleString("en-US", {
+                        month: "short",
+                        day: "2-digit",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Forget ${entry.wallet}`}
+                    onClick={() => forgetWallet(entry.wallet)}
+                    className="opacity-0 transition-opacity group-hover/recent:opacity-100 focus-visible:opacity-100"
+                  >
+                    <Xmark aria-hidden="true" className="size-4" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }
@@ -325,38 +359,39 @@ function CredentialCard({
   }, [errorInfo]);
 
   return (
-    <section
-      aria-labelledby="credential-heading"
-      className="rounded-[var(--radius-6)] border border-border-subtle bg-surface p-6"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <span
-            id="credential-heading"
-            className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase"
-          >
-            Credential
-          </span>
-          <p className="mt-1 font-mono text-sm text-ink break-all">{wallet}</p>
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <CardTitle className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">
+              Credential
+            </CardTitle>
+            <TruncatedHash
+              value={wallet}
+              head={10}
+              tail={10}
+              className="text-sm text-ink"
+            />
+          </div>
+          <CredentialStatus
+            loading={isLoading}
+            notFound={errorInfo?.kind === "not-found"}
+            credential={credential ?? null}
+            authError={errorInfo?.kind === "auth"}
+            otherError={errorInfo?.kind === "other"}
+          />
         </div>
-        <CredentialStatus
-          loading={isLoading}
-          notFound={errorInfo?.kind === "not-found"}
-          credential={credential ?? null}
-          authError={errorInfo?.kind === "auth"}
-          otherError={errorInfo?.kind === "other"}
-        />
-      </div>
+      </CardHeader>
 
-      {isLoading ? (
-        <p className="mt-4 font-mono text-xs text-stone">Loading credential…</p>
-      ) : null}
+      <CardContent>
+        {isLoading ? <CredentialSkeleton /> : null}
 
-      {credential ? (
-        <CredentialDetails credential={credential} />
-      ) : null}
+        {credential ? (
+          <CredentialDetails credential={credential} />
+        ) : null}
 
-      <div className="mt-6 border-t border-border-subtle pt-5">
+        <Separator className="my-5" />
+
         {credential && !credential.revoked ? (
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div>
@@ -365,15 +400,10 @@ function CredentialCard({
                 Zeros the wallet&apos;s leaf in the membership tree. Requires re-publish to take effect on-chain.
               </p>
             </div>
-            <Button
-              variant="ghost"
-              size="md"
-              onClick={onRevoke}
-              disabled={revokePending}
-            >
-              <Trash aria-hidden="true" className="size-4" />
-              {revokePending ? "Revoking…" : "Revoke"}
-            </Button>
+            <RevokeConfirmDialog
+              onConfirm={onRevoke}
+              revokePending={revokePending}
+            />
           </div>
         ) : null}
 
@@ -383,7 +413,7 @@ function CredentialCard({
             <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
               <label className="flex flex-col gap-1.5 sm:max-w-[200px]">
                 <span className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">
-                  Jurisdiction (ISO α-2)
+                  Jurisdiction (ISO alpha-2)
                 </span>
                 <Input
                   value={issueJurisdiction}
@@ -405,9 +435,70 @@ function CredentialCard({
             </div>
           </div>
         ) : null}
+      </CardContent>
+    </Card>
+  );
+}
 
-      </div>
-    </section>
+function RevokeConfirmDialog({
+  onConfirm,
+  revokePending,
+}: Readonly<{ onConfirm: () => void; revokePending: boolean }>) {
+  const [open, setOpen] = useState(false);
+
+  const handleConfirm = () => {
+    onConfirm();
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <Button variant="ghost" size="md" disabled={revokePending}>
+            <Trash aria-hidden="true" className="size-4" />
+            {revokePending ? "Revoking…" : "Revoke"}
+          </Button>
+        }
+      />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Revoke credential</DialogTitle>
+          <DialogDescription>
+            This will zero the wallet&apos;s leaf in the membership tree. The change requires a re-publish to take effect on-chain. This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose
+            render={<Button variant="ghost" />}
+          >
+            Cancel
+          </DialogClose>
+          <Button
+            variant="primary"
+            size="md"
+            onClick={handleConfirm}
+            disabled={revokePending}
+          >
+            <Trash aria-hidden="true" className="size-4" />
+            {revokePending ? "Revoking…" : "Yes, revoke"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CredentialSkeleton() {
+  return (
+    <div className="grid gap-y-3 sm:grid-cols-[140px_1fr]">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="contents">
+          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -436,21 +527,32 @@ function CredentialStatus({
 function CredentialDetails({ credential }: Readonly<{ credential: Credential }>) {
   const walletHex = bytesToHex(credential.wallet);
   return (
-    <dl className="mt-5 grid gap-y-3 sm:grid-cols-[140px_1fr]">
-      <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Wallet</dt>
-      <dd className="font-mono text-sm text-ink break-all">{walletHex}</dd>
+    <Card className="bg-surface-deep ring-0">
+      <CardContent className="pt-1">
+        <dl className="grid gap-y-3 sm:grid-cols-[140px_1fr]">
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Wallet</dt>
+          <dd>
+            <TruncatedHash
+              value={walletHex}
+              head={10}
+              tail={10}
+              className="text-sm text-ink"
+            />
+          </dd>
 
-      <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Leaf index</dt>
-      <dd className="font-mono text-sm text-ink">{credential.leaf_index}</dd>
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Leaf index</dt>
+          <dd className="font-mono text-sm text-ink">{credential.leaf_index}</dd>
 
-      <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Jurisdiction</dt>
-      <dd className="font-mono text-sm text-ink">{credential.jurisdiction}</dd>
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Jurisdiction</dt>
+          <dd className="font-mono text-sm text-ink">{credential.jurisdiction}</dd>
 
-      <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Issued at</dt>
-      <dd className="font-mono text-sm text-ink">{formatTimestamp(credential.issued_at)}</dd>
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Issued at</dt>
+          <dd className="font-mono text-sm text-ink">{formatTimestamp(credential.issued_at)}</dd>
 
-      <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Revoked</dt>
-      <dd className="font-mono text-sm text-ink">{credential.revoked ? "yes" : "no"}</dd>
-    </dl>
+          <dt className="font-mono text-[11px] tracking-[0.08em] text-muted uppercase">Revoked</dt>
+          <dd className="font-mono text-sm text-ink">{credential.revoked ? "yes" : "no"}</dd>
+        </dl>
+      </CardContent>
+    </Card>
   );
 }

--- a/frontend/src/components/dashboard/wallets-credentials-panel.tsx
+++ b/frontend/src/components/dashboard/wallets-credentials-panel.tsx
@@ -492,8 +492,8 @@ function RevokeConfirmDialog({
 function CredentialSkeleton() {
   return (
     <div className="grid gap-y-3 sm:grid-cols-[140px_1fr]">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="contents">
+      {(["issuer", "wallet", "status", "issued", "expires"] as const).map((field) => (
+        <div key={field} className="contents">
           <Skeleton className="h-4 w-20" />
           <Skeleton className="h-4 w-48" />
         </div>

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-3 right-3 inline-flex size-7 cursor-pointer items-center justify-center rounded-[var(--radius-3)] text-muted transition-colors hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
+          >
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t border-border-subtle bg-surface p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="ghost" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -8,26 +8,26 @@ import { Button } from "@/components/ui/button"
 import { XIcon } from "lucide-react"
 
 
-function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+function Dialog({ ...props }: Readonly<DialogPrimitive.Root.Props>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
-function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+function DialogTrigger({ ...props }: Readonly<DialogPrimitive.Trigger.Props>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
-function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+function DialogPortal({ ...props }: Readonly<DialogPrimitive.Portal.Props>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
-function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+function DialogClose({ ...props }: Readonly<DialogPrimitive.Close.Props>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
 function DialogOverlay({
   className,
   ...props
-}: DialogPrimitive.Backdrop.Props) {
+}: Readonly<DialogPrimitive.Backdrop.Props>) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
@@ -45,9 +45,9 @@ function DialogContent({
   children,
   showCloseButton = true,
   ...props
-}: DialogPrimitive.Popup.Props & {
+}: Readonly<DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
-}) {
+}>) {
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -74,7 +74,7 @@ function DialogContent({
   )
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: Readonly<React.ComponentProps<"div">>) {
   return (
     <div
       data-slot="dialog-header"
@@ -89,9 +89,9 @@ function DialogFooter({
   showCloseButton = false,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
+}: Readonly<React.ComponentProps<"div"> & {
   showCloseButton?: boolean
-}) {
+}>) {
   return (
     <div
       data-slot="dialog-footer"
@@ -111,7 +111,7 @@ function DialogFooter({
   )
 }
 
-function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+function DialogTitle({ className, ...props }: Readonly<DialogPrimitive.Title.Props>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
@@ -127,7 +127,7 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
 function DialogDescription({
   className,
   ...props
-}: DialogPrimitive.Description.Props) {
+}: Readonly<DialogPrimitive.Description.Props>) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -6,15 +6,15 @@ import { Menu as MenuPrimitive } from "@base-ui/react/menu"
 import { cn } from "@/lib/utils"
 import { ChevronRightIcon, CheckIcon } from "lucide-react"
 
-function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+function DropdownMenu({ ...props }: Readonly<MenuPrimitive.Root.Props>) {
   return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
 }
 
-function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+function DropdownMenuPortal({ ...props }: Readonly<MenuPrimitive.Portal.Props>) {
   return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
 }
 
-function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+function DropdownMenuTrigger({ ...props }: Readonly<MenuPrimitive.Trigger.Props>) {
   return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
 }
 
@@ -25,11 +25,11 @@ function DropdownMenuContent({
   sideOffset = 4,
   className,
   ...props
-}: MenuPrimitive.Popup.Props &
+}: Readonly<MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  >>) {
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
@@ -49,7 +49,7 @@ function DropdownMenuContent({
   )
 }
 
-function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+function DropdownMenuGroup({ ...props }: Readonly<MenuPrimitive.Group.Props>) {
   return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
 }
 
@@ -57,9 +57,9 @@ function DropdownMenuLabel({
   className,
   inset,
   ...props
-}: MenuPrimitive.GroupLabel.Props & {
+}: Readonly<MenuPrimitive.GroupLabel.Props & {
   inset?: boolean
-}) {
+}>) {
   return (
     <MenuPrimitive.GroupLabel
       data-slot="dropdown-menu-label"
@@ -78,10 +78,10 @@ function DropdownMenuItem({
   inset,
   variant = "default",
   ...props
-}: MenuPrimitive.Item.Props & {
+}: Readonly<MenuPrimitive.Item.Props & {
   inset?: boolean
   variant?: "default" | "destructive"
-}) {
+}>) {
   return (
     <MenuPrimitive.Item
       data-slot="dropdown-menu-item"
@@ -96,7 +96,7 @@ function DropdownMenuItem({
   )
 }
 
-function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+function DropdownMenuSub({ ...props }: Readonly<MenuPrimitive.SubmenuRoot.Props>) {
   return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
 }
 
@@ -105,9 +105,9 @@ function DropdownMenuSubTrigger({
   inset,
   children,
   ...props
-}: MenuPrimitive.SubmenuTrigger.Props & {
+}: Readonly<MenuPrimitive.SubmenuTrigger.Props & {
   inset?: boolean
-}) {
+}>) {
   return (
     <MenuPrimitive.SubmenuTrigger
       data-slot="dropdown-menu-sub-trigger"
@@ -131,7 +131,7 @@ function DropdownMenuSubContent({
   sideOffset = 0,
   className,
   ...props
-}: React.ComponentProps<typeof DropdownMenuContent>) {
+}: Readonly<React.ComponentProps<typeof DropdownMenuContent>>) {
   return (
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
@@ -151,9 +151,9 @@ function DropdownMenuCheckboxItem({
   checked,
   inset,
   ...props
-}: MenuPrimitive.CheckboxItem.Props & {
+}: Readonly<MenuPrimitive.CheckboxItem.Props & {
   inset?: boolean
-}) {
+}>) {
   return (
     <MenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
@@ -179,7 +179,7 @@ function DropdownMenuCheckboxItem({
   )
 }
 
-function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+function DropdownMenuRadioGroup({ ...props }: Readonly<MenuPrimitive.RadioGroup.Props>) {
   return (
     <MenuPrimitive.RadioGroup
       data-slot="dropdown-menu-radio-group"
@@ -193,9 +193,9 @@ function DropdownMenuRadioItem({
   children,
   inset,
   ...props
-}: MenuPrimitive.RadioItem.Props & {
+}: Readonly<MenuPrimitive.RadioItem.Props & {
   inset?: boolean
-}) {
+}>) {
   return (
     <MenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
@@ -223,7 +223,7 @@ function DropdownMenuRadioItem({
 function DropdownMenuSeparator({
   className,
   ...props
-}: MenuPrimitive.Separator.Props) {
+}: Readonly<MenuPrimitive.Separator.Props>) {
   return (
     <MenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
@@ -236,7 +236,7 @@ function DropdownMenuSeparator({
 function DropdownMenuShortcut({
   className,
   ...props
-}: React.ComponentProps<"span">) {
+}: Readonly<React.ComponentProps<"span">>) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -5,11 +5,11 @@ import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
 
 import { cn } from "@/lib/utils"
 
-function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+function Popover({ ...props }: Readonly<PopoverPrimitive.Root.Props>) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
-function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+function PopoverTrigger({ ...props }: Readonly<PopoverPrimitive.Trigger.Props>) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
@@ -20,11 +20,11 @@ function PopoverContent({
   side = "bottom",
   sideOffset = 4,
   ...props
-}: PopoverPrimitive.Popup.Props &
+}: Readonly<PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  >>) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
@@ -47,7 +47,7 @@ function PopoverContent({
   )
 }
 
-function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+function PopoverHeader({ className, ...props }: Readonly<React.ComponentProps<"div">>) {
   return (
     <div
       data-slot="popover-header"
@@ -57,7 +57,7 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+function PopoverTitle({ className, ...props }: Readonly<PopoverPrimitive.Title.Props>) {
   return (
     <PopoverPrimitive.Title
       data-slot="popover-title"
@@ -70,7 +70,7 @@ function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
 function PopoverDescription({
   className,
   ...props
-}: PopoverPrimitive.Description.Props) {
+}: Readonly<PopoverPrimitive.Description.Props>) {
   return (
     <PopoverPrimitive.Description
       data-slot="popover-description"

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -8,7 +8,7 @@ import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
 
 const Select = SelectPrimitive.Root
 
-function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+function SelectGroup({ className, ...props }: Readonly<SelectPrimitive.Group.Props>) {
   return (
     <SelectPrimitive.Group
       data-slot="select-group"
@@ -18,7 +18,7 @@ function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   )
 }
 
-function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+function SelectValue({ className, ...props }: Readonly<SelectPrimitive.Value.Props>) {
   return (
     <SelectPrimitive.Value
       data-slot="select-value"
@@ -33,9 +33,9 @@ function SelectTrigger({
   size = "default",
   children,
   ...props
-}: SelectPrimitive.Trigger.Props & {
+}: Readonly<SelectPrimitive.Trigger.Props & {
   size?: "sm" | "default"
-}) {
+}>) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
@@ -65,11 +65,11 @@ function SelectContent({
   alignOffset = 0,
   alignItemWithTrigger = true,
   ...props
-}: SelectPrimitive.Popup.Props &
+}: Readonly<SelectPrimitive.Popup.Props &
   Pick<
     SelectPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
-  >) {
+  >>) {
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Positioner
@@ -98,7 +98,7 @@ function SelectContent({
 function SelectLabel({
   className,
   ...props
-}: SelectPrimitive.GroupLabel.Props) {
+}: Readonly<SelectPrimitive.GroupLabel.Props>) {
   return (
     <SelectPrimitive.GroupLabel
       data-slot="select-label"
@@ -112,7 +112,7 @@ function SelectItem({
   className,
   children,
   ...props
-}: SelectPrimitive.Item.Props) {
+}: Readonly<SelectPrimitive.Item.Props>) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
@@ -139,7 +139,7 @@ function SelectItem({
 function SelectSeparator({
   className,
   ...props
-}: SelectPrimitive.Separator.Props) {
+}: Readonly<SelectPrimitive.Separator.Props>) {
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
@@ -152,7 +152,7 @@ function SelectSeparator({
 function SelectScrollUpButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+}: Readonly<React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>>) {
   return (
     <SelectPrimitive.ScrollUpArrow
       data-slot="select-scroll-up-button"
@@ -171,7 +171,7 @@ function SelectScrollUpButton({
 function SelectScrollDownButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+}: Readonly<React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>>) {
   return (
     <SelectPrimitive.ScrollDownArrow
       data-slot="select-scroll-down-button"

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,44 +1,201 @@
-import { forwardRef, type SelectHTMLAttributes } from "react";
+"use client"
 
-import { cn } from "@/lib/cn";
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
 
-export type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
 
-export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  ({ className, children, ...props }, ref) => (
-    <div className="relative inline-flex w-full">
-      <select
-        ref={ref}
-        className={cn(
-          "h-10 w-full appearance-none rounded-[var(--radius-2)] border border-border-subtle bg-canvas py-0 pr-9 pl-3 font-sans text-base text-ink",
-          "transition-colors duration-150 ease-[var(--ease-brand)]",
-          "hover:border-border",
-          "focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          className,
-        )}
-        {...props}
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
       >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
         {children}
-      </select>
-      <svg
-        aria-hidden="true"
-        focusable="false"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        fill="none"
-        className="pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 text-quill"
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
       >
-        <path
-          d="M4 6l4 4 4-4"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </div>
-  ),
-);
-Select.displayName = "Select";
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -8,7 +8,7 @@ function Separator({
   className,
   orientation = "horizontal",
   ...props
-}: SeparatorPrimitive.Props) {
+}: Readonly<SeparatorPrimitive.Props>) {
   return (
     <SeparatorPrimitive
       data-slot="separator"

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-surface-deep", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t border-border-subtle bg-surface font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b border-border-subtle transition-colors hover:bg-surface-deep",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 function TooltipProvider({
   delay = 0,
   ...props
-}: TooltipPrimitive.Provider.Props) {
+}: Readonly<TooltipPrimitive.Provider.Props>) {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
@@ -17,11 +17,11 @@ function TooltipProvider({
   )
 }
 
-function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+function Tooltip({ ...props }: Readonly<TooltipPrimitive.Root.Props>) {
   return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
 }
 
-function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+function TooltipTrigger({ ...props }: Readonly<TooltipPrimitive.Trigger.Props>) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
@@ -33,11 +33,11 @@ function TooltipContent({
   alignOffset = 0,
   children,
   ...props
-}: TooltipPrimitive.Popup.Props &
+}: Readonly<TooltipPrimitive.Popup.Props &
   Pick<
     TooltipPrimitive.Positioner.Props,
     "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  >>) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -224,7 +224,8 @@ async function runStepSubmit(
   const {
     checkIssuerExists, buildRegisterIssuerIx,
     checkHookPayloadExists, buildCloseHookPayloadIx,
-    buildInitHookPayloadIx, buildWriteChunkIx, buildFinalizeHookPayloadIx,
+    buildInitHookPayloadIx, buildResizeHookPayloadIx,
+    buildWriteChunkIx, buildFinalizeHookPayloadIx,
     CHUNK_SIZE,
   } = sdk;
 
@@ -239,7 +240,10 @@ async function runStepSubmit(
   };
 
   const sendSigned = async (signed: Transaction) => {
-    const sig = await connection.sendRawTransaction(signed.serialize(), { skipPreflight: true });
+    const sig = await connection.sendRawTransaction(signed.serialize(), {
+      skipPreflight: true,
+      maxRetries: 3,
+    });
     await confirmTx(sig);
     return sig;
   };
@@ -281,6 +285,18 @@ async function runStepSubmit(
 
   const initIx = await buildInitHookPayloadIx(publicKey, proofBytes.length, connection);
 
+  // Solana caps realloc at 10 KiB per instruction. Compute how many
+  // resize instructions are needed to grow from header-only to full size.
+  const BASE_SPACE = 293;
+  const headerSize = 8 + BASE_SPACE;
+  const targetSize = headerSize + proofBytes.length;
+  const resizeIxs = [];
+  let currentSize = headerSize;
+  while (currentSize < targetSize) {
+    resizeIxs.push(await buildResizeHookPayloadIx(publicKey, connection));
+    currentSize = Math.min(targetSize, currentSize + 10_240);
+  }
+
   const writeIxs = [];
   for (let offset = 0; offset < proofBytes.length; offset += chunkSize) {
     const chunk = proofBytes.slice(offset, Math.min(offset + chunkSize, proofBytes.length));
@@ -296,32 +312,61 @@ async function runStepSubmit(
     amount: new BN(transferParams.amount),
   }, connection);
 
-  // Assemble transactions
-  const txs: Transaction[] = [];
-  txs.push(new Transaction().add(initIx));
+  // ── Batch 1: init + resize (own blockhash + Phantom popup) ──
+  const initResizeTxs: Transaction[] = [];
+  const initTx = new Transaction().add(initIx);
+  if (resizeIxs.length > 0) initTx.add(resizeIxs[0]!);
+  initResizeTxs.push(initTx);
+  for (let i = 1; i < resizeIxs.length; i++) {
+    initResizeTxs.push(new Transaction().add(resizeIxs[i]!));
+  }
+
+  const bh1 = await connection.getLatestBlockhash("confirmed");
+  for (const tx of initResizeTxs) {
+    tx.feePayer = publicKey;
+    tx.recentBlockhash = bh1.blockhash;
+  }
+  const signedInitResize = await signAllTransactions(initResizeTxs);
+  for (const tx of signedInitResize) {
+    await sendSigned(tx!);
+  }
+
+  // ── Batch 2: writes only (fresh blockhash + Phantom popup) ──
+  const writeTxs: Transaction[] = [];
   for (let i = 0; i < writeIxs.length; i += writesPerTx) {
     const tx = new Transaction();
     for (const ix of writeIxs.slice(i, i + writesPerTx)) tx.add(ix);
-    txs.push(tx);
+    writeTxs.push(tx);
   }
-  txs.push(new Transaction().add(finalizeIx));
 
-  // Set feePayer and recentBlockhash on all
-  const { blockhash } = await connection.getLatestBlockhash("confirmed");
-  for (const tx of txs) {
+  const bh2 = await connection.getLatestBlockhash("confirmed");
+  for (const tx of writeTxs) {
     tx.feePayer = publicKey;
-    tx.recentBlockhash = blockhash;
+    tx.recentBlockhash = bh2.blockhash;
+  }
+  const signedWrites = await signAllTransactions(writeTxs);
+
+  // Send writes sequentially — the on-chain handler enforces that each
+  // chunk offset matches high_water_mark, so ordering must be preserved.
+  let lastWriteSig = "";
+  for (const tx of signedWrites) {
+    lastWriteSig = await connection.sendRawTransaction(tx!.serialize(), {
+      skipPreflight: true,
+      maxRetries: 5,
+    });
   }
 
-  // ── Single Phantom popup: sign ALL transactions at once ──
-  const signedTxs = await signAllTransactions(txs);
+  // Confirming the last write guarantees all prior writes landed (each
+  // write's offset must match the cumulative high_water_mark).
+  if (lastWriteSig) await confirmTx(lastWriteSig);
 
-  // ── Send sequentially with confirmation between each ──
-  let finalSig = "";
-  for (let i = 0; i < signedTxs.length; i++) {
-    const sig = await sendSigned(signedTxs[i]!);
-    if (i === signedTxs.length - 1) finalSig = sig;
-  }
+  // ── Batch 3: finalize (own fresh blockhash + Phantom popup) ──
+  const finalizeTx = new Transaction().add(finalizeIx);
+  const bh3 = await connection.getLatestBlockhash("confirmed");
+  finalizeTx.feePayer = publicKey;
+  finalizeTx.recentBlockhash = bh3.blockhash;
+  const [signedFinalize] = await signAllTransactions([finalizeTx]);
+  const finalSig = await sendSigned(signedFinalize!);
 
   dispatch({ type: "SET_TX", signature: finalSig });
   dispatch({
@@ -378,12 +423,13 @@ function handleCredentialError(dispatch: Dispatch<FlowAction>, err: unknown): vo
 
 function handleSubmitError(dispatch: Dispatch<FlowAction>, err: unknown): void {
   console.error("[zksettle] Submit step error:", err);
+  try { console.error("[zksettle] Error JSON:", JSON.stringify(err, Object.getOwnPropertyNames(err as object))); } catch { /* */ }
   const errRecord = err as Record<string, unknown>;
   const inner = errRecord?.error;
   if (inner) console.error("[zksettle] Inner error:", inner);
   const logs = (errRecord?.logs ?? (inner as Record<string, unknown>)?.logs) as string[] | undefined;
   if (logs) console.error("[zksettle] Transaction logs:", logs);
-  const message = err instanceof Error ? err.message : "Transaction failed";
+  const message = err instanceof Error ? err.message : String(errRecord?.message ?? "Transaction failed");
   const isRejected = message.includes("rejected") || message.includes("User rejected");
   dispatch({ type: "STEP_ERROR", step: 4, error: isRejected ? "Transaction rejected by wallet." : message });
 }

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -369,17 +369,30 @@ interface LiveFlowContext {
   transferParams: TransferParams;
 }
 
+function handleCredentialError(dispatch: Dispatch<FlowAction>, err: unknown): void {
+  const msg = stepError(dispatch, 1, err, "Failed to fetch credential");
+  if (msg.includes("404")) {
+    dispatch({ type: "STEP_ERROR", step: 1, error: "No credential found for this wallet. Issue one from the Wallets & Credentials page, or try demo mode." });
+  }
+}
+
+function handleSubmitError(dispatch: Dispatch<FlowAction>, err: unknown): void {
+  console.error("[zksettle] Submit step error:", err);
+  const errRecord = err as Record<string, unknown>;
+  const inner = errRecord?.error;
+  if (inner) console.error("[zksettle] Inner error:", inner);
+  const logs = (errRecord?.logs ?? (inner as Record<string, unknown>)?.logs) as string[] | undefined;
+  if (logs) console.error("[zksettle] Transaction logs:", logs);
+  const message = err instanceof Error ? err.message : "Transaction failed";
+  const isRejected = message.includes("rejected") || message.includes("User rejected");
+  dispatch({ type: "STEP_ERROR", step: 4, error: isRejected ? "Transaction rejected by wallet." : message });
+}
+
 async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
   const { dispatch, walletHex, publicKey, connection, signAllTransactions, generate, ensureApi, derivePrivateKey, transferParams } = ctx;
   let credential;
   try { credential = await runStepCredential(dispatch, walletHex); }
-  catch (err) {
-    const msg = stepError(dispatch, 1, err, "Failed to fetch credential");
-    if (msg.includes("404")) {
-      dispatch({ type: "STEP_ERROR", step: 1, error: "No credential found for this wallet. Issue one from the Wallets & Credentials page, or try demo mode." });
-    }
-    return;
-  }
+  catch (err) { handleCredentialError(dispatch, err); return; }
 
   let paths;
   try { paths = await runStepMerklePaths(dispatch, walletHex, derivePrivateKey); }
@@ -393,15 +406,7 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
   try {
     txSignature = await runStepSubmit(dispatch, step3Result.proofResult, publicKey, connection, signAllTransactions, { ...step3Result, roots: paths.roots }, transferParams);
   } catch (err) {
-    console.error("[zksettle] Submit step error:", err);
-    const errRecord = err as Record<string, unknown>;
-    const inner = errRecord?.error;
-    if (inner) console.error("[zksettle] Inner error:", inner);
-    const logs = (errRecord?.logs ?? (inner as Record<string, unknown>)?.logs) as string[] | undefined;
-    if (logs) console.error("[zksettle] Transaction logs:", logs);
-    const message = err instanceof Error ? err.message : "Transaction failed";
-    const isRejected = message.includes("rejected") || message.includes("User rejected");
-    dispatch({ type: "STEP_ERROR", step: 4, error: isRejected ? "Transaction rejected by wallet." : message });
+    handleSubmitError(dispatch, err);
     return;
   }
 

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -258,7 +258,7 @@ async function runStepSubmit(
     tx.feePayer = publicKey;
     tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed);
+    await sendSigned(signed!);
   }
 
   const stalePayload = await checkHookPayloadExists(publicKey, connection);
@@ -268,7 +268,7 @@ async function runStepSubmit(
     tx.feePayer = publicKey;
     tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed);
+    await sendSigned(signed!);
   }
 
   // ── Build ALL proof upload transactions upfront ──
@@ -319,7 +319,7 @@ async function runStepSubmit(
   // ── Send sequentially with confirmation between each ──
   let finalSig = "";
   for (let i = 0; i < signedTxs.length; i++) {
-    const sig = await sendSigned(signedTxs[i]);
+    const sig = await sendSigned(signedTxs[i]!);
     if (i === signedTxs.length - 1) finalSig = sig;
   }
 
@@ -394,9 +394,10 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
     txSignature = await runStepSubmit(dispatch, step3Result.proofResult, publicKey, connection, signAllTransactions, { ...step3Result, roots: paths.roots }, transferParams);
   } catch (err) {
     console.error("[zksettle] Submit step error:", err);
-    const inner = (err as any)?.error;
+    const errRecord = err as Record<string, unknown>;
+    const inner = errRecord?.error;
     if (inner) console.error("[zksettle] Inner error:", inner);
-    const logs = (err as any)?.logs ?? (inner as any)?.logs;
+    const logs = (errRecord?.logs ?? (inner as Record<string, unknown>)?.logs) as string[] | undefined;
     if (logs) console.error("[zksettle] Transaction logs:", logs);
     const message = err instanceof Error ? err.message : "Transaction failed";
     const isRejected = message.includes("rejected") || message.includes("User rejected");

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useReducer, type Dispatch } from "react";
+import { useCallback, useReducer, useRef, type Dispatch } from "react";
 import type { Connection, PublicKey, Transaction } from "@solana/web3.js";
 
 import { useWallet, useConnection } from "@/hooks/use-wallet-connection";
@@ -204,7 +204,7 @@ async function runStepSubmit(
   proofResult: ProofResult,
   publicKey: PublicKey,
   connection: Connection,
-  sendTransaction: (tx: Transaction, conn: Connection) => Promise<string>,
+  signAllTransactions: (txs: Transaction[]) => Promise<Transaction[]>,
   submitCtx: {
     zkPrivateKey: string;
     credentialExpiry: string;
@@ -221,7 +221,12 @@ async function runStepSubmit(
     import("@coral-xyz/anchor"),
     import("@solana/web3.js"),
   ]);
-  const { uploadProofChunked, checkIssuerExists, buildRegisterIssuerIx, checkHookPayloadExists, buildCloseHookPayloadIx } = sdk;
+  const {
+    checkIssuerExists, buildRegisterIssuerIx,
+    checkHookPayloadExists, buildCloseHookPayloadIx,
+    buildInitHookPayloadIx, buildWriteChunkIx, buildFinalizeHookPayloadIx,
+    CHUNK_SIZE,
+  } = sdk;
 
   const hexToBytes = (hex: string): Uint8Array => {
     const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
@@ -229,70 +234,103 @@ async function runStepSubmit(
   };
 
   const confirmTx = async (sig: string) => {
-    const bh = await connection.getLatestBlockhash("confirmed");
-    await connection.confirmTransaction({ signature: sig, ...bh }, "confirmed");
+    const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
+    await connection.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
   };
 
+  const sendSigned = async (signed: Transaction) => {
+    const sig = await connection.sendRawTransaction(signed.serialize(), { skipPreflight: true });
+    await confirmTx(sig);
+    return sig;
+  };
+
+  // ── Pre-requisites (issuer registration, stale cleanup) ──
+  // These need separate signing since they must complete before the proof upload.
   const issuerExists = await checkIssuerExists(publicKey, connection);
   if (!issuerExists) {
     const roots = submitCtx.roots;
-    const ix = await buildRegisterIssuerIx(
-      publicKey,
-      {
-        merkleRoot: hexToBytes(roots.membership_root),
-        sanctionsRoot: hexToBytes(roots.sanctions_root),
-        jurisdictionRoot: hexToBytes(roots.jurisdiction_root),
-      },
-      connection,
-    );
-    const sig = await sendTransaction(new Transaction().add(ix), connection);
-    await confirmTx(sig);
+    const ix = await buildRegisterIssuerIx(publicKey, {
+      merkleRoot: hexToBytes(roots.membership_root),
+      sanctionsRoot: hexToBytes(roots.sanctions_root),
+      jurisdictionRoot: hexToBytes(roots.jurisdiction_root),
+    }, connection);
+    const tx = new Transaction().add(ix);
+    tx.feePayer = publicKey;
+    tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
+    const [signed] = await signAllTransactions([tx]);
+    await sendSigned(signed);
   }
 
   const stalePayload = await checkHookPayloadExists(publicKey, connection);
   if (stalePayload) {
-    const closeIx = await buildCloseHookPayloadIx(publicKey, connection);
-    const sig = await sendTransaction(new Transaction().add(closeIx), connection);
-    await confirmTx(sig);
+    const ix = await buildCloseHookPayloadIx(publicKey, connection);
+    const tx = new Transaction().add(ix);
+    tx.feePayer = publicKey;
+    tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
+    const [signed] = await signAllTransactions([tx]);
+    await sendSigned(signed);
   }
 
-  const nullifierHex = proofResult.publicInputs[1] ?? "";
-  const nullifierBytes = hexToBytes(nullifierHex);
-
+  // ── Build ALL proof upload transactions upfront ──
+  const proofBytes = proofResult.proof;
+  const nullifierBytes = hexToBytes(proofResult.publicInputs[1] ?? "");
   const mintPubkey = new SolPublicKey(transferParams.mint);
   const recipientPubkey = new SolPublicKey(transferParams.recipient);
+  const chunkSize = CHUNK_SIZE;
+  const writesPerTx = 2;
 
-  const result = await uploadProofChunked(
-    {
-      connection,
-      wallet: publicKey,
-      proof: proofResult.proof,
-      nullifierHash: nullifierBytes,
-      transferContext: {
-        mint: mintPubkey,
-        recipient: recipientPubkey,
-        amount: new BN(transferParams.amount),
-        epoch: Math.floor(Date.now() / 1000 / 86400),
-        privateKey: submitCtx.zkPrivateKey,
-        credentialExpiry: submitCtx.credentialExpiry,
-        jurisdictionPath: submitCtx.jurisdictionProof.path.map((h) =>
-          h.startsWith("0x") ? h : `0x${h}`,
-        ),
-        jurisdictionPathIndices: submitCtx.jurisdictionProof.path_indices,
-      },
-    },
-    (tx) => sendTransaction(tx, connection),
-  );
+  const initIx = await buildInitHookPayloadIx(publicKey, proofBytes.length, connection);
 
-  const signature = result.finalizeSignature;
-  dispatch({ type: "SET_TX", signature });
+  const writeIxs = [];
+  for (let offset = 0; offset < proofBytes.length; offset += chunkSize) {
+    const chunk = proofBytes.slice(offset, Math.min(offset + chunkSize, proofBytes.length));
+    writeIxs.push(await buildWriteChunkIx(publicKey, offset, chunk, connection));
+  }
+
+  const epoch = Math.floor(Date.now() / 1000 / 86400);
+  const finalizeIx = await buildFinalizeHookPayloadIx(publicKey, {
+    nullifierHash: nullifierBytes,
+    mint: mintPubkey,
+    epoch,
+    recipient: recipientPubkey,
+    amount: new BN(transferParams.amount),
+  }, connection);
+
+  // Assemble transactions
+  const txs: Transaction[] = [];
+  txs.push(new Transaction().add(initIx));
+  for (let i = 0; i < writeIxs.length; i += writesPerTx) {
+    const tx = new Transaction();
+    for (const ix of writeIxs.slice(i, i + writesPerTx)) tx.add(ix);
+    txs.push(tx);
+  }
+  txs.push(new Transaction().add(finalizeIx));
+
+  // Set feePayer and recentBlockhash on all
+  const { blockhash } = await connection.getLatestBlockhash("confirmed");
+  for (const tx of txs) {
+    tx.feePayer = publicKey;
+    tx.recentBlockhash = blockhash;
+  }
+
+  // ── Single Phantom popup: sign ALL transactions at once ──
+  const signedTxs = await signAllTransactions(txs);
+
+  // ── Send sequentially with confirmation between each ──
+  let finalSig = "";
+  for (let i = 0; i < signedTxs.length; i++) {
+    const sig = await sendSigned(signedTxs[i]);
+    if (i === signedTxs.length - 1) finalSig = sig;
+  }
+
+  dispatch({ type: "SET_TX", signature: finalSig });
   dispatch({
     type: "STEP_SUCCESS",
     step: 4,
-    data: { signature },
+    data: { signature: finalSig },
     durationMs: performance.now() - start,
   });
-  return signature;
+  return finalSig;
 }
 
 async function runStepConfirm(
@@ -324,7 +362,7 @@ interface LiveFlowContext {
   walletHex: string;
   publicKey: PublicKey;
   connection: Connection;
-  sendTransaction: (tx: Transaction, conn: Connection) => Promise<string>;
+  signAllTransactions: (txs: Transaction[]) => Promise<Transaction[]>;
   generate: (inputs: ProofInputs) => Promise<ProofResult>;
   ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>;
   derivePrivateKey: () => Promise<string>;
@@ -332,7 +370,7 @@ interface LiveFlowContext {
 }
 
 async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
-  const { dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey, transferParams } = ctx;
+  const { dispatch, walletHex, publicKey, connection, signAllTransactions, generate, ensureApi, derivePrivateKey, transferParams } = ctx;
   let credential;
   try { credential = await runStepCredential(dispatch, walletHex); }
   catch (err) {
@@ -353,8 +391,13 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
 
   let txSignature: string | undefined;
   try {
-    txSignature = await runStepSubmit(dispatch, step3Result.proofResult, publicKey, connection, sendTransaction, { ...step3Result, roots: paths.roots }, transferParams);
+    txSignature = await runStepSubmit(dispatch, step3Result.proofResult, publicKey, connection, signAllTransactions, { ...step3Result, roots: paths.roots }, transferParams);
   } catch (err) {
+    console.error("[zksettle] Submit step error:", err);
+    const inner = (err as any)?.error;
+    if (inner) console.error("[zksettle] Inner error:", inner);
+    const logs = (err as any)?.logs ?? (inner as any)?.logs;
+    if (logs) console.error("[zksettle] Transaction logs:", logs);
     const message = err instanceof Error ? err.message : "Transaction failed";
     const isRejected = message.includes("rejected") || message.includes("User rejected");
     dispatch({ type: "STEP_ERROR", step: 4, error: isRejected ? "Transaction rejected by wallet." : message });
@@ -372,7 +415,7 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
 
 export function useProveFlow(): UseProveFlowReturn {
   const [state, dispatch] = useReducer(flowReducer, INITIAL_STATE);
-  const { connected, publicKey, sendTransaction } = useWallet();
+  const { connected, publicKey, signAllTransactions } = useWallet();
   const { connection } = useConnection();
 
   const walletHex = publicKey
@@ -382,6 +425,7 @@ export function useProveFlow(): UseProveFlowReturn {
   const { generate, ensureApi } = useProofGeneration();
   const { derivePrivateKey } = useZkPrivateKey();
 
+  const runningRef = useRef(false);
   const isRunning = state.steps.some((s) => s.status === "running");
   const isDone = state.steps.at(-1)?.status === "success";
   const txUrl = state.txSignature
@@ -390,6 +434,9 @@ export function useProveFlow(): UseProveFlowReturn {
 
   const runFlow = useCallback(
     async (mode: "live" | "demo", params?: TransferParams) => {
+      if (runningRef.current) return;
+      runningRef.current = true;
+      try {
       dispatch({ type: "START_FLOW", mode });
 
       dispatch({ type: "STEP_RUNNING", step: 0 });
@@ -410,9 +457,15 @@ export function useProveFlow(): UseProveFlowReturn {
         return;
       }
 
-      await runLiveFlow({ dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey, transferParams: params });
+      if (!signAllTransactions) {
+        dispatch({ type: "STEP_ERROR", step: 1, error: "Wallet does not support batch transaction signing." });
+        return;
+      }
+
+      await runLiveFlow({ dispatch, walletHex, publicKey, connection, signAllTransactions, generate, ensureApi, derivePrivateKey, transferParams: params });
+      } finally { runningRef.current = false; }
     },
-    [connected, publicKey, walletHex, connection, sendTransaction, generate, ensureApi, derivePrivateKey],
+    [connected, publicKey, walletHex, connection, signAllTransactions, generate, ensureApi, derivePrivateKey],
   );
 
   const startFlow = useCallback((params: TransferParams) => runFlow("live", params), [runFlow]);

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -25,9 +25,15 @@ import {
 } from "@/lib/prove-flow";
 import type { ProofInputs, ProofResult } from "@/types/proof";
 
+export interface TransferParams {
+  mint: string;
+  recipient: string;
+  amount: number;
+}
+
 export interface UseProveFlowReturn {
   state: FlowState;
-  startFlow: () => Promise<void>;
+  startFlow: (params: TransferParams) => Promise<void>;
   startDemo: () => Promise<void>;
   reset: () => void;
   canStart: boolean;
@@ -133,17 +139,21 @@ async function runStepProofGeneration(
   paths: Awaited<ReturnType<typeof runStepMerklePaths>>,
   ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>,
   generate: (inputs: ProofInputs) => Promise<ProofResult>,
+  transferParams: TransferParams,
 ) {
   dispatch({ type: "STEP_RUNNING", step: 3 });
   const { membership, sanctions, roots, jurisdictionProof, zkPrivateKey } = paths;
-  const mintBytes = publicKey.toBytes();
-  const recipientBytes = publicKey.toBytes();
+  const { PublicKey: SolPublicKey } = await import("@solana/web3.js");
+  const mintPubkey = new SolPublicKey(transferParams.mint);
+  const recipientPubkey = new SolPublicKey(transferParams.recipient);
+  const mintBytes = mintPubkey.toBytes();
+  const recipientBytes = recipientPubkey.toBytes();
   const mintLo = toHex(mintBytes.slice(0, 16));
   const mintHi = toHex(mintBytes.slice(16, 32));
   const recipientLo = toHex(recipientBytes.slice(0, 16));
   const recipientHi = toHex(recipientBytes.slice(16, 32));
   const epoch = String(Math.floor(Date.now() / 1000 / 86400));
-  const amount = "1000";
+  const amount = String(transferParams.amount);
   const timestamp = String(Math.floor(Date.now() / 1000));
   const credentialExpiry = String(credential.issued_at + CREDENTIAL_VALIDITY_SECS);
 
@@ -195,21 +205,48 @@ async function runStepSubmit(
   publicKey: PublicKey,
   connection: Connection,
   sendTransaction: (tx: Transaction, conn: Connection) => Promise<string>,
-  submitCtx: { zkPrivateKey: string; credentialExpiry: string; jurisdictionProof: { path: string[]; path_indices: number[] } },
+  submitCtx: {
+    zkPrivateKey: string;
+    credentialExpiry: string;
+    jurisdictionProof: { path: string[]; path_indices: number[] };
+    roots: import("@/lib/api/schemas").Roots;
+  },
+  transferParams: TransferParams,
 ): Promise<string | undefined> {
   dispatch({ type: "STEP_RUNNING", step: 4 });
 
   const start = performance.now();
-  const [{ uploadProofChunked }, { BN }] = await Promise.all([
+  const [{ uploadProofChunked, checkIssuerExists, buildRegisterIssuerIx }, { BN }, { PublicKey: SolPublicKey, Transaction }] = await Promise.all([
     import("@zksettle/sdk"),
     import("@coral-xyz/anchor"),
+    import("@solana/web3.js"),
   ]);
 
+  const hexToBytes = (hex: string): Uint8Array => {
+    const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+    return new Uint8Array(clean.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []);
+  };
+
+  const issuerExists = await checkIssuerExists(publicKey, connection);
+  if (!issuerExists) {
+    const roots = submitCtx.roots;
+    const ix = await buildRegisterIssuerIx(
+      publicKey,
+      {
+        merkleRoot: hexToBytes(roots.membership_root),
+        sanctionsRoot: hexToBytes(roots.sanctions_root),
+        jurisdictionRoot: hexToBytes(roots.jurisdiction_root),
+      },
+      connection,
+    );
+    await sendTransaction(new Transaction().add(ix), connection);
+  }
+
   const nullifierHex = proofResult.publicInputs[1] ?? "";
-  const cleanHex = nullifierHex.startsWith("0x") ? nullifierHex.slice(2) : nullifierHex;
-  const nullifierBytes = new Uint8Array(
-    cleanHex.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? [],
-  );
+  const nullifierBytes = hexToBytes(nullifierHex);
+
+  const mintPubkey = new SolPublicKey(transferParams.mint);
+  const recipientPubkey = new SolPublicKey(transferParams.recipient);
 
   const result = await uploadProofChunked(
     {
@@ -218,9 +255,9 @@ async function runStepSubmit(
       proof: proofResult.proof,
       nullifierHash: nullifierBytes,
       transferContext: {
-        mint: publicKey,
-        recipient: publicKey,
-        amount: new BN(1000),
+        mint: mintPubkey,
+        recipient: recipientPubkey,
+        amount: new BN(transferParams.amount),
         epoch: Math.floor(Date.now() / 1000 / 86400),
         privateKey: submitCtx.zkPrivateKey,
         credentialExpiry: submitCtx.credentialExpiry,
@@ -277,10 +314,11 @@ interface LiveFlowContext {
   generate: (inputs: ProofInputs) => Promise<ProofResult>;
   ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>;
   derivePrivateKey: () => Promise<string>;
+  transferParams: TransferParams;
 }
 
 async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
-  const { dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey } = ctx;
+  const { dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey, transferParams } = ctx;
   let credential;
   try { credential = await runStepCredential(dispatch, walletHex); }
   catch (err) {
@@ -296,12 +334,12 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
   catch (err) { stepError(dispatch, 2, err, "Failed to fetch Merkle paths"); return; }
 
   let step3Result;
-  try { step3Result = await runStepProofGeneration(dispatch, publicKey, credential, paths, ensureApi, generate); }
+  try { step3Result = await runStepProofGeneration(dispatch, publicKey, credential, paths, ensureApi, generate, transferParams); }
   catch (err) { stepError(dispatch, 3, err, "Proof generation failed"); return; }
 
   let txSignature: string | undefined;
   try {
-    txSignature = await runStepSubmit(dispatch, step3Result.proofResult, publicKey, connection, sendTransaction, step3Result);
+    txSignature = await runStepSubmit(dispatch, step3Result.proofResult, publicKey, connection, sendTransaction, { ...step3Result, roots: paths.roots }, transferParams);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Transaction failed";
     const isRejected = message.includes("rejected") || message.includes("User rejected");
@@ -337,7 +375,7 @@ export function useProveFlow(): UseProveFlowReturn {
     : null;
 
   const runFlow = useCallback(
-    async (mode: "live" | "demo") => {
+    async (mode: "live" | "demo", params?: TransferParams) => {
       dispatch({ type: "START_FLOW", mode });
 
       dispatch({ type: "STEP_RUNNING", step: 0 });
@@ -353,17 +391,17 @@ export function useProveFlow(): UseProveFlowReturn {
         return;
       }
 
-      if (!walletHex) {
+      if (!walletHex || !params) {
         dispatch({ type: "STEP_ERROR", step: 1, error: "Wallet not resolved." });
         return;
       }
 
-      await runLiveFlow({ dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey });
+      await runLiveFlow({ dispatch, walletHex, publicKey, connection, sendTransaction, generate, ensureApi, derivePrivateKey, transferParams: params });
     },
     [connected, publicKey, walletHex, connection, sendTransaction, generate, ensureApi, derivePrivateKey],
   );
 
-  const startFlow = useCallback(() => runFlow("live"), [runFlow]);
+  const startFlow = useCallback((params: TransferParams) => runFlow("live", params), [runFlow]);
   const startDemo = useCallback(() => runFlow("demo"), [runFlow]);
   const reset = useCallback(() => dispatch({ type: "RESET" }), []);
 

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -216,15 +216,21 @@ async function runStepSubmit(
   dispatch({ type: "STEP_RUNNING", step: 4 });
 
   const start = performance.now();
-  const [{ uploadProofChunked, checkIssuerExists, buildRegisterIssuerIx }, { BN }, { PublicKey: SolPublicKey, Transaction }] = await Promise.all([
+  const [sdk, { BN }, { PublicKey: SolPublicKey, Transaction }] = await Promise.all([
     import("@zksettle/sdk"),
     import("@coral-xyz/anchor"),
     import("@solana/web3.js"),
   ]);
+  const { uploadProofChunked, checkIssuerExists, buildRegisterIssuerIx, checkHookPayloadExists, buildCloseHookPayloadIx } = sdk;
 
   const hexToBytes = (hex: string): Uint8Array => {
     const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
     return new Uint8Array(clean.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []);
+  };
+
+  const confirmTx = async (sig: string) => {
+    const bh = await connection.getLatestBlockhash("confirmed");
+    await connection.confirmTransaction({ signature: sig, ...bh }, "confirmed");
   };
 
   const issuerExists = await checkIssuerExists(publicKey, connection);
@@ -239,7 +245,15 @@ async function runStepSubmit(
       },
       connection,
     );
-    await sendTransaction(new Transaction().add(ix), connection);
+    const sig = await sendTransaction(new Transaction().add(ix), connection);
+    await confirmTx(sig);
+  }
+
+  const stalePayload = await checkHookPayloadExists(publicKey, connection);
+  if (stalePayload) {
+    const closeIx = await buildCloseHookPayloadIx(publicKey, connection);
+    const sig = await sendTransaction(new Transaction().add(closeIx), connection);
+    await confirmTx(sig);
   }
 
   const nullifierHex = proofResult.publicInputs[1] ?? "";

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@aztec/bb.js':
         specifier: 3.0.0-nightly.20260102
         version: 3.0.0-nightly.20260102
+      '@base-ui/react':
+        specifier: ^1.4.1
+        version: 1.4.1(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@coral-xyz/anchor':
         specifier: ^0.31.1
         version: 0.31.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
@@ -70,6 +73,9 @@ importers:
       lenis:
         specifier: ^1.3.23
         version: 1.3.23(react@19.0.0)
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@19.0.0)
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -82,6 +88,9 @@ importers:
       react-dom:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
+      shadcn:
+        specifier: ^4.7.0
+        version: 4.7.0(@types/node@22.19.17)(typescript@5.9.3)
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -94,6 +103,9 @@ importers:
       three:
         specifier: ^0.184.0
         version: 0.184.0
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       zod:
         specifier: ^4.3.6
         version: 4.4.3
@@ -160,7 +172,7 @@ importers:
         version: 8.59.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^2
-        version: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.2)
+        version: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.14.5(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)
 
   sdk:
     dependencies:
@@ -194,7 +206,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@25.6.0)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.2)
+        version: 2.1.9(@types/node@25.6.0)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.14.5(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.2)
 
 packages:
 
@@ -241,12 +253,26 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-create-class-features-plugin@7.29.3':
+    resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -258,6 +284,24 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -280,6 +324,36 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.28.5':
+    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
@@ -295,6 +369,33 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.4.1':
+    resolution: {integrity: sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.8':
+    resolution: {integrity: sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -355,6 +456,16 @@ packages:
 
   '@dimforge/rapier3d-compat@0.12.0':
     resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
+
+  '@dotenvx/dotenvx@1.65.0':
+    resolution: {integrity: sha512-v4FA/Lw3pTEloLxBqTOaYDX6MNo0Jo7lGBsPZhwnJBqRJp0AzQg1ZZNxrFsh6HVC6QWeWrfIKLn0y2eyIXaVDg==}
+    hasBin: true
+
+  '@ecies/ciphers@0.2.6':
+    resolution: {integrity: sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==}
+    engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
+    peerDependencies:
+      '@noble/ciphers': ^1.0.0
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -550,11 +661,32 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@gsap/react@2.1.2':
     resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
     peerDependencies:
       gsap: ^3.12.5
       react: '>=17'
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -713,6 +845,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.12':
+    resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.9':
+    resolution: {integrity: sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -752,6 +919,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -781,6 +958,10 @@ packages:
     resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
     cpu: [x64]
     os: [win32]
+
+  '@mswjs/interceptors@0.41.8':
+    resolution: {integrity: sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -839,6 +1020,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
@@ -874,6 +1059,18 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1079,6 +1276,9 @@ packages:
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
@@ -1112,6 +1312,10 @@ packages:
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.8':
     resolution: {integrity: sha512-W9DbsFvl5lSOe7KT3dJX4tjbxfYIoOtOTJpvLMgkojyRU0UKChQ4vHvbOZQ3GkUJ8wOIS4qdrM0Yytd1Vy+YQQ==}
@@ -1465,6 +1669,9 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@ts-morph/common@0.27.0':
+    resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
@@ -1521,8 +1728,14 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/three@0.184.0':
     resolution: {integrity: sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==}
@@ -1532,6 +1745,9 @@ packages:
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/validate-npm-package-name@4.0.2':
+    resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
@@ -1799,8 +2015,19 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
@@ -1877,6 +2104,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -1936,6 +2167,10 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
@@ -1983,6 +2218,14 @@ packages:
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -2058,6 +2301,18 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2072,6 +2327,9 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2084,6 +2342,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -2107,8 +2369,41 @@ packages:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -2121,11 +2416,20 @@ packages:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2175,6 +2479,14 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  dedent@1.7.2:
+    resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -2182,9 +2494,25 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -2213,6 +2541,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
@@ -2223,6 +2555,10 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -2230,11 +2566,18 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  eciesjs@0.4.18:
+    resolution: {integrity: sha512-wG99Zcfcys9fZux7Cft8BAX/YrOJLJSZ3jyYPfhZHqN2E+Ffx+QXBDsv3gubEgPtV6dTzJMSQUwk1H98/t/0wQ==}
+    engines: {bun: '>=1', deno: '>=2', node: '>=16'}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2257,6 +2600,13 @@ packages:
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -2422,6 +2772,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -2455,12 +2810,38 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.1:
+    resolution: {integrity: sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   eyes@0.1.8:
     resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
@@ -2473,6 +2854,10 @@ packages:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2481,6 +2866,18 @@ packages:
 
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
@@ -2505,8 +2902,16 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2522,6 +2927,10 @@ packages:
   finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
     engines: {node: '>= 0.8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2549,6 +2958,14 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
@@ -2566,6 +2983,14 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2587,6 +3012,9 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  fuzzysort@3.1.0:
+    resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
+
   geist@1.7.0:
     resolution: {integrity: sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==}
     peerDependencies:
@@ -2604,13 +3032,29 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
+  get-own-enumerable-keys@1.0.0:
+    resolution: {integrity: sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==}
+    engines: {node: '>=14.16'}
+
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -2646,6 +3090,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql@16.14.0:
+    resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gsap@3.15.0:
     resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
@@ -2683,6 +3131,9 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
   hermes-compiler@250829098.0.10:
     resolution: {integrity: sha512-TcRlZ0/TlyfJqquRFAWoyElVNnkdYRi/sEp4/Qy8/GYxjg8j2cS9D4MjuaQ+qimkmLN7AmO+44IznRf06mAr0w==}
 
@@ -2697,6 +3148,10 @@ packages:
 
   hermes-parser@0.35.0:
     resolution: {integrity: sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==}
+
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -2716,6 +3171,14 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
@@ -2726,6 +3189,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   idb-keyval@6.2.2:
@@ -2765,9 +3232,20 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -2805,6 +3283,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2825,6 +3308,19 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -2832,6 +3328,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2841,16 +3340,31 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-obj@3.0.0:
+    resolution: {integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==}
+    engines: {node: '>=12'}
+
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
+
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
 
   is-set@2.0.3:
     resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
@@ -2859,6 +3373,14 @@ packages:
   is-shared-array-buffer@1.0.4:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -2871,6 +3393,14 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -2888,11 +3418,19 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -2947,6 +3485,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
@@ -2977,8 +3518,17 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2995,12 +3545,23 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -3104,6 +3665,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -3117,6 +3681,10 @@ packages:
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
+  log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -3134,6 +3702,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.14.0:
+    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -3165,8 +3738,16 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   merge-options@3.0.4:
     resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
@@ -3272,6 +3853,14 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3332,6 +3921,20 @@ packages:
   msgpackr@1.11.12:
     resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
 
+  msw@2.14.5:
+    resolution: {integrity: sha512-X6G05oX4x0e+CNI55KMdhMmwHCBKf2iwazGr+iwsdoJ94JA1ED7wSXb6V+lLPdqFkmIlPiGYvayqnaNcOzobDA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3370,6 +3973,11 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
@@ -3382,6 +3990,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -3396,6 +4008,14 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
@@ -3415,6 +4035,10 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  object-treeify@1.1.33:
+    resolution: {integrity: sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==}
+    engines: {node: '>= 10'}
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
@@ -3444,11 +4068,26 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
 
   open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
@@ -3457,6 +4096,13 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@8.2.0:
+    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
+    engines: {node: '>=18'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -3492,12 +4138,23 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
+
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3507,12 +4164,22 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -3532,6 +4199,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -3550,6 +4221,10 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3557,6 +4232,10 @@ packages:
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3630,14 +4309,26 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
   promise@8.3.0:
     resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3648,6 +4339,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -3657,6 +4352,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
@@ -3697,6 +4396,10 @@ packages:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -3728,6 +4431,9 @@ packages:
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3740,6 +4446,13 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3749,8 +4462,16 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rpc-websockets@9.3.8:
     resolution: {integrity: sha512-7r+fm4tSJmLf9GvZfL1DJ1SJwpagpp6AazqM0FUaeV7CA+7+NYINSk1syWa4tU/6OF2CyBicLtzENGmXRJH6wQ==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3796,6 +4517,10 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
@@ -3804,8 +4529,15 @@ packages:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -3821,6 +4553,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shadcn@4.7.0:
+    resolution: {integrity: sha512-70fwnesNrY1GgeD7Kdzn+3SsYeyfibm8immsA5L68+OusoPTvYF01oWExl8/latKpMpvVXcbgdbbE6VFBJQ38w==}
+    hasBin: true
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -3861,6 +4597,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3868,6 +4607,9 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -3917,6 +4659,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -3927,6 +4673,9 @@ packages:
   stream-json@1.9.1:
     resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
 
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3934,6 +4683,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -3961,6 +4714,10 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  stringify-object@5.0.0:
+    resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
+    engines: {node: '>=14.16'}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -3972,6 +4729,14 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -4012,6 +4777,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -4039,6 +4808,9 @@ packages:
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4107,11 +4879,21 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-morph@26.0.0:
+    resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4120,6 +4902,14 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4163,6 +4953,10 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -4178,12 +4972,19 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -4194,9 +4995,17 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   utf-8-validate@6.0.6:
     resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
     engines: {node: '>=6.14.2'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -4215,6 +5024,14 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  validate-npm-package-name@7.0.2:
+    resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4293,6 +5110,10 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -4343,6 +5164,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -4363,6 +5189,9 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -4387,6 +5216,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -4429,6 +5262,22 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-spinner@1.2.0:
+    resolution: {integrity: sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==}
+    engines: {node: '>=18.19'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -4510,6 +5359,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.3
@@ -4518,7 +5371,27 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -4536,6 +5409,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-optimise-call-expression@7.27.1':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -4550,6 +5445,46 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/runtime@7.29.2': {}
 
@@ -4575,6 +5510,29 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@floating-ui/utils': 0.2.11
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      use-sync-external-store: 1.6.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -4636,6 +5594,23 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@dimforge/rapier3d-compat@0.12.0': {}
+
+  '@dotenvx/dotenvx@1.65.0':
+    dependencies:
+      commander: 11.1.0
+      dotenv: 17.4.2
+      eciesjs: 0.4.18
+      execa: 5.1.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      ignore: 5.3.2
+      object-treeify: 1.1.33
+      picomatch: 4.0.4
+      which: 4.0.0
+      yocto-spinner: 1.2.0
+
+  '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
+    dependencies:
+      '@noble/ciphers': 1.3.0
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4772,10 +5747,31 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 1.8.0
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@gsap/react@2.1.2(gsap@3.15.0)(react@19.0.0)':
     dependencies:
       gsap: 3.15.0
       react: 19.0.0
+
+  '@hono/node-server@1.19.14(hono@4.12.18)':
+    dependencies:
+      hono: 4.12.18
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4890,6 +5886,59 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.12(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@22.19.17)
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/confirm@6.0.12(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/core': 11.1.9(@types/node@25.6.0)
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+    optionalDependencies:
+      '@types/node': 25.6.0
+    optional: true
+
+  '@inquirer/core@11.1.9(@types/node@22.19.17)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@22.19.17)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/core@11.1.9(@types/node@25.6.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@25.6.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    optional: true
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@22.19.17)':
+    optionalDependencies:
+      '@types/node': 22.19.17
+
+  '@inquirer/type@4.0.5(@types/node@25.6.0)':
+    optionalDependencies:
+      '@types/node': 25.6.0
+    optional: true
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4940,6 +5989,28 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.18)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.1(express@5.2.1)
+      hono: 4.12.18
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -4957,6 +6028,15 @@ snapshots:
 
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
+
+  '@mswjs/interceptors@0.41.8':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4995,6 +6075,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -5029,6 +6111,17 @@ snapshots:
   '@noir-lang/types@1.0.0-beta.18': {}
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5194,6 +6287,8 @@ snapshots:
 
   '@rushstack/eslint-patch@1.16.1': {}
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -5235,6 +6330,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sinclair/typebox@0.27.10': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@solana-mobile/mobile-wallet-adapter-protocol-web3js@2.2.8(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.2(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.0.0)(utf-8-validate@6.0.6))(typescript@5.9.3)':
     dependencies:
@@ -5688,6 +6785,12 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@ts-morph/common@0.27.0':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+
   '@tweenjs/tween.js@23.1.3': {}
 
   '@tybys/wasm-util@0.10.2':
@@ -5747,7 +6850,13 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/stats.js@0.17.4': {}
+
+  '@types/statuses@2.0.6': {}
 
   '@types/three@0.184.0':
     dependencies:
@@ -5761,6 +6870,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/uuid@10.0.0': {}
+
+  '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/webxr@0.5.24': {}
 
@@ -5944,7 +7055,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.2)
+      vitest: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.14.5(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5955,20 +7066,22 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2))':
+  '@vitest/mocker@2.1.9(msw@2.14.5(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.5(@types/node@22.19.17)(typescript@5.9.3)
       vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2)
 
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2))':
+  '@vitest/mocker@2.1.9(msw@2.14.5(@types/node@25.6.0)(typescript@5.9.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.5(@types/node@25.6.0)(typescript@5.9.3)
       vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2)
 
   '@vitest/pretty-format@2.1.9':
@@ -5999,7 +7112,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.2)
+      vitest: 2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.14.5(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2)
 
   '@vitest/utils@2.1.9':
     dependencies:
@@ -6055,12 +7168,23 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   anser@1.4.10: {}
 
@@ -6157,6 +7281,10 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   async-function@1.0.0: {}
 
   available-typed-arrays@1.0.7:
@@ -6202,6 +7330,20 @@ snapshots:
       file-uri-to-path: 1.0.0
 
   bn.js@5.2.3: {}
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   borsh@0.7.0:
     dependencies:
@@ -6263,6 +7405,12 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -6341,6 +7489,14 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-spinners@2.9.2: {}
+
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
 
   cliui@6.0.0:
@@ -6357,6 +7513,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  code-block-writer@13.0.3: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -6366,6 +7524,8 @@ snapshots:
   comlink@4.4.2: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@11.1.0: {}
 
   commander@12.1.0: {}
 
@@ -6386,7 +7546,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   cross-fetch@3.2.0:
     dependencies:
@@ -6405,9 +7589,13 @@ snapshots:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -6450,15 +7638,28 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  dedent@1.7.2: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
+
+  deepmerge@4.3.1: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
 
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -6480,6 +7681,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@8.0.4: {}
+
   dijkstrajs@1.0.3: {}
 
   doctrine@2.1.0:
@@ -6487,6 +7690,8 @@ snapshots:
       esutils: 2.0.3
 
   dom-accessibility-api@0.5.16: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -6496,9 +7701,18 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  eciesjs@0.4.18:
+    dependencies:
+      '@ecies/ciphers': 0.2.6(@noble/ciphers@1.3.0)
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.349: {}
+
+  emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
 
@@ -6514,6 +7728,12 @@ snapshots:
       tapable: 2.3.3
 
   entities@8.0.0: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -6846,6 +8066,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -6870,9 +8092,80 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   eyes@0.1.8: {}
 
@@ -6886,11 +8179,31 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
   fast-stable-stringify@1.0.0: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
@@ -6908,7 +8221,16 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.8.2: {}
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6929,6 +8251,17 @@ snapshots:
       parseurl: 1.3.3
       statuses: 1.5.0
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6960,6 +8293,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
   framer-motion@12.38.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       motion-dom: 12.38.0
@@ -6970,6 +8309,14 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
+
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fsevents@2.3.2:
     optional: true
@@ -6990,6 +8337,8 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  fuzzysort@3.1.0: {}
+
   geist@1.7.0(next@15.5.15(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
     dependencies:
       next: 15.5.15(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -6999,6 +8348,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -7013,10 +8364,19 @@ snapshots:
       hasown: 2.0.3
       math-intrinsics: 1.1.0
 
+  get-own-enumerable-keys@1.0.0: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -7055,6 +8415,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql@16.14.0: {}
 
   gsap@3.15.0: {}
 
@@ -7098,6 +8460,11 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
+
   hermes-compiler@250829098.0.10: {}
 
   hermes-estree@0.33.3: {}
@@ -7111,6 +8478,8 @@ snapshots:
   hermes-parser@0.35.0:
     dependencies:
       hermes-estree: 0.35.0
+
+  hono@4.12.18: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -7135,6 +8504,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@2.1.0: {}
+
+  human-signals@8.0.1: {}
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
@@ -7144,6 +8517,10 @@ snapshots:
       react: 19.0.0
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -7178,11 +8555,17 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -7224,6 +8607,8 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -7244,9 +8629,19 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-interactive@2.0.0: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -7255,10 +8650,16 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-obj@3.0.0: {}
+
   is-plain-obj@2.1.0:
     optional: true
 
+  is-plain-obj@4.1.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -7267,11 +8668,17 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.3
 
+  is-regexp@3.1.0: {}
+
   is-set@2.0.3: {}
 
   is-shared-array-buffer@1.0.4:
     dependencies:
       call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
 
   is-string@1.1.1:
     dependencies:
@@ -7288,6 +8695,10 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-unicode-supported@1.3.0: {}
+
+  is-unicode-supported@2.1.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -7303,9 +8714,15 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
 
   isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)):
     dependencies:
@@ -7394,6 +8811,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
@@ -7434,7 +8853,13 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -7446,6 +8871,12 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -7456,6 +8887,10 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -7530,6 +8965,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lines-and-columns@1.2.4: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -7541,6 +8978,11 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash.throttle@4.1.1: {}
+
+  log-symbols@6.0.0:
+    dependencies:
+      chalk: 5.6.2
+      is-unicode-supported: 1.3.0
 
   loose-envify@1.4.0:
     dependencies:
@@ -7555,6 +8997,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.14.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
 
   lz-string@1.5.0: {}
 
@@ -7594,7 +9040,11 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0: {}
+
   memoize-one@5.2.1: {}
+
+  merge-descriptors@2.0.0: {}
 
   merge-options@3.0.4:
     dependencies:
@@ -7811,6 +9261,10 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mimic-fn@2.1.0: {}
+
+  mimic-function@5.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -7865,6 +9319,59 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
+  msw@2.14.5(@types/node@22.19.17)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.12(@types/node@22.19.17)
+      '@mswjs/interceptors': 0.41.8
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  msw@2.14.5(@types/node@25.6.0)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.12(@types/node@25.6.0)
+      '@mswjs/interceptors': 0.41.8
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.0
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.12: {}
 
   napi-postinstall@0.3.4: {}
@@ -7897,6 +9404,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -7907,6 +9416,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
@@ -7920,6 +9435,15 @@ snapshots:
 
   node-releases@2.0.38: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   nullthrows@1.1.1: {}
 
   ob1@0.84.4:
@@ -7931,6 +9455,8 @@ snapshots:
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
+
+  object-treeify@1.1.33: {}
 
   object.assign@4.1.7:
     dependencies:
@@ -7976,6 +9502,18 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -7983,6 +9521,15 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
 
   open@7.4.2:
     dependencies:
@@ -7997,6 +9544,20 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  ora@8.2.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  outvariant@1.4.3: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -8030,15 +9591,28 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
+  parse-ms@4.0.0: {}
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -8046,6 +9620,10 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.3
+
+  path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@1.1.2: {}
 
@@ -8056,6 +9634,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.59.1: {}
 
@@ -8069,6 +9649,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.12
@@ -8080,6 +9665,8 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   prelude-ls@1.2.1: {}
 
@@ -8101,9 +9688,18 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
   promise@8.3.0:
     dependencies:
       asap: 2.0.6
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -8113,6 +9709,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
   qrcode@1.5.4:
@@ -8121,6 +9722,10 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   queue-microtask@1.2.3: {}
 
   queue@6.0.2:
@@ -8128,6 +9733,13 @@ snapshots:
       inherits: 2.0.4
 
   range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-devtools-core@6.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
@@ -8197,6 +9809,14 @@ snapshots:
 
   react@19.0.0: {}
 
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -8235,6 +9855,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  reselect@5.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -8247,6 +9869,13 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rettime@0.11.11: {}
 
   reusify@1.1.0: {}
 
@@ -8281,6 +9910,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rpc-websockets@9.3.8:
     dependencies:
       '@swc/helpers': 0.5.21
@@ -8293,6 +9932,8 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
+
+  run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -8351,6 +9992,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@2.1.0: {}
 
   serve-static@1.16.3:
@@ -8362,7 +10019,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -8387,6 +10055,49 @@ snapshots:
       es-object-atoms: 1.1.1
 
   setprototypeof@1.2.0: {}
+
+  shadcn@4.7.0(@types/node@22.19.17)(typescript@5.9.3):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@dotenvx/dotenvx': 1.65.0
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@types/validate-npm-package-name': 4.0.2
+      browserslist: 4.28.2
+      commander: 14.0.3
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      dedent: 1.7.2
+      deepmerge: 4.3.1
+      diff: 8.0.4
+      execa: 9.6.1
+      fast-glob: 3.3.3
+      fs-extra: 11.3.5
+      fuzzysort: 3.1.0
+      https-proxy-agent: 7.0.6
+      kleur: 4.1.5
+      msw: 2.14.5(@types/node@22.19.17)(typescript@5.9.3)
+      node-fetch: 3.3.2
+      open: 11.0.0
+      ora: 8.2.0
+      postcss: 8.5.14
+      postcss-selector-parser: 7.1.1
+      prompts: 2.4.2
+      recast: 0.23.11
+      stringify-object: 5.0.0
+      tailwind-merge: 3.5.0
+      ts-morph: 26.0.0
+      tsconfig-paths: 4.2.0
+      validate-npm-package-name: 7.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - typescript
 
   sharp@0.34.5:
     dependencies:
@@ -8469,6 +10180,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   sirv@3.0.2:
@@ -8476,6 +10189,8 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
 
   sonner@2.0.7(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -8511,6 +10226,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stdin-discarder@0.2.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -8522,6 +10239,8 @@ snapshots:
     dependencies:
       stream-chain: 2.2.5
 
+  strict-event-emitter@0.5.1: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -8532,6 +10251,12 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string.prototype.includes@2.0.1:
@@ -8589,6 +10314,12 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  stringify-object@5.0.0:
+    dependencies:
+      get-own-enumerable-keys: 1.0.0
+      is-obj: 3.0.0
+      is-regexp: 3.1.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8598,6 +10329,10 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  strip-final-newline@2.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -8624,6 +10359,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.4: {}
@@ -8648,6 +10385,8 @@ snapshots:
   three@0.184.0: {}
 
   throat@5.0.0: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -8698,6 +10437,11 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-morph@26.0.0:
+    dependencies:
+      '@ts-morph/common': 0.27.0
+      code-block-writer: 13.0.3
+
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -8705,13 +10449,31 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
   tslib@2.8.1: {}
+
+  tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
   type-fest@0.7.1: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -8772,6 +10534,8 @@ snapshots:
 
   undici@7.25.0: {}
 
+  unicorn-magic@0.3.0: {}
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -8794,6 +10558,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
 
@@ -8821,6 +10587,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -8831,10 +10599,16 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
   utf-8-validate@6.0.6:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
+
+  util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
 
@@ -8843,6 +10617,10 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
+
+  validate-npm-package-name@7.0.2: {}
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -8912,10 +10690,10 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.46.2
 
-  vitest@2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.2):
+  vitest@2.1.9(@types/node@22.19.17)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.14.5(@types/node@22.19.17)(typescript@5.9.3))(terser@5.46.2):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2))
+      '@vitest/mocker': 2.1.9(msw@2.14.5(@types/node@22.19.17)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.46.2))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -8949,10 +10727,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@25.6.0)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.46.2):
+  vitest@2.1.9(@types/node@25.6.0)(@vitest/ui@2.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(msw@2.14.5(@types/node@25.6.0)(typescript@5.9.3))(terser@5.46.2):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2))
+      '@vitest/mocker': 2.1.9(msw@2.14.5(@types/node@25.6.0)(typescript@5.9.3))(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)(terser@5.46.2))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -8995,6 +10773,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -9068,6 +10848,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -9093,6 +10877,8 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:
       bufferutil: 4.1.0
@@ -9102,6 +10888,11 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   xml-name-validator@5.0.0: {}
 
@@ -9147,6 +10938,18 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yocto-spinner@1.2.0:
+    dependencies:
+      yoctocolors: 2.1.2
+
+  yoctocolors@2.1.2: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/sdk/src/idl/zksettle.json
+++ b/sdk/src/idl/zksettle.json
@@ -649,6 +649,85 @@
       ]
     },
     {
+      "name": "resize_hook_payload",
+      "discriminator": [
+        178,
+        222,
+        42,
+        251,
+        26,
+        170,
+        146,
+        236
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "issuer"
+          ]
+        },
+        {
+          "name": "issuer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  105,
+                  115,
+                  115,
+                  117,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "hook_payload",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  104,
+                  111,
+                  111,
+                  107,
+                  45,
+                  112,
+                  97,
+                  121,
+                  108,
+                  111,
+                  97,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "settle_hook",
       "docs": [
         "Direct-call settlement. Issuer authority signs and receives rent refund",
@@ -823,7 +902,7 @@
         "payload PDA is NOT closed here — SPL passes `owner` as read-only",
         "(`AccountMeta::new_readonly`), blocking `close = owner`. Authority",
         "calls `close_hook_payload` after the transfer to reclaim rent and",
-        "unblock the next payload staging cycle."
+        "unblock the next `init_hook_payload`."
       ],
       "discriminator": [
         105,
@@ -1550,41 +1629,51 @@
     },
     {
       "code": 6035,
+      "name": "MerkleTreeTooSmall",
+      "msg": "Pre-allocated merkle tree account is too small for configured depth/buffer"
+    },
+    {
+      "code": 6036,
+      "name": "MerkleTreeWrongOwner",
+      "msg": "Pre-allocated merkle tree account is not owned by SPL account compression"
+    },
+    {
+      "code": 6037,
       "name": "BubblegumTailInvalid",
       "msg": "Trailing Bubblegum account count is invalid for remaining_accounts split"
     },
     {
-      "code": 6036,
+      "code": 6038,
       "name": "BubblegumLeafOwnerMismatch",
       "msg": "Bubblegum leaf owner does not match settlement recipient"
     },
     {
-      "code": 6037,
+      "code": 6039,
       "name": "MintHookMismatch",
       "msg": "Mint's TransferHook extension does not point to this program"
     },
     {
-      "code": 6038,
+      "code": 6040,
       "name": "ChunkOutOfBounds",
       "msg": "Chunk write exceeds expected_proof_len"
     },
     {
-      "code": 6039,
+      "code": 6041,
       "name": "ChunkNotSequential",
       "msg": "Chunk offset does not match high_water_mark (sequential writes required)"
     },
     {
-      "code": 6040,
+      "code": 6042,
       "name": "PayloadAlreadyFinalized",
       "msg": "Cannot write to a finalized payload"
     },
     {
-      "code": 6041,
+      "code": 6043,
       "name": "PayloadNotReady",
       "msg": "Payload must be finalized before settlement"
     },
     {
-      "code": 6042,
+      "code": 6044,
       "name": "ProofIncomplete",
       "msg": "Proof length does not match expected_proof_len at finalize"
     }
@@ -2087,9 +2176,10 @@
       "docs": [
         "Pre-staged Light CPI arguments stored in the hook payload so the Token-2022",
         "Execute entry — which only receives `amount: u64` as instruction data — can",
-        "still drive a Light CPI. Clients must stage the payload via the chunked flow",
-        "(`init_hook_payload` → `write_hook_proof` → `finalize_hook_payload`) before the",
-        "Token-2022 transfer, otherwise the tree-root index and validity proof go stale."
+        "still drive a Light CPI. Clients stage via the chunked path",
+        "(`init_hook_payload` → `write_hook_proof` → `finalize_hook_payload`) and",
+        "include `finalize` + Token-2022 transfer in a single atomic transaction,",
+        "otherwise the tree-root index and validity proof go stale."
       ],
       "type": {
         "kind": "struct",

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,6 +1,7 @@
 export { prove, loadCircuit, Prover, computeNullifier, type NullifierInputs } from "./prove/index.js";
 export {
   buildInitHookPayloadIx,
+  buildResizeHookPayloadIx,
   buildWriteChunkIx,
   buildFinalizeHookPayloadIx,
   uploadProofChunked,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,6 +4,8 @@ export {
   buildWriteChunkIx,
   buildFinalizeHookPayloadIx,
   uploadProofChunked,
+  checkIssuerExists,
+  buildRegisterIssuerIx,
   CHUNK_SIZE,
 } from "./wrap/index.js";
 export { findIssuerPda, findHookPayloadPda, findRegistryPda, findTreeCreatorPda, findTreeConfigPda } from "./wrap/pda.js";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -6,6 +6,8 @@ export {
   uploadProofChunked,
   checkIssuerExists,
   buildRegisterIssuerIx,
+  checkHookPayloadExists,
+  buildCloseHookPayloadIx,
   CHUNK_SIZE,
 } from "./wrap/index.js";
 export { findIssuerPda, findHookPayloadPda, findRegistryPda, findTreeCreatorPda, findTreeConfigPda } from "./wrap/pda.js";

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -138,6 +138,27 @@ export async function buildInitHookPayloadIx(
     .instruction();
 }
 
+export async function buildResizeHookPayloadIx(
+  wallet: PublicKey,
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+  program?: Program,
+): Promise<TransactionInstruction> {
+  const [issuerPda] = findIssuerPda(wallet, programId);
+  const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
+  const prog = program ?? await makeProgram(connection);
+
+  return prog.methods
+    .resizeHookPayload()
+    .accounts({
+      authority: wallet,
+      issuer: issuerPda,
+      hookPayload: hookPayloadPda,
+      systemProgram: SystemProgram.programId,
+    })
+    .instruction();
+}
+
 export async function buildWriteChunkIx(
   wallet: PublicKey,
   offset: number,

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -207,6 +207,10 @@ export async function uploadProofChunked(
   const proofBytes = opts.proof;
   const program = await makeProgram(opts.connection);
 
+  console.log("[zksettle-sdk] uploadProofChunked: building initHookPayload ix", {
+    wallet: opts.wallet.toBase58(),
+    proofLen: proofBytes.length,
+  });
   const initIx = await buildInitHookPayloadIx(
     opts.wallet,
     proofBytes.length,
@@ -214,7 +218,9 @@ export async function uploadProofChunked(
     programId,
     program,
   );
+  console.log("[zksettle-sdk] uploadProofChunked: sending initHookPayload tx...");
   const initSignature = await signAndSend(new Transaction().add(initIx));
+  console.log("[zksettle-sdk] uploadProofChunked: initHookPayload sig:", initSignature);
 
   const writeIxs: TransactionInstruction[] = [];
   for (let offset = 0; offset < proofBytes.length; offset += chunkSize) {

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -81,6 +81,34 @@ export async function buildRegisterIssuerIx(
     .instruction();
 }
 
+export async function checkHookPayloadExists(
+  wallet: PublicKey,
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+): Promise<boolean> {
+  const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
+  const info = await connection.getAccountInfo(hookPayloadPda);
+  return info !== null;
+}
+
+export async function buildCloseHookPayloadIx(
+  wallet: PublicKey,
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+  program?: Program,
+): Promise<TransactionInstruction> {
+  const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
+  const prog = program ?? await makeProgram(connection);
+
+  return prog.methods
+    .closeHookPayload()
+    .accounts({
+      authority: wallet,
+      hookPayload: hookPayloadPda,
+    })
+    .instruction();
+}
+
 async function makeProgram(connection: Connection): Promise<Program> {
   const { AnchorProvider, Program } = await loadAnchorBrowser();
   const dummyWallet = new DummyWallet();

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -47,6 +47,40 @@ const DEFAULT_LIGHT_ARGS: StagedLightArgs = {
 export const CHUNK_SIZE = 450;
 export const WRITES_PER_TX = 2;
 
+export async function checkIssuerExists(
+  wallet: PublicKey,
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+): Promise<boolean> {
+  const [issuerPda] = findIssuerPda(wallet, programId);
+  const info = await connection.getAccountInfo(issuerPda);
+  return info !== null;
+}
+
+export async function buildRegisterIssuerIx(
+  wallet: PublicKey,
+  roots: { merkleRoot: Uint8Array; sanctionsRoot: Uint8Array; jurisdictionRoot: Uint8Array },
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+  program?: Program,
+): Promise<TransactionInstruction> {
+  const [issuerPda] = findIssuerPda(wallet, programId);
+  const prog = program ?? await makeProgram(connection);
+
+  return prog.methods
+    .registerIssuer(
+      Array.from(roots.merkleRoot),
+      Array.from(roots.sanctionsRoot),
+      Array.from(roots.jurisdictionRoot),
+    )
+    .accounts({
+      authority: wallet,
+      issuer: issuerPda,
+      systemProgram: SystemProgram.programId,
+    })
+    .instruction();
+}
+
 async function makeProgram(connection: Connection): Promise<Program> {
   const { AnchorProvider, Program } = await loadAnchorBrowser();
   const dummyWallet = new DummyWallet();


### PR DESCRIPTION
## Summary

### Dashboard UI/UX overhaul
- Install shadcn/ui (base-nova style) alongside existing custom components — adds Select, Dialog, Tooltip, Skeleton, Card, Popover, DropdownMenu, Separator, Table
- Create shared helpers: `TruncatedHash` (tooltip + copy), `EmptyState` (icon + title + CTA), `TableSkeleton` (animated loading rows), `StatCard` with `isLoading` skeleton
- Refine all 7 dashboard pages: audit-log, API keys, wallets/credentials, attestations, issuer status, billing, prove
- Cross-cutting polish: sidebar hover transitions, topbar border-color transition on scroll, consistent `toast.success("Copied to clipboard")` across all copy actions
- Map shadcn CSS variables to existing ZKSettle design tokens — no visual breaking changes to existing components

### Prove flow: issuer registration & transfer context
- Auto-register issuer on-chain if not already registered before proof upload
- Close stale hook payloads before starting a new upload
- Thread mint, recipient, and amount inputs through the prove flow via IntroCard
- Build all proof-upload transactions (init, write chunks, finalize) upfront and sign in a single wallet prompt via `signAllTransactions`
- Add `runningRef` guard to prevent duplicate flow executions

### On-chain: bypass Solana 10KB realloc limit for UltraHonk proofs
- UltraHonk proofs from Barretenberg are 10-15+ KB, exceeding Solana's 10KB per-instruction realloc limit
- Split `init_hook_payload` into header-only init (~301 bytes) + new `resize_hook_payload` instruction that grows by up to 10KB per call
- Add `ResizeHookPayload` accounts struct with issuer authorization and finalization guard
- Update IDL with the new `resize_hook_payload` instruction

### Frontend: 3-batch transaction pipeline with fresh blockhashes
- Batch 1: `init_hook_payload` + `resize_hook_payload` (1-2 resize calls) — own blockhash + Phantom popup
- Batch 2: sequential `write_hook_proof` chunks — own blockhash + Phantom popup, fire-and-forget sends with last-write confirmation
- Batch 3: `finalize_hook_payload` — own fresh blockhash + Phantom popup, guarantees no blockhash expiry
- Each batch gets a fresh blockhash so Phantom approval time doesn't consume the validity window
- Use `skipPreflight: true` with `maxRetries` for reliable delivery on devnet

### SDK enhancements
- Add browser-compatible `buildRegisterIssuerIx` and `checkIssuerExists`
- Add `checkHookPayloadExists` and `buildCloseHookPayloadIx` for stale payload cleanup
- Add `buildResizeHookPayloadIx` for the new resize instruction
- Export individual instruction builders (`buildInitHookPayloadIx`, `buildResizeHookPayloadIx`, `buildWriteChunkIx`, `buildFinalizeHookPayloadIx`, `CHUNK_SIZE`) for client-side batch assembly
- Add debug logging to `uploadProofChunked` path

### Devnet infrastructure
- Make devnet setup idempotent with client-side tree allocation
- Validate pre-allocated merkle tree instead of CPI create
- Add merkle tree validation error variants
- Update program IDs for fresh devnet deployment
- Extract `loadWallet` to shared benchmark-utils module

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] 83/83 tests pass
- [x] Manual: prove flow end-to-end on devnet — issuer registration, proof upload, finalize all succeed
- [ ] Manual: navigate all 7 dashboard pages, verify filters/dialogs/tooltips/skeletons
- [ ] Manual: verify responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned dashboard with card-based UI, shared primitives (cards, tables, dialogs, menus, popovers, tooltips, selects, separators, skeletons), TruncatedHash, and Prove Flow inputs for mint/recipient/amount with validation.

* **Bug Fixes / UX**
  * Consistent loading skeletons, improved empty states, confirm dialogs for destructive actions, copy-to-clipboard success toasts, and refined header/sidebar transitions.

* **Backend & SDK**
  * Support for resizing/staging proofs and issuer existence/registration flows to enable robust chunked proof submissions.

* **Docs**
  * Added design and implementation plans for prove-flow issuer/transfer updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->