### PR TITLE
deploy(backend): unify Dockerfile with SERVICE env var selector for R…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,23 +6,11 @@ COPY programs/ programs/
 COPY crates/ crates/
 RUN cargo build --release --locked -p api-gateway -p issuer-service -p indexer
 
-FROM debian:bookworm-slim AS api-gateway
+FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 RUN useradd -r -s /usr/sbin/nologin appuser
 COPY --from=builder /app/target/release/api-gateway /usr/local/bin/
-USER appuser
-CMD ["api-gateway"]
-
-FROM debian:bookworm-slim AS issuer-service
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN useradd -r -s /usr/sbin/nologin appuser
 COPY --from=builder /app/target/release/issuer-service /usr/local/bin/
-USER appuser
-CMD ["issuer-service"]
-
-FROM debian:bookworm-slim AS indexer
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-RUN useradd -r -s /usr/sbin/nologin appuser
 COPY --from=builder /app/target/release/indexer /usr/local/bin/
 USER appuser
-CMD ["indexer"]
+CMD ["sh", "-c", "exec ${SERVICE:-api-gateway}"]

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -19,10 +19,10 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-      target: api-gateway
     ports:
       - "4000:4000"
     environment:
+      SERVICE: "api-gateway"
       GATEWAY_PORT: "4000"
       GATEWAY_UPSTREAM_URL: "http://localhost:3333"
       GATEWAY_INDEXER_URL: "http://localhost:3334"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,10 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-      target: api-gateway
     ports:
       - "4000:4000"
     environment:
+      SERVICE: "api-gateway"
       GATEWAY_PORT: "4000"
       GATEWAY_UPSTREAM_URL: "http://issuer-service:3000"
       GATEWAY_INDEXER_URL: "http://indexer:3001"
@@ -39,10 +39,10 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-      target: issuer-service
     ports:
       - "3000:3000"
     environment:
+      SERVICE: "issuer-service"
       LISTEN_ADDR: "0.0.0.0:3000"
       PROGRAM_ID: "${PROGRAM_ID:?set PROGRAM_ID}"
       KEYPAIR_PATH: "/keys/id.json"
@@ -54,10 +54,10 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-      target: indexer
     ports:
       - "3001:3001"
     environment:
+      SERVICE: "indexer"
       INDEXER_PORT: "3001"
       INDEXER_HELIUS_AUTH_TOKEN: "${INDEXER_HELIUS_AUTH_TOKEN:?set INDEXER_HELIUS_AUTH_TOKEN}"
       INDEXER_PROGRAM_ID: "${INDEXER_PROGRAM_ID:?set INDEXER_PROGRAM_ID}"


### PR DESCRIPTION
…ailway

Railway doesn't natively support Docker build targets, so consolidate the three multi-stage runtime images into a single image that ships all three binaries and selects which to run via the SERVICE env var.

Each Railway service points at the same Dockerfile and sets SERVICE=api-gateway, SERVICE=issuer-service, or SERVICE=indexer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Docker build configuration to use a single runtime stage with environment variable-based service selection instead of separate build targets per service. Updated docker-compose configurations to explicitly define the `SERVICE` environment variable for each deployed service.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->