### PR TITLE
fix(frontend): align stablecoin admin with deployed devnet program

### DIFF
--- a/frontend/src/app/dashboard/admin/admin-panels.tsx
+++ b/frontend/src/app/dashboard/admin/admin-panels.tsx
@@ -52,10 +52,19 @@ export function AdminPanels() {
     );
   }
 
-  if (isLoading || !treasury) {
+  if (isLoading) {
     return (
       <p className="rounded-[var(--radius-6)] border border-border-subtle bg-surface px-5 py-4 text-sm text-muted">
         Loading treasury…
+      </p>
+    );
+  }
+
+  if (!treasury) {
+    return (
+      <p className="rounded-[var(--radius-6)] border border-border-subtle bg-surface px-5 py-4 text-sm text-stone">
+        Treasury not initialized for this mint. The stablecoin program must
+        initialize the treasury before admin controls are available.
       </p>
     );
   }

--- a/frontend/src/lib/stablecoin/program.ts
+++ b/frontend/src/lib/stablecoin/program.ts
@@ -1,7 +1,7 @@
 import { PublicKey } from "@solana/web3.js";
 
 export const STABLECOIN_PROGRAM_ID = new PublicKey(
-  "2CdXRSPo6QLfLBJTikmrqmBiWwa1HpuuYJ2Qu6Yy3Liv",
+  "8UCELgX3D64aWPJcJre7AtuoSre5eWjHdAFsRUkeqCMe",
 );
 
 export const STABLECOIN_DECIMALS = 6;

--- a/frontend/src/lib/stablecoin/sdk-adapter.ts
+++ b/frontend/src/lib/stablecoin/sdk-adapter.ts
@@ -23,14 +23,8 @@ type SdkRedemptionRequest = import("@zksettle/sdk").RedemptionRequest;
 
 let sdkPromise: Promise<SdkModule> | null = null;
 
-// Use an indirect specifier to prevent vite/rollup from eagerly resolving
-// the SDK at test-collection time. Without this, vitest fails on a fresh
-// checkout before `sdk/dist/` is built, even though only a handful of tests
-// actually exercise the sdk adapter.
-const SDK_SPECIFIER = "@zksettle/sdk";
-
 function loadSdk(): Promise<SdkModule> {
-  sdkPromise ??= import(/* @vite-ignore */ SDK_SPECIFIER) as Promise<SdkModule>;
+  sdkPromise ??= import("@zksettle/sdk") as Promise<SdkModule>;
   return sdkPromise;
 }
 


### PR DESCRIPTION
## Summary
- Sync frontend program ID with the deployed devnet address (`8UCELgX3...`) so the SDK adapter resolves the correct treasury PDA
- Fix `sdk-adapter.ts` dynamic import: replace indirect `import(variable)` with direct `import("@zksettle/sdk")` — webpack cannot resolve expression-based dynamic imports at bundle time
- Separate "loading" from "treasury not found" state in `AdminPanels` so users see an informative message instead of infinite loading spinner when the treasury hasn't been initialized

## Test plan
- [x] `npx tsc --noEmit` passes (no new type errors)
- [x] Dev server compiles `/dashboard/admin` without errors
- [x] With SDK adapter pointing at devnet: treasury data loads from chain, role detection works, form validation enables/disables buttons correctly
- [x] When treasury PDA doesn't exist: shows "Treasury not initialized" instead of "Loading treasury…" forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when treasury requires initialization before accessing admin controls.

* **Chores**
  * Updated stablecoin program configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/182)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->