### PR TITLE
fix(frontend): dashboard auth + attestation lookup UX

### DIFF
--- a/frontend/src/components/dashboard/attestation-explorer-panel.tsx
+++ b/frontend/src/components/dashboard/attestation-explorer-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Copy, NavArrowDown, Search, Xmark } from "iconoir-react";
-import { useEffect, useState, type ReactNode, type SyntheticEvent } from "react";
+import { useEffect, useRef, useState, type ReactNode, type SyntheticEvent } from "react";
 import { toast } from "sonner";
 
 import { EmptyState } from "@/components/dashboard/empty-state";
@@ -28,9 +28,10 @@ import {
 } from "@/hooks/use-recent-wallets";
 import { useRoots } from "@/hooks/use-roots";
 import { useSanctionsProof } from "@/hooks/use-sanctions-proof";
+import { useConnectedWallet } from "@/hooks/use-wallet-connection";
 import { ApiError } from "@/lib/api/client";
 import { cn } from "@/lib/cn";
-import { isValidWalletHex, normalizeWalletHex } from "@/lib/wallet";
+import { bytesToHex, isValidWalletHex, normalizeWalletHex } from "@/lib/wallet";
 
 const EMPTY_LEAF = "0".repeat(64);
 
@@ -72,8 +73,13 @@ function rootMismatchMessage(
 function describeProofError(err: unknown): { kind: "not-found" | "auth" | "other"; message: string } {
   if (err instanceof ApiError) {
     if (err.status === 404) return { kind: "not-found", message: "No proof found for this wallet." };
-    if (err.status === 401 || err.status === 403)
+    if (err.status === 401 || err.status === 403) {
+      const body = err.body as Record<string, unknown> | undefined;
+      const detail = typeof body?.error === "string" ? body.error : "";
+      if (detail.includes("signature") || detail.includes("wallet"))
+        return { kind: "auth", message: "You can only look up proofs for your own connected wallet." };
       return { kind: "auth", message: "Not authorized. Select an active API key in the sidebar." };
+    }
     return { kind: "other", message: err.message };
   }
   return { kind: "other", message: err instanceof Error ? err.message : "Unknown error" };
@@ -98,8 +104,19 @@ export function AttestationExplorerPanel() {
   const { data: recent = [] } = useRecentWallets();
   const recordWallet = useRecordWallet();
   const forgetWallet = useForgetWallet();
+  const connectedPubkey = useConnectedWallet();
+  const connectedHex = connectedPubkey
+    ? bytesToHex(Array.from(connectedPubkey.toBytes()))
+    : null;
 
   const inputValid = isValidWalletHex(walletInput);
+
+  const useMyWallet = () => {
+    if (!connectedHex) return;
+    setWalletInput(connectedHex);
+    setActiveWallet(connectedHex);
+    recordWallet(connectedHex);
+  };
 
   const lookup = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -111,7 +128,12 @@ export function AttestationExplorerPanel() {
 
   const pickRecent = (wallet: string) => {
     setWalletInput(wallet);
-    setActiveWallet(wallet);
+    if (wallet === activeWallet) {
+      membershipQuery.refetch();
+      sanctionsQuery.refetch();
+    } else {
+      setActiveWallet(wallet);
+    }
     recordWallet(wallet);
   };
 
@@ -147,6 +169,11 @@ export function AttestationExplorerPanel() {
               <Search aria-hidden="true" className="size-4" />
               Search
             </Button>
+            {connectedHex && (
+              <Button type="button" variant="ghost" size="md" onClick={useMyWallet}>
+                Use my wallet
+              </Button>
+            )}
           </form>
 
           {walletInput.length > 0 && !inputValid ? (

--- a/frontend/src/components/dashboard/require-api-key.tsx
+++ b/frontend/src/components/dashboard/require-api-key.tsx
@@ -6,6 +6,7 @@ import { Copy, Key, WarningTriangle } from "iconoir-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
+  clearActiveApiKey,
   fetchActiveKeyStatus,
   onActiveKeyChanged,
   setActiveApiKey,
@@ -23,6 +24,14 @@ export function RequireApiKey({ children }: Readonly<{ children: ReactNode }>) {
     const refresh = async () => {
       try {
         const next = await fetchActiveKeyStatus();
+        if (next.hasKey) {
+          const probe = await fetch("/api/proxy/usage", { credentials: "same-origin" });
+          if (probe.status === 401 || probe.status === 403) {
+            await clearActiveApiKey().catch(() => {});
+            if (!cancelled) setStatus({ hasKey: false });
+            return;
+          }
+        }
         if (!cancelled) setStatus(next);
       } catch {
         if (!cancelled) setStatus({ hasKey: false });

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -4,7 +4,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
 import { useWallet } from "@/hooks/use-wallet-connection";
-import { clearActiveApiKey } from "@/lib/api/active-key";
+import { clearActiveApiKey, setActiveApiKey, fetchActiveKeyStatus } from "@/lib/api/active-key";
+import { createApiKey } from "@/lib/api/endpoints";
 import { getMe, signIn as authSignIn, signOut as authSignOut } from "@/lib/auth";
 
 export const authMeQueryKey = ["auth", "me"] as const;
@@ -29,8 +30,17 @@ export function useSignIn() {
       }
       await authSignIn(publicKey, signMessage);
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.invalidateQueries({ queryKey: authMeQueryKey });
+      try {
+        const status = await fetchActiveKeyStatus();
+        if (!status.hasKey) {
+          const { api_key } = await createApiKey("dashboard");
+          await setActiveApiKey(api_key);
+        }
+      } catch {
+        // Non-fatal: user can still create a key manually via the gate
+      }
     },
   });
 }

--- a/frontend/src/lib/api/schemas.ts
+++ b/frontend/src/lib/api/schemas.ts
@@ -89,7 +89,7 @@ export const EventDtoSchema = z.object({
   jurisdiction_root: z.string(),
   mint: z.string(),
   recipient: z.string(),
-  payer: z.string(),
+  payer: z.string().optional(),
   amount: z.number().int().nonnegative(),
   epoch: z.number().int().nonnegative(),
 });

--- a/frontend/src/lib/api/wallet-auth.ts
+++ b/frontend/src/lib/api/wallet-auth.ts
@@ -98,10 +98,25 @@ async function signAndCache(
   };
 }
 
-export async function getWalletAuthHeaders(): Promise<Record<string, string>> {
-  if (!registeredSigner) return {};
+function getPhantomFallback(): RegisteredSigner | null {
+  if (typeof globalThis.window === "undefined") return null;
+  const phantom =
+    (globalThis as unknown as { phantom?: { solana?: { isConnected: boolean; publicKey: PublicKey; signMessage: SignMessageFn } } }).phantom?.solana;
+  if (!phantom?.isConnected || !phantom.publicKey || typeof phantom.signMessage !== "function")
+    return null;
+  return {
+    publicKey: phantom.publicKey,
+    signMessage: (msg: Uint8Array) => phantom.signMessage(msg).then((r: { signature: Uint8Array } | Uint8Array) =>
+      r instanceof Uint8Array ? r : r.signature,
+    ),
+  };
+}
 
-  const { publicKey, signMessage } = registeredSigner;
+export async function getWalletAuthHeaders(): Promise<Record<string, string>> {
+  const signer = registeredSigner ?? getPhantomFallback();
+  if (!signer) return {};
+
+  const { publicKey, signMessage } = signer;
   const walletHex = bytesToHex(Array.from(publicKey.toBytes()));
   const now = Date.now();
 


### PR DESCRIPTION
## Summary
- Auto-provision API key on wallet login so dashboard pages work immediately without manual key creation
- Validate stale API key cookies before trusting them (probe `/usage` endpoint)
- Add Phantom direct fallback for wallet message signing when the standard wallet adapter doesn't expose `signMessage`
- Fix `EventDto.payer` schema to be optional, matching the indexer response (fixes audit log showing 0 events)
- Show accurate error message for wallet signature failures instead of misleading "Select an active API key" toast
- Add "Use my wallet" button to attestation explorer for easy self-lookup
- Fix re-clicking recent lookups to refetch instead of returning cached error

## Test plan
- [ ] Login with Phantom → dashboard loads without API key gate
- [ ] Attestations → click "Use my wallet" → shows COMPLIANT with membership + sanctions proofs
- [ ] Attestations → click a recent lookup for a different wallet → shows "You can only look up proofs for your own connected wallet" instead of API key error
- [ ] Audit log → events table populates correctly
- [ ] Logout → login again → API key auto-provisioned, no manual step needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic API key creation and activation upon sign-in
  * "Use my wallet" button to quickly select and auto-fill your connected wallet address in attestation explorer

* **Improvements**
  * Enhanced authorization error messages for clearer feedback
  * Added Phantom wallet support as fallback authentication method
  * Strengthened API key validation checks

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->