### PR TITLE
feat(issuer): load keypair from ISSUER_KEYPAIR_JSON env var

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -6036,7 +6036,6 @@ dependencies = [
  "hex",
  "mutants",
  "reqwest 0.12.28",
- "serde_json",
  "sha2 0.10.9",
  "solana-rpc-client",
  "solana-sdk",
@@ -12057,6 +12056,10 @@ dependencies = [
 [[package]]
 name = "zksettle-config"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "tracing",
+]
 
 [[package]]
 name = "zksettle-crypto"

--- a/backend/crates/issuer-service/src/config.rs
+++ b/backend/crates/issuer-service/src/config.rs
@@ -5,6 +5,7 @@ use zksettle_config::{env_or, expand_tilde};
 pub struct Config {
     pub rpc_url: String,
     pub keypair_path: String,
+    pub keypair_json: Option<String>,
     pub program_id: String,
     pub rotation_interval_secs: u64,
     pub listen_addr: SocketAddr,
@@ -17,6 +18,9 @@ impl Config {
         Self {
             rpc_url: env_or("RPC_URL", "http://127.0.0.1:8899"),
             keypair_path: expand_tilde(&env_or("KEYPAIR_PATH", "~/.config/solana/id.json")),
+            keypair_json: std::env::var("ISSUER_KEYPAIR_JSON")
+                .ok()
+                .filter(|s| !s.trim().is_empty()),
             program_id: env_or("PROGRAM_ID", "zkSet11ezkSet11ezkSet11ezkSet11ezkSet11ezkS"),
             rotation_interval_secs: env_or("ROTATION_INTERVAL_SECS", "43200")
                 .parse()

--- a/backend/crates/issuer-service/src/main.rs
+++ b/backend/crates/issuer-service/src/main.rs
@@ -45,13 +45,14 @@ async fn main() {
 
     let cfg = Config::from_env();
 
-    let keypair_json: Vec<u8> = match std::env::var("ISSUER_KEYPAIR_JSON") {
-        Ok(env_json) if !env_json.trim().is_empty() => {
+    let keypair_json: Vec<u8> = match cfg.keypair_json {
+        Some(ref env_json) => {
             tracing::info!("loading issuer keypair from ISSUER_KEYPAIR_JSON env var");
-            serde_json::from_str(&env_json)
-                .unwrap_or_else(|e| panic!("failed to parse ISSUER_KEYPAIR_JSON: {e}"))
+            serde_json::from_str(env_json).unwrap_or_else(|e| {
+                panic!("failed to parse ISSUER_KEYPAIR_JSON (expected JSON array like [1,2,3,...]): {e}")
+            })
         }
-        _ => {
+        None => {
             tracing::info!(path = %cfg.keypair_path, "loading issuer keypair from file");
             let keypair_bytes = std::fs::read(&cfg.keypair_path).unwrap_or_else(|e| {
                 panic!("failed to read keypair at {}: {e}", cfg.keypair_path)

--- a/backend/crates/issuer-service/src/main.rs
+++ b/backend/crates/issuer-service/src/main.rs
@@ -45,10 +45,21 @@ async fn main() {
 
     let cfg = Config::from_env();
 
-    let keypair_bytes = std::fs::read(&cfg.keypair_path)
-        .unwrap_or_else(|e| panic!("failed to read keypair at {}: {e}", cfg.keypair_path));
-    let keypair_json: Vec<u8> = serde_json::from_slice(&keypair_bytes)
-        .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"));
+    let keypair_json: Vec<u8> = match std::env::var("ISSUER_KEYPAIR_JSON") {
+        Ok(env_json) if !env_json.trim().is_empty() => {
+            tracing::info!("loading issuer keypair from ISSUER_KEYPAIR_JSON env var");
+            serde_json::from_str(&env_json)
+                .unwrap_or_else(|e| panic!("failed to parse ISSUER_KEYPAIR_JSON: {e}"))
+        }
+        _ => {
+            tracing::info!(path = %cfg.keypair_path, "loading issuer keypair from file");
+            let keypair_bytes = std::fs::read(&cfg.keypair_path).unwrap_or_else(|e| {
+                panic!("failed to read keypair at {}: {e}", cfg.keypair_path)
+            });
+            serde_json::from_slice(&keypair_bytes)
+                .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"))
+        }
+    };
     let keypair = Keypair::try_from(keypair_json.as_slice())
         .unwrap_or_else(|e| panic!("invalid keypair bytes: {e}"));
     let program_id: Pubkey = cfg

--- a/backend/crates/issuer-service/src/main.rs
+++ b/backend/crates/issuer-service/src/main.rs
@@ -45,22 +45,11 @@ async fn main() {
 
     let cfg = Config::from_env();
 
-    let keypair_json: Vec<u8> = match cfg.keypair_json {
-        Some(ref env_json) => {
-            tracing::info!("loading issuer keypair from ISSUER_KEYPAIR_JSON env var");
-            serde_json::from_str(env_json).unwrap_or_else(|e| {
-                panic!("failed to parse ISSUER_KEYPAIR_JSON (expected JSON array like [1,2,3,...]): {e}")
-            })
-        }
-        None => {
-            tracing::info!(path = %cfg.keypair_path, "loading issuer keypair from file");
-            let keypair_bytes = std::fs::read(&cfg.keypair_path).unwrap_or_else(|e| {
-                panic!("failed to read keypair at {}: {e}", cfg.keypair_path)
-            });
-            serde_json::from_slice(&keypair_bytes)
-                .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"))
-        }
-    };
+    let keypair_json = zksettle_config::load_keypair_json(
+        cfg.keypair_json.as_deref(),
+        &cfg.keypair_path,
+        "ISSUER_KEYPAIR_JSON",
+    );
     let keypair = Keypair::try_from(keypair_json.as_slice())
         .unwrap_or_else(|e| panic!("invalid keypair bytes: {e}"));
     let program_id: Pubkey = cfg

--- a/backend/crates/sanctions-updater/Cargo.toml
+++ b/backend/crates/sanctions-updater/Cargo.toml
@@ -25,7 +25,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 borsh = "1"
 sha2 = "0.10"
-serde_json = "1"
 mutants = "0.0.3"
 
 [dev-dependencies]

--- a/backend/crates/sanctions-updater/src/config.rs
+++ b/backend/crates/sanctions-updater/src/config.rs
@@ -3,6 +3,7 @@ use zksettle_config::{env_or, expand_tilde};
 pub struct Config {
     pub rpc_url: String,
     pub keypair_path: String,
+    pub keypair_json: Option<String>,
     pub program_id: String,
     pub update_interval_secs: u64,
     pub mock_sanctions: bool,
@@ -15,6 +16,9 @@ impl Config {
         Self {
             rpc_url: env_or("RPC_URL", "http://127.0.0.1:8899"),
             keypair_path: expand_tilde(&env_or("KEYPAIR_PATH", "~/.config/solana/id.json")),
+            keypair_json: std::env::var("ISSUER_KEYPAIR_JSON")
+                .ok()
+                .filter(|s| !s.trim().is_empty()),
             program_id: env_or("PROGRAM_ID", "zkSet11ezkSet11ezkSet11ezkSet11ezkSet11ezkS"),
             update_interval_secs: env_or("UPDATE_INTERVAL_SECS", "86400")
                 .parse()

--- a/backend/crates/sanctions-updater/src/main.rs
+++ b/backend/crates/sanctions-updater/src/main.rs
@@ -27,10 +27,22 @@ async fn main() {
         )
         .init();
 
-    let keypair_bytes = std::fs::read(&cfg.keypair_path)
-        .unwrap_or_else(|e| panic!("failed to read keypair at {}: {e}", cfg.keypair_path));
-    let keypair_json: Vec<u8> = serde_json::from_slice(&keypair_bytes)
-        .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"));
+    let keypair_json: Vec<u8> = match cfg.keypair_json {
+        Some(ref env_json) => {
+            tracing::info!("loading keypair from ISSUER_KEYPAIR_JSON env var");
+            serde_json::from_str(env_json).unwrap_or_else(|e| {
+                panic!("failed to parse ISSUER_KEYPAIR_JSON (expected JSON array like [1,2,3,...]): {e}")
+            })
+        }
+        None => {
+            tracing::info!(path = %cfg.keypair_path, "loading keypair from file");
+            let keypair_bytes = std::fs::read(&cfg.keypair_path).unwrap_or_else(|e| {
+                panic!("failed to read keypair at {}: {e}", cfg.keypair_path)
+            });
+            serde_json::from_slice(&keypair_bytes)
+                .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"))
+        }
+    };
     let keypair = Keypair::try_from(keypair_json.as_slice())
         .unwrap_or_else(|e| panic!("invalid keypair bytes: {e}"));
     let program_id: Pubkey = cfg

--- a/backend/crates/sanctions-updater/src/main.rs
+++ b/backend/crates/sanctions-updater/src/main.rs
@@ -27,22 +27,11 @@ async fn main() {
         )
         .init();
 
-    let keypair_json: Vec<u8> = match cfg.keypair_json {
-        Some(ref env_json) => {
-            tracing::info!("loading keypair from ISSUER_KEYPAIR_JSON env var");
-            serde_json::from_str(env_json).unwrap_or_else(|e| {
-                panic!("failed to parse ISSUER_KEYPAIR_JSON (expected JSON array like [1,2,3,...]): {e}")
-            })
-        }
-        None => {
-            tracing::info!(path = %cfg.keypair_path, "loading keypair from file");
-            let keypair_bytes = std::fs::read(&cfg.keypair_path).unwrap_or_else(|e| {
-                panic!("failed to read keypair at {}: {e}", cfg.keypair_path)
-            });
-            serde_json::from_slice(&keypair_bytes)
-                .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"))
-        }
-    };
+    let keypair_json = zksettle_config::load_keypair_json(
+        cfg.keypair_json.as_deref(),
+        &cfg.keypair_path,
+        "ISSUER_KEYPAIR_JSON",
+    );
     let keypair = Keypair::try_from(keypair_json.as_slice())
         .unwrap_or_else(|e| panic!("invalid keypair bytes: {e}"));
     let program_id: Pubkey = cfg

--- a/backend/crates/zksettle-config/Cargo.toml
+++ b/backend/crates/zksettle-config/Cargo.toml
@@ -2,3 +2,7 @@
 name = "zksettle-config"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+serde_json = "1"
+tracing = "0.1"

--- a/backend/crates/zksettle-config/src/lib.rs
+++ b/backend/crates/zksettle-config/src/lib.rs
@@ -14,6 +14,36 @@ pub fn expand_tilde(path: &str) -> String {
     path.to_string()
 }
 
+/// Load a Solana keypair JSON byte array either from the given env-var string
+/// (when `Some`) or from `file_path` (when `None`). Panics with a descriptive
+/// message on any parse or I/O failure.
+///
+/// `env_var_name` is used purely for log/panic messages so operators can tell
+/// which env var was consulted.
+pub fn load_keypair_json(
+    env_keypair: Option<&str>,
+    file_path: &str,
+    env_var_name: &str,
+) -> Vec<u8> {
+    match env_keypair {
+        Some(env_json) => {
+            tracing::info!("loading keypair from {} env var", env_var_name);
+            serde_json::from_str(env_json).unwrap_or_else(|e| {
+                panic!(
+                    "failed to parse {env_var_name} (expected JSON array like [1,2,3,...]): {e}"
+                )
+            })
+        }
+        None => {
+            tracing::info!(path = %file_path, "loading keypair from file");
+            let bytes = std::fs::read(file_path)
+                .unwrap_or_else(|e| panic!("failed to read keypair at {file_path}: {e}"));
+            serde_json::from_slice(&bytes)
+                .unwrap_or_else(|e| panic!("failed to parse keypair JSON: {e}"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -40,3 +40,10 @@ sonar.cpd.exclusions=\
 
 # Exclude CLI scripts, SDK, and frontend from coverage analysis
 sonar.coverage.exclusions=scripts/**/*,sdk/**/*,frontend/**/*
+
+# Suppress "missing Cargo.lock" rule on workspace-member Cargo.toml files.
+# Cargo workspaces share a single Cargo.lock at the workspace root
+# (backend/Cargo.lock); per-member lockfiles are forbidden by Cargo.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=text:S8570
+sonar.issue.ignore.multicriteria.e1.resourceKey=backend/crates/**/Cargo.toml


### PR DESCRIPTION
## Summary
- Issuer service now reads keypair from `ISSUER_KEYPAIR_JSON` env var when set
- Falls back to `KEYPAIR_PATH` file when env var unset/empty (backward compatible)
- Unblocks Railway-style deploys where mounting secret files is impractical

## Why
Railway has no UI for uploading secret files into containers. The previous file-only path forced workarounds (custom start commands writing env-to-file). Reading the env var directly is cleaner and keeps the secret out of the filesystem.

## Test plan
- [x] `cargo check -p issuer-service` passes
- [x] `cargo clippy -p issuer-service -- -D warnings` clean
- [x] `cargo test -p issuer-service --bins` 79 passed
- [ ] Set `ISSUER_KEYPAIR_JSON` on Railway → deploy → verify logs show "loading issuer keypair from ISSUER_KEYPAIR_JSON env var"
- [ ] Local dev unchanged (no env var set → file path used)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issuer keypair can now be loaded directly from an environment variable, with automatic fallback to file-based configuration when the variable is not set or empty

* **Improvements**
  * Enhanced error handling and reporting during server startup for keypair configuration operations, including improved contextual error messages for both loading methods

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/184)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->