### PR TITLE
fix(indexer): use dedicated migration table for shared DB

### DIFF
--- a/backend/crates/indexer/migration/src/lib.rs
+++ b/backend/crates/indexer/migration/src/lib.rs
@@ -8,6 +8,10 @@ pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
+    fn migration_table_name() -> sea_orm::DynIden {
+        sea_orm::sea_query::Alias::new("seaql_migrations_indexer").into_iden()
+    }
+
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
             Box::new(m20260430_001_create_events_table::Migration),


### PR DESCRIPTION
## Summary
- Indexer and api-gateway share a single Postgres instance on Railway
- Both services' SeaORM migrators used the default `seaql_migrations` table, causing the indexer to crash on gateway migration records it doesn't own
- Override `migration_table_name()` in the indexer migrator to use `seaql_migrations_indexer`, isolating each service's migration tracking

## Deploy steps
1. Merge this PR
2. Drop the shared Postgres DB (or just delete all tables)
3. Redeploy both services — each will create its own migration table and run migrations cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration configuration to ensure proper table naming in the indexer service.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/185)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->