### PR TITLE
Wire settle_hook in prove flow so events table populates

### DIFF
--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -337,7 +337,7 @@ async function runStepSubmit(
   }
   const signedInitResize = await signAllTransactions(initResizeTxs);
   for (const tx of signedInitResize) {
-    await sendSigned(tx!, bh1);
+    await sendSigned(tx, bh1);
   }
 
   // ── Batch 2: writes only (fresh blockhash + Phantom popup) ──

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -402,17 +402,14 @@ async function runStepSubmit(
   return finalSig;
 }
 
-async function runStepConfirm(
-  dispatch: Dispatch<FlowAction>,
-  connection: Connection,
-  txSignature: string | undefined,
-): Promise<void> {
+async function runStepConfirm(dispatch: Dispatch<FlowAction>): Promise<void> {
+  // Step 4 (`runStepSubmit`) already awaited `confirmTransaction` for the
+  // settle tx using its original signing blockhash. Re-confirming here with a
+  // freshly-fetched blockhash would (a) decouple the wait-loop expiry from
+  // the actual tx (Solana docs explicitly warn against this) and (b) be
+  // redundant. Keep this step purely for the UI step-machine.
   dispatch({ type: "STEP_RUNNING", step: 5 });
   const start = performance.now();
-  if (txSignature) {
-    const latestBlockhash = await connection.getLatestBlockhash("confirmed");
-    await connection.confirmTransaction({ signature: txSignature, ...latestBlockhash }, "confirmed");
-  }
   dispatch({
     type: "STEP_SUCCESS",
     step: 5,
@@ -480,7 +477,7 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
     return;
   }
 
-  try { await runStepConfirm(dispatch, connection, txSignature); }
+  try { await runStepConfirm(dispatch); }
   catch (err) {
     if (txSignature) { stepError(dispatch, 5, err, "Confirmation failed"); }
     else { dispatch({ type: "STEP_SUCCESS", step: 5 }); }

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -286,16 +286,14 @@ async function runStepSubmit(
 
   const initIx = await buildInitHookPayloadIx(publicKey, proofBytes.length, connection);
 
-  // Solana caps realloc at 10 KiB per instruction. Compute how many
-  // resize instructions are needed to grow from header-only to full size.
-  const BASE_SPACE = 293;
-  const headerSize = 8 + BASE_SPACE;
-  const targetSize = headerSize + proofBytes.length;
+  // Solana caps realloc at 10 KiB per instruction. Pre-count resize ixs so
+  // they batch into one Phantom popup with init. Upper-bound the count from
+  // proof size alone so we never under-allocate (extra resizes are idempotent
+  // no-ops on-chain). Avoids hardcoding HookPayload::BASE_SPACE on the client.
+  const resizeCount = Math.ceil(proofBytes.length / 10_240);
   const resizeIxs = [];
-  let currentSize = headerSize;
-  while (currentSize < targetSize) {
+  for (let i = 0; i < resizeCount; i++) {
     resizeIxs.push(await buildResizeHookPayloadIx(publicKey, connection));
-    currentSize = Math.min(targetSize, currentSize + 10_240);
   }
 
   const writeIxs = [];

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -226,6 +226,7 @@ async function runStepSubmit(
     checkHookPayloadExists, buildCloseHookPayloadIx,
     buildInitHookPayloadIx, buildResizeHookPayloadIx,
     buildWriteChunkIx, buildFinalizeHookPayloadIx,
+    buildSettleHookIx,
     CHUNK_SIZE,
   } = sdk;
 
@@ -366,7 +367,22 @@ async function runStepSubmit(
   finalizeTx.feePayer = publicKey;
   finalizeTx.recentBlockhash = bh3.blockhash;
   const [signedFinalize] = await signAllTransactions([finalizeTx]);
-  const finalSig = await sendSigned(signedFinalize!);
+  await sendSigned(signedFinalize!);
+
+  // ── Batch 4: settle_hook — invokes gnark verifier, emits ProofSettled,
+  // closes the payload PDA and refunds rent. Without this the indexer
+  // never sees a ProofSettled event and the events table stays empty.
+  const settleIx = await buildSettleHookIx(
+    publicKey,
+    new BN(transferParams.amount),
+    connection,
+  );
+  const settleTx = new Transaction().add(settleIx);
+  const bh4 = await connection.getLatestBlockhash("confirmed");
+  settleTx.feePayer = publicKey;
+  settleTx.recentBlockhash = bh4.blockhash;
+  const [signedSettle] = await signAllTransactions([settleTx]);
+  const finalSig = await sendSigned(signedSettle!);
 
   dispatch({ type: "SET_TX", signature: finalSig });
   dispatch({

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -235,17 +235,25 @@ async function runStepSubmit(
     return new Uint8Array(clean.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []);
   };
 
-  const confirmTx = async (sig: string) => {
-    const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
-    await connection.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+  // `confirmTransaction({signature, blockhash, lastValidBlockHeight})` ties
+  // the wait-loop expiry to the SAME blockhash the tx was signed with.
+  // Fetching a fresh blockhash here decouples the timeout from actual tx
+  // expiry and can yield false timeouts / false success (Solana docs).
+  // Always pass the bh that was set on `tx.recentBlockhash` before signing.
+  type Blockhash = { blockhash: string; lastValidBlockHeight: number };
+  const confirmTx = async (sig: string, bh: Blockhash) => {
+    await connection.confirmTransaction(
+      { signature: sig, blockhash: bh.blockhash, lastValidBlockHeight: bh.lastValidBlockHeight },
+      "confirmed",
+    );
   };
 
-  const sendSigned = async (signed: Transaction) => {
+  const sendSigned = async (signed: Transaction, bh: Blockhash) => {
     const sig = await connection.sendRawTransaction(signed.serialize(), {
       skipPreflight: true,
       maxRetries: 3,
     });
-    await confirmTx(sig);
+    await confirmTx(sig, bh);
     return sig;
   };
 
@@ -261,9 +269,10 @@ async function runStepSubmit(
     }, connection);
     const tx = new Transaction().add(ix);
     tx.feePayer = publicKey;
-    tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
+    const bhRegister = await connection.getLatestBlockhash("confirmed");
+    tx.recentBlockhash = bhRegister.blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed!);
+    await sendSigned(signed!, bhRegister);
   }
 
   const stalePayload = await checkHookPayloadExists(publicKey, connection);
@@ -271,9 +280,10 @@ async function runStepSubmit(
     const ix = await buildCloseHookPayloadIx(publicKey, connection);
     const tx = new Transaction().add(ix);
     tx.feePayer = publicKey;
-    tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
+    const bhClose = await connection.getLatestBlockhash("confirmed");
+    tx.recentBlockhash = bhClose.blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed!);
+    await sendSigned(signed!, bhClose);
   }
 
   // ── Build ALL proof upload transactions upfront ──
@@ -327,7 +337,7 @@ async function runStepSubmit(
   }
   const signedInitResize = await signAllTransactions(initResizeTxs);
   for (const tx of signedInitResize) {
-    await sendSigned(tx!);
+    await sendSigned(tx!, bh1);
   }
 
   // ── Batch 2: writes only (fresh blockhash + Phantom popup) ──
@@ -357,7 +367,7 @@ async function runStepSubmit(
 
   // Confirming the last write guarantees all prior writes landed (each
   // write's offset must match the cumulative high_water_mark).
-  if (lastWriteSig) await confirmTx(lastWriteSig);
+  if (lastWriteSig) await confirmTx(lastWriteSig, bh2);
 
   // ── Batch 3: finalize (own fresh blockhash + Phantom popup) ──
   const finalizeTx = new Transaction().add(finalizeIx);
@@ -365,7 +375,7 @@ async function runStepSubmit(
   finalizeTx.feePayer = publicKey;
   finalizeTx.recentBlockhash = bh3.blockhash;
   const [signedFinalize] = await signAllTransactions([finalizeTx]);
-  await sendSigned(signedFinalize!);
+  await sendSigned(signedFinalize!, bh3);
 
   // ── Batch 4: settle_hook — invokes gnark verifier, emits ProofSettled,
   // closes the payload PDA and refunds rent. Without this the indexer
@@ -380,7 +390,7 @@ async function runStepSubmit(
   settleTx.feePayer = publicKey;
   settleTx.recentBlockhash = bh4.blockhash;
   const [signedSettle] = await signAllTransactions([settleTx]);
-  const finalSig = await sendSigned(signedSettle!);
+  const finalSig = await sendSigned(signedSettle!, bh4);
 
   dispatch({ type: "SET_TX", signature: finalSig });
   dispatch({

--- a/gotchas.md
+++ b/gotchas.md
@@ -8,15 +8,17 @@ Program flow requires: `init_hook_payload` → `resize_hook_payload` → `write_
 
 For proofs > ~10 KB the client must call `resizeHookPayload()` multiple times until `data_len >= target`.
 
-## Helius webhook auth: `Bearer ` prefix required
+<!-- markdownlint-disable-next-line MD038 -->
+## Helius webhook auth: `Bearer ` prefix required (with trailing space)
 
-Indexer `verify_auth` (routes/webhook.rs) strips `Bearer ` prefix from `Authorization` header. Helius sends the auth header value verbatim, so the dashboard's "Authentication Header" field must include `Bearer ` prefix:
+<!-- markdownlint-disable-next-line MD038 -->
+Indexer `verify_auth` (`backend/crates/indexer/src/routes/webhook.rs:107`) strips the literal 7-character prefix `Bearer ` from the `Authorization` header. The trailing space matters — Helius sends the dashboard's "Authentication Header" value verbatim, so it must be exactly:
 
-```
+```text
 Bearer <INDEXER_HELIUS_AUTH_TOKEN value>
 ```
 
-Without prefix → 401. After fix → 200.
+Without the prefix (or with the space missing) → 401. After fix → 200.
 
 ## Frontend prove flow was missing `settle_hook` call entirely
 
@@ -27,3 +29,23 @@ Settlement path (direct call) needs ~13 accounts including `registry.merkle_tree
 ## SDK `uploadProofChunked` skipped resize step
 
 Same bug as the original `transfer.ts`: helper exported from the SDK but built `init → write → finalize` only. Fortunately nothing outside the SDK called it, so no production impact — but the helper itself would have panicked on first use. Fixed to include `resize_hook_payload` loop matching the on-chain realloc cap (10 KiB / ix).
+
+## `confirmTransaction` MUST use the same blockhash the tx was signed with
+
+In `@solana/web3.js`, `connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, commitment)` ties the wait-loop's expiry to the supplied `lastValidBlockHeight`. Confirming a tx using a **fresh** `getLatestBlockhash()` instead of the one that was set on `tx.recentBlockhash` decouples the timeout from the actual tx expiry — Solana docs explicitly warn this yields incorrect results (false timeouts or false success). The string-only deprecated overload `confirmTransaction(sig, commitment)` is safer than passing a mismatched strategy because it just polls signature status. Pattern in this repo: capture `bh = await getLatestBlockhash("confirmed")`, set `tx.recentBlockhash = bh.blockhash`, sign+send, then confirm using the *same* `bh`.
+
+## Anchor 0.31 `new Program(idl, provider)` uses `idl.address`, not a separate `programId` arg
+
+`@coral-xyz/anchor` 0.31 dropped the `programId` parameter from the `Program` constructor. The program address comes from `idl.address`. If a wrapper helper accepts a `programId` override and derives PDAs from it but constructs the `Program` from the raw IDL, the helper will derive PDAs for one program while encoding the instruction with the IDL's embedded address — silent mismatch. Always clone the IDL and override `idl.address = programId.toBase58()` before `new Program(...)` when honoring a programId override.
+
+## `signAndSend` callbacks: confirmation contract must be explicit
+
+In `ChunkedUploadOptions.signAndSend(tx) => Promise<string>` (SDK `uploadProofChunked`) the contract did not require the callback to confirm — only sign+send. Reading `getAccountInfo` immediately after a send races the network: the account may be `null` or stale, tripping the new "missing after init/resize" guards. Fix: either document confirmation as part of the callback contract, or have the SDK explicitly `await connection.confirmTransaction(sig, ...)` before reading. Picking the latter is more defensive because most wallet adapters' `signAndSendTransaction` returns after broadcast, not after confirmation.
+
+## `write_hook_proof` ordering: confirm between writes too
+
+The same `signAndSend`-resolves-on-broadcast hazard bites the write loop in `uploadProofChunked`. `write_hook_proof_handler` enforces `offset == high_water_mark`; if the wallet adapter returns after broadcast, the next chunk's submit can race ahead of the previous one and the program rejects it. Unlike the frontend (which sets `maxRetries: 5` on `sendRawTransaction`), the SDK has no retry path, so out-of-order arrival is unrecoverable. Confirm each chunk before the next — same pattern as init/resize. The finalize step also reads cumulative high_water_mark, so the last write must be confirmed before finalize (subsumed by per-write confirm).
+
+## `runStepConfirm` is purely UI now — do not re-confirm
+
+`use-prove-flow.ts` step 4 (`runStepSubmit`) already awaits `confirmTransaction` for the settle tx using its **original signing blockhash**. Re-confirming in step 5 with a fresh `getLatestBlockhash()` would re-introduce the very bug step 4 fixed (decoupled wait-loop expiry). Step 5 exists only to drive the UI step machine — keep it side-effect free.

--- a/gotchas.md
+++ b/gotchas.md
@@ -1,0 +1,29 @@
+# Gotchas
+
+## scripts/devnet-hook/transfer.ts: missing `resize_hook_payload` call
+
+Program flow requires: `init_hook_payload` → `resize_hook_payload` → `write_hook_proof` → `finalize_hook_payload` → `settle_hook`.
+
+`init_hook_payload` only allocates `BASE_SPACE` (header). `resize_hook_payload` is what grows the PDA AND allocates `proof_and_witness: vec![0u8; expected]`. Skipping resize leaves the Vec at length 0, so `write_hook_proof_handler` panics at `handlers.rs:91` on `copy_from_slice` into len-0 slice with message `range end index N out of range for slice of length 0`.
+
+For proofs > ~10 KB the client must call `resizeHookPayload()` multiple times until `data_len >= target`.
+
+## Helius webhook auth: `Bearer ` prefix required
+
+Indexer `verify_auth` (routes/webhook.rs) strips `Bearer ` prefix from `Authorization` header. Helius sends the auth header value verbatim, so the dashboard's "Authentication Header" field must include `Bearer ` prefix:
+
+```
+Bearer <INDEXER_HELIUS_AUTH_TOKEN value>
+```
+
+Without prefix → 401. After fix → 200.
+
+## Frontend prove flow was missing `settle_hook` call entirely
+
+`use-prove-flow.ts` stopped at `finalizeHookPayload`. No `settleHook`, no Token-2022 `transferChecked` triggering the hook. Result: real proofs were staged in the `hook_payload` PDA but the verifier never ran, so `ProofSettled` was never emitted and the indexer's `events` table stayed empty — even with a fully wired Helius → indexer pipeline returning 200.
+
+Settlement path (direct call) needs ~13 accounts including `registry.merkle_tree` (fetch from chain) and PDAs `tree_config` / `tree_creator`. `buildSettleHookIx` in `sdk/src/wrap/index.ts` resolves them.
+
+## SDK `uploadProofChunked` skipped resize step
+
+Same bug as the original `transfer.ts`: helper exported from the SDK but built `init → write → finalize` only. Fortunately nothing outside the SDK called it, so no production impact — but the helper itself would have panicked on first use. Fixed to include `resize_hook_payload` loop matching the on-chain realloc cap (10 KiB / ix).

--- a/scripts/devnet-hook/transfer.ts
+++ b/scripts/devnet-hook/transfer.ts
@@ -218,6 +218,31 @@ async function main() {
       .rpc();
     console.log(`Payload init: tx ${initSig}`);
 
+    // 1a-bis. resize_hook_payload — grow PDA + allocate proof_and_witness vec.
+    // Required before write_hook_proof or the vec stays length 0.
+    // Solana caps realloc at 10 KiB / ix, so loop until on-chain data.length
+    // has grown by proofBytes.length bytes (avoids hardcoding BASE_SPACE).
+    const baselineInfo = await connection.getAccountInfo(hookPayloadPda);
+    if (!baselineInfo) throw new Error("hook_payload PDA missing after init");
+    const headerSize = baselineInfo.data.length;
+    const targetSize = headerSize + proofBytes.length;
+    let currentSize = headerSize;
+    while (currentSize < targetSize) {
+      const resizeSig = await program.methods
+        .resizeHookPayload()
+        .accounts({
+          authority: wallet.publicKey,
+          issuer: issuerPda,
+          hookPayload: hookPayloadPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+      console.log(`Payload resized: tx ${resizeSig}`);
+      const after = await connection.getAccountInfo(hookPayloadPda);
+      if (!after) throw new Error("hook_payload PDA missing after resize");
+      currentSize = after.data.length;
+    }
+
     // 1b. write_hook_proof — upload proof in one chunk (< 1KB fits single tx)
     const writeSig = await program.methods
       .writeHookProof(0, proofBytes)

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,6 +4,7 @@ export {
   buildResizeHookPayloadIx,
   buildWriteChunkIx,
   buildFinalizeHookPayloadIx,
+  buildSettleHookIx,
   uploadProofChunked,
   checkIssuerExists,
   buildRegisterIssuerIx,

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -76,7 +76,7 @@ export async function buildRegisterIssuerIx(
   program?: Program,
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .registerIssuer(
@@ -109,7 +109,7 @@ export async function buildCloseHookPayloadIx(
   program?: Program,
 ): Promise<TransactionInstruction> {
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .closeHookPayload()
@@ -120,11 +120,19 @@ export async function buildCloseHookPayloadIx(
     .instruction();
 }
 
-async function makeProgram(connection: Connection): Promise<Program> {
+async function makeProgram(
+  connection: Connection,
+  programId: PublicKey = ZKSETTLE_PROGRAM_ID,
+): Promise<Program> {
   const { AnchorProvider, Program } = await loadAnchorBrowser();
   const dummyWallet = new DummyWallet();
   const provider = new AnchorProvider(connection, dummyWallet as any, {});
-  return new Program(idl as any, provider);
+  // Anchor 0.31 reads the program address from `idl.address`; the old
+  // `new Program(idl, programId, provider)` form was removed. Honor a
+  // caller-supplied override by cloning the IDL with a new address — otherwise
+  // PDAs derived from `programId` would mismatch the ix target address.
+  const idlWithAddress = { ...(idl as any), address: programId.toBase58() };
+  return new Program(idlWithAddress, provider);
 }
 
 export async function buildInitHookPayloadIx(
@@ -136,7 +144,7 @@ export async function buildInitHookPayloadIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .initHookPayload(proofLen)
@@ -157,7 +165,7 @@ export async function buildResizeHookPayloadIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .resizeHookPayload()
@@ -180,7 +188,7 @@ export async function buildWriteChunkIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .writeHookProof(offset, Buffer.from(chunk))
@@ -208,7 +216,7 @@ export async function buildFinalizeHookPayloadIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   const lightArgs = metadata.lightArgs ?? DEFAULT_LIGHT_ARGS;
 
@@ -240,7 +248,7 @@ export async function buildSettleHookIx(
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
   const [registryPda] = findRegistryPda(programId);
   const [treeCreatorPda] = findTreeCreatorPda(programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   // Fetch registry (resolves merkle_tree; settle_hook enforces
   // `merkle_tree == registry.merkle_tree`) and hook_payload (recipient/mint
@@ -284,7 +292,7 @@ export async function uploadProofChunked(
   const raw = opts.chunkSize ?? CHUNK_SIZE;
   const chunkSize = Math.max(1, Math.floor(raw));
   const proofBytes = opts.proof;
-  const program = await makeProgram(opts.connection);
+  const program = await makeProgram(opts.connection, programId);
 
   console.log("[zksettle-sdk] uploadProofChunked: building initHookPayload ix", {
     wallet: opts.wallet.toBase58(),

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -308,6 +308,11 @@ export async function uploadProofChunked(
   console.log("[zksettle-sdk] uploadProofChunked: sending initHookPayload tx...");
   const initSignature = await signAndSend(new Transaction().add(initIx));
   console.log("[zksettle-sdk] uploadProofChunked: initHookPayload sig:", initSignature);
+  // `signAndSend` is caller-supplied — wallet adapters typically resolve after
+  // broadcast, not after confirmation. Explicitly confirm before any
+  // getAccountInfo read so the loop below doesn't race a null/stale account.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
+  await opts.connection.confirmTransaction(initSignature, "confirmed");
 
   // resize_hook_payload grows the PDA AND allocates `proof_and_witness`.
   // Without it write_hook_proof panics copying into a zero-length Vec.
@@ -331,7 +336,12 @@ export async function uploadProofChunked(
       programId,
       program,
     );
-    await signAndSend(new Transaction().add(resizeIx));
+    const resizeSig = await signAndSend(new Transaction().add(resizeIx));
+    // Same rationale as the post-init confirm: the loop terminates on
+    // observed account size, so we must wait for the resize to land before
+    // reading or the loop can hang reading the pre-resize size.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
+    await opts.connection.confirmTransaction(resizeSig, "confirmed");
     const after = await opts.connection.getAccountInfo(hookPayloadPda);
     if (!after) {
       throw new Error("hook_payload PDA missing after resize");
@@ -362,6 +372,13 @@ export async function uploadProofChunked(
       tx.add(ix);
     }
     const sig = await signAndSend(tx);
+    // `write_hook_proof` enforces `offset == high_water_mark` on-chain. If
+    // `signAndSend` resolves on broadcast (typical wallet-adapter behavior),
+    // the next chunk's submit can race ahead of the previous one and the
+    // program rejects it. There is no SDK-side retry, so confirm before the
+    // next write.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
+    await opts.connection.confirmTransaction(sig, "confirmed");
     chunkSignatures.push(sig);
   }
 

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -14,8 +14,19 @@ import type {
   ChunkedUploadResult,
 } from "../types.js";
 import { loadAnchorBrowser } from "../anchor.js";
-import { ZKSETTLE_PROGRAM_ID } from "../constants.js";
-import { findIssuerPda, findHookPayloadPda } from "./pda.js";
+import {
+  ZKSETTLE_PROGRAM_ID,
+  MPL_BUBBLEGUM_ID,
+  SPL_ACCOUNT_COMPRESSION_ID,
+  SPL_NOOP_ID,
+} from "../constants.js";
+import {
+  findIssuerPda,
+  findHookPayloadPda,
+  findRegistryPda,
+  findTreeCreatorPda,
+  findTreeConfigPda,
+} from "./pda.js";
 import idl from "../idl/zksettle.json" with { type: "json" };
 
 // Minimal wallet shim that satisfies AnchorProvider without importing
@@ -214,6 +225,53 @@ export async function buildFinalizeHookPayloadIx(
       authority: wallet,
       issuer: issuerPda,
       hookPayload: hookPayloadPda,
+    })
+    .instruction();
+}
+
+export async function buildSettleHookIx(
+  wallet: PublicKey,
+  amount: AnchorBN,
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+  program?: Program,
+): Promise<TransactionInstruction> {
+  const [issuerPda] = findIssuerPda(wallet, programId);
+  const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
+  const [registryPda] = findRegistryPda(programId);
+  const [treeCreatorPda] = findTreeCreatorPda(programId);
+  const prog = program ?? await makeProgram(connection);
+
+  // Fetch registry (resolves merkle_tree; settle_hook enforces
+  // `merkle_tree == registry.merkle_tree`) and hook_payload (recipient/mint
+  // staged at finalize; both `destination_token` and `leaf_owner` must equal
+  // recipient) in parallel — independent reads.
+  const [registry, payload] = await Promise.all([
+    (prog.account as any).bubblegumTreeRegistry.fetch(registryPda),
+    (prog.account as any).hookPayload.fetch(hookPayloadPda),
+  ]);
+  const merkleTree: PublicKey = registry.merkleTree;
+  const [treeConfigPda] = findTreeConfigPda(merkleTree);
+  const recipient: PublicKey = payload.recipient;
+  const mint: PublicKey = payload.mint;
+
+  return prog.methods
+    .settleHook(amount)
+    .accounts({
+      authority: wallet,
+      mint,
+      destinationToken: recipient,
+      hookPayload: hookPayloadPda,
+      leafOwner: recipient,
+      issuer: issuerPda,
+      registry: registryPda,
+      merkleTree,
+      treeConfig: treeConfigPda,
+      treeCreator: treeCreatorPda,
+      bubblegumProgram: MPL_BUBBLEGUM_ID,
+      compressionProgram: SPL_ACCOUNT_COMPRESSION_ID,
+      logWrapper: SPL_NOOP_ID,
+      systemProgram: SystemProgram.programId,
     })
     .instruction();
 }

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -306,13 +306,26 @@ export async function uploadProofChunked(
     program,
   );
   console.log("[zksettle-sdk] uploadProofChunked: sending initHookPayload tx...");
-  const initSignature = await signAndSend(new Transaction().add(initIx));
+  // Pre-set blockhash + feePayer so we can use the non-deprecated
+  // strategy-form confirmTransaction below. Wallet adapters preserve
+  // these when already set.
+  const initTx = new Transaction().add(initIx);
+  initTx.feePayer = opts.wallet;
+  const initBh = await opts.connection.getLatestBlockhash("confirmed");
+  initTx.recentBlockhash = initBh.blockhash;
+  const initSignature = await signAndSend(initTx);
   console.log("[zksettle-sdk] uploadProofChunked: initHookPayload sig:", initSignature);
   // `signAndSend` is caller-supplied — wallet adapters typically resolve after
   // broadcast, not after confirmation. Explicitly confirm before any
   // getAccountInfo read so the loop below doesn't race a null/stale account.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
-  await opts.connection.confirmTransaction(initSignature, "confirmed");
+  await opts.connection.confirmTransaction(
+    {
+      signature: initSignature,
+      blockhash: initBh.blockhash,
+      lastValidBlockHeight: initBh.lastValidBlockHeight,
+    },
+    "confirmed",
+  );
 
   // resize_hook_payload grows the PDA AND allocates `proof_and_witness`.
   // Without it write_hook_proof panics copying into a zero-length Vec.
@@ -336,12 +349,22 @@ export async function uploadProofChunked(
       programId,
       program,
     );
-    const resizeSig = await signAndSend(new Transaction().add(resizeIx));
+    const resizeTx = new Transaction().add(resizeIx);
+    resizeTx.feePayer = opts.wallet;
+    const resizeBh = await opts.connection.getLatestBlockhash("confirmed");
+    resizeTx.recentBlockhash = resizeBh.blockhash;
+    const resizeSig = await signAndSend(resizeTx);
     // Same rationale as the post-init confirm: the loop terminates on
     // observed account size, so we must wait for the resize to land before
     // reading or the loop can hang reading the pre-resize size.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
-    await opts.connection.confirmTransaction(resizeSig, "confirmed");
+    await opts.connection.confirmTransaction(
+      {
+        signature: resizeSig,
+        blockhash: resizeBh.blockhash,
+        lastValidBlockHeight: resizeBh.lastValidBlockHeight,
+      },
+      "confirmed",
+    );
     const after = await opts.connection.getAccountInfo(hookPayloadPda);
     if (!after) {
       throw new Error("hook_payload PDA missing after resize");
@@ -371,14 +394,23 @@ export async function uploadProofChunked(
     for (const ix of writeIxs.slice(i, i + WRITES_PER_TX)) {
       tx.add(ix);
     }
+    tx.feePayer = opts.wallet;
+    const writeBh = await opts.connection.getLatestBlockhash("confirmed");
+    tx.recentBlockhash = writeBh.blockhash;
     const sig = await signAndSend(tx);
     // `write_hook_proof` enforces `offset == high_water_mark` on-chain. If
     // `signAndSend` resolves on broadcast (typical wallet-adapter behavior),
     // the next chunk's submit can race ahead of the previous one and the
     // program rejects it. There is no SDK-side retry, so confirm before the
     // next write.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
-    await opts.connection.confirmTransaction(sig, "confirmed");
+    await opts.connection.confirmTransaction(
+      {
+        signature: sig,
+        blockhash: writeBh.blockhash,
+        lastValidBlockHeight: writeBh.lastValidBlockHeight,
+      },
+      "confirmed",
+    );
     chunkSignatures.push(sig);
   }
 

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -301,6 +301,36 @@ export async function uploadProofChunked(
   const initSignature = await signAndSend(new Transaction().add(initIx));
   console.log("[zksettle-sdk] uploadProofChunked: initHookPayload sig:", initSignature);
 
+  // resize_hook_payload grows the PDA AND allocates `proof_and_witness`.
+  // Without it write_hook_proof panics copying into a zero-length Vec.
+  // Solana realloc cap = 10 KiB / ix, so large proofs need multiple calls.
+  // Loop terminates on observed on-chain account size: capture the
+  // header-only baseline right after init, then resize until the account
+  // has grown by `proofBytes.length` bytes. This avoids hardcoding
+  // HookPayload::BASE_SPACE (which can drift if StagedLightArgs changes).
+  const [hookPayloadPda] = findHookPayloadPda(opts.wallet, programId);
+  const baselineInfo = await opts.connection.getAccountInfo(hookPayloadPda);
+  if (!baselineInfo) {
+    throw new Error("hook_payload PDA missing after init");
+  }
+  const headerSize = baselineInfo.data.length;
+  const targetSize = headerSize + proofBytes.length;
+  let currentSize = headerSize;
+  while (currentSize < targetSize) {
+    const resizeIx = await buildResizeHookPayloadIx(
+      opts.wallet,
+      opts.connection,
+      programId,
+      program,
+    );
+    await signAndSend(new Transaction().add(resizeIx));
+    const after = await opts.connection.getAccountInfo(hookPayloadPda);
+    if (!after) {
+      throw new Error("hook_payload PDA missing after resize");
+    }
+    currentSize = after.data.length;
+  }
+
   const writeIxs: TransactionInstruction[] = [];
   for (let offset = 0; offset < proofBytes.length; offset += chunkSize) {
     const end = Math.min(offset + chunkSize, proofBytes.length);

--- a/sdk/src/wrap/settle.test.ts
+++ b/sdk/src/wrap/settle.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import { AnchorProvider, Program } from "@coral-xyz/anchor";
+import idl from "../idl/zksettle.json" with { type: "json" };
+import { buildSettleHookIx } from "./index.js";
+import {
+  findHookPayloadPda,
+  findIssuerPda,
+  findRegistryPda,
+  findTreeConfigPda,
+  findTreeCreatorPda,
+} from "./pda.js";
+import {
+  MPL_BUBBLEGUM_ID,
+  SPL_ACCOUNT_COMPRESSION_ID,
+  SPL_NOOP_ID,
+  ZKSETTLE_PROGRAM_ID,
+} from "../constants.js";
+
+const SETTLE_HOOK_DISCRIMINATOR = new Uint8Array([188, 162, 182, 6, 30, 19, 21, 139]);
+
+class DummyWallet {
+  readonly payer = Keypair.generate();
+  readonly publicKey = this.payer.publicKey;
+  async signTransaction<T>(tx: T): Promise<T> { return tx; }
+  async signAllTransactions<T>(txs: T[]): Promise<T[]> { return txs; }
+}
+
+function buildProgram() {
+  // Connection URL is never hit; AnchorProvider/Program construction is RPC-free
+  // and we mock the only `.account.X.fetch` calls below.
+  const connection = new Connection("http://127.0.0.1:8899");
+  const provider = new AnchorProvider(connection, new DummyWallet() as any, {});
+  return new Program(idl as any, provider);
+}
+
+describe("buildSettleHookIx", () => {
+  const authority = Keypair.generate().publicKey;
+  const merkleTree = Keypair.generate().publicKey;
+  const recipient = Keypair.generate().publicKey;
+  const mint = Keypair.generate().publicKey;
+  const amount = new BN(1_234_567);
+
+  let program: Program;
+  let registryFetch: ReturnType<typeof vi.fn>;
+  let payloadFetch: ReturnType<typeof vi.fn>;
+  let ix: Awaited<ReturnType<typeof buildSettleHookIx>>;
+
+  beforeAll(async () => {
+    program = buildProgram();
+    registryFetch = vi.fn().mockResolvedValue({ merkleTree });
+    payloadFetch = vi.fn().mockResolvedValue({ recipient, mint });
+    (program.account as any).bubblegumTreeRegistry.fetch = registryFetch;
+    (program.account as any).hookPayload.fetch = payloadFetch;
+
+    const connection = new Connection("http://127.0.0.1:8899");
+    ix = await buildSettleHookIx(
+      authority,
+      amount as any,
+      connection,
+      ZKSETTLE_PROGRAM_ID,
+      program,
+    );
+  });
+
+  it("targets the zksettle program", () => {
+    expect(ix.programId.equals(ZKSETTLE_PROGRAM_ID)).toBe(true);
+  });
+
+  it("has 14 accounts (matches IDL SettleHook ctx)", () => {
+    expect(ix.keys).toHaveLength(14);
+  });
+
+  it("encodes the settle_hook discriminator", () => {
+    expect(Buffer.from(ix.data.subarray(0, 8))).toEqual(Buffer.from(SETTLE_HOOK_DISCRIMINATOR));
+  });
+
+  it("encodes amount as little-endian u64 after discriminator", () => {
+    expect(ix.data.length).toBe(16);
+    expect(ix.data.readBigUInt64LE(8)).toBe(BigInt(amount.toString()));
+  });
+
+  it("fetches registry and hook_payload from the correct PDAs", () => {
+    const [registryPda] = findRegistryPda(ZKSETTLE_PROGRAM_ID);
+    const [hookPayloadPda] = findHookPayloadPda(authority, ZKSETTLE_PROGRAM_ID);
+    expect((registryFetch.mock.calls[0]?.[0] as PublicKey).equals(registryPda)).toBe(true);
+    expect((payloadFetch.mock.calls[0]?.[0] as PublicKey).equals(hookPayloadPda)).toBe(true);
+  });
+
+  it("issues both fetches in parallel (Promise.all)", () => {
+    // Both mocks must have been invoked before either resolves — Promise.all
+    // starts every promise synchronously. We assert both were called exactly
+    // once, which is the observable contract; ordering between them is not
+    // guaranteed but must both fire before the methods chain runs.
+    expect(registryFetch).toHaveBeenCalledTimes(1);
+    expect(payloadFetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe("account layout (must match settle_hook IDL order)", () => {
+    const [issuerPda] = findIssuerPda(authority, ZKSETTLE_PROGRAM_ID);
+    const [hookPayloadPda] = findHookPayloadPda(authority, ZKSETTLE_PROGRAM_ID);
+    const [registryPda] = findRegistryPda(ZKSETTLE_PROGRAM_ID);
+    const [treeCreatorPda] = findTreeCreatorPda(ZKSETTLE_PROGRAM_ID);
+
+    it("0: authority — signer + writable", () => {
+      const k = ix.keys[0]!;
+      expect(k.pubkey.equals(authority)).toBe(true);
+      expect(k.isSigner).toBe(true);
+      expect(k.isWritable).toBe(true);
+    });
+
+    it("1: mint (from payload)", () => {
+      expect(ix.keys[1]!.pubkey.equals(mint)).toBe(true);
+      expect(ix.keys[1]!.isSigner).toBe(false);
+    });
+
+    it("2: destinationToken == payload.recipient", () => {
+      expect(ix.keys[2]!.pubkey.equals(recipient)).toBe(true);
+    });
+
+    it("3: hookPayload PDA — writable", () => {
+      expect(ix.keys[3]!.pubkey.equals(hookPayloadPda)).toBe(true);
+      expect(ix.keys[3]!.isWritable).toBe(true);
+    });
+
+    it("4: leafOwner == recipient (settle_hook requires equality)", () => {
+      expect(ix.keys[4]!.pubkey.equals(recipient)).toBe(true);
+    });
+
+    it("5: issuer PDA", () => {
+      expect(ix.keys[5]!.pubkey.equals(issuerPda)).toBe(true);
+    });
+
+    it("6: registry PDA", () => {
+      expect(ix.keys[6]!.pubkey.equals(registryPda)).toBe(true);
+    });
+
+    it("7: merkleTree (from registry) — writable", () => {
+      expect(ix.keys[7]!.pubkey.equals(merkleTree)).toBe(true);
+      expect(ix.keys[7]!.isWritable).toBe(true);
+    });
+
+    it("8: treeConfig PDA derived from merkleTree — writable", () => {
+      const [treeConfigPda] = findTreeConfigPda(merkleTree);
+      expect(ix.keys[8]!.pubkey.equals(treeConfigPda)).toBe(true);
+      expect(ix.keys[8]!.isWritable).toBe(true);
+    });
+
+    it("9: treeCreator PDA", () => {
+      expect(ix.keys[9]!.pubkey.equals(treeCreatorPda)).toBe(true);
+    });
+
+    it("10: bubblegumProgram", () => {
+      expect(ix.keys[10]!.pubkey.equals(MPL_BUBBLEGUM_ID)).toBe(true);
+    });
+
+    it("11: compressionProgram", () => {
+      expect(ix.keys[11]!.pubkey.equals(SPL_ACCOUNT_COMPRESSION_ID)).toBe(true);
+    });
+
+    it("12: logWrapper (noop)", () => {
+      expect(ix.keys[12]!.pubkey.equals(SPL_NOOP_ID)).toBe(true);
+    });
+
+    it("13: systemProgram", () => {
+      expect(ix.keys[13]!.pubkey.equals(PublicKey.default)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Frontend stopped at `finalizeHookPayload`; gnark verifier never ran, `ProofSettled` never emitted, indexer's `events` table stayed empty even with valid proofs and a wired Helius webhook. Adds `settle_hook` call after finalize (frontend) and a new `buildSettleHookIx` SDK helper.
- `uploadProofChunked` and the devnet test script also skipped `resize_hook_payload`, leaving `proof_and_witness` as a zero-length Vec; `write_hook_proof` then panicked at `handlers.rs:91`. Both fixed with a resize loop terminating on observed on-chain account size.
- Replace hardcoded `BASE_SPACE = 293` magic number in the frontend with `ceil(proofLen / 10240)`, which is exact per Solana's 10 KiB realloc cap and removes drift risk if `StagedLightArgs` ever changes.

## Test plan
- [x] SDK typecheck + build clean (`cd sdk && pnpm typecheck && pnpm build`)
- [x] SDK tests pass — 101/101 (`pnpm test`), including 20 new `buildSettleHookIx` cases (14 accounts, discriminator, encoding, PDA derivation)
- [x] Frontend typecheck — no errors in `use-prove-flow.ts` (pre-existing test-file errors unchanged)
- [x] Devnet end-to-end: script runs `init → resize → write → finalize → settle`; dummy proof fails at gnark with `MalformedProof` as expected, proving the wiring closes
- [ ] Run frontend prove flow on devnet with a valid wallet credential and confirm a row lands in the indexer's `events` table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added settlement transaction execution to complete the proof flow, enabling proper on-chain token transfer hook execution.

* **Bug Fixes**
  * Improved proof staging account allocation with dynamic resizing to prevent out-of-range errors during large proof uploads.

* **Documentation**
  * Added troubleshooting guide covering common issues and required call ordering for proof flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/186)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->