### PR TITLE
Fall back to signature-status poll on confirm expiry

### DIFF
--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useReducer, useRef, type Dispatch } from "react";
+import { TransactionExpiredBlockheightExceededError } from "@solana/web3.js";
 import type { Connection, PublicKey, Transaction } from "@solana/web3.js";
 
 import { useWallet, useConnection } from "@/hooks/use-wallet-connection";
@@ -234,9 +235,45 @@ async function runStepSubmit(
     return new Uint8Array(clean.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []);
   };
 
+  const CONFIRM_FALLBACK_TIMEOUT_MS = 30_000;
+  const CONFIRM_FALLBACK_INITIAL_DELAY_MS = 1_000;
+  const CONFIRM_FALLBACK_MAX_DELAY_MS = 4_000;
   const confirmTx = async (sig: string) => {
     const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
-    await connection.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+    try {
+      await connection.confirmTransaction(
+        { signature: sig, blockhash, lastValidBlockHeight },
+        "confirmed",
+      );
+    } catch (err) {
+      // Narrow: only fall back on the strategy's edge-window expiry.
+      // Other errors (RPC/network/SendTransactionError) re-throw immediately
+      // so we don't burn 30s polling on a failure that won't resolve.
+      if (!(err instanceof TransactionExpiredBlockheightExceededError)) throw err;
+      // BlockheightBasedTransactionConfirmationStrategy returns the moment
+      // current height passes lastValidBlockHeight, even if the tx lands at
+      // the edge of the validity window. Poll getSignatureStatus directly
+      // so a late inclusion isn't surfaced as a false-negative expiry.
+      const deadline = Date.now() + CONFIRM_FALLBACK_TIMEOUT_MS;
+      let delay = CONFIRM_FALLBACK_INITIAL_DELAY_MS;
+      while (Date.now() < deadline) {
+        const { value } = await connection.getSignatureStatus(sig, {
+          searchTransactionHistory: true,
+        });
+        if (
+          value?.confirmationStatus === "confirmed" ||
+          value?.confirmationStatus === "finalized"
+        ) {
+          if (value.err) {
+            throw new Error("tx landed but failed on chain", { cause: value.err });
+          }
+          return;
+        }
+        await new Promise((r) => setTimeout(r, delay));
+        delay = Math.min(delay * 2, CONFIRM_FALLBACK_MAX_DELAY_MS);
+      }
+      throw err;
+    }
   };
 
   const sendSigned = async (signed: Transaction) => {


### PR DESCRIPTION
## Summary

- `BlockheightBasedTransactionConfirmationStrategy` in `@solana/web3.js` returns `TransactionExpiredBlockheightExceededError` the instant current block height passes `lastValidBlockHeight`, even if the tx lands at the edge of the window. UI showed *"block height exceeded"* on transactions that actually finalized on-chain — verified against two devnet signatures (`HoF8…J3ot`, `23FA…2JsH`, both `Status: Ok`).
- On expiry specifically, poll `getSignatureStatus` with exponential backoff (1s → 2s → 4s capped, 30s total). Return success on confirmed/finalized, surface on-chain errors via `Error.cause` to preserve structured Solana errors, re-throw the original expiry only after the poll deadline.
- Catch narrowed to `TransactionExpiredBlockheightExceededError` so RPC/network/`SendTransactionError` failures re-throw immediately without burning 30s.

## Test plan

- [ ] `cd frontend && rtk tsc --noEmit` — clean on touched file (7 pre-existing errors in unrelated test files remain)
- [ ] `cd frontend && rtk lint src/hooks/use-prove-flow.ts` — no issues
- [ ] Manual: trigger a prove flow on devnet, confirm the *"block height exceeded"* false-negative no longer fires when the on-chain tx actually lands
- [ ] Manual: verify a tx that genuinely never lands still surfaces the expiry error after ~30s
- [ ] Manual: verify a tx that lands-then-fails surfaces the on-chain error via `Error.cause`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction confirmation handling to better detect and report blockchain errors with improved reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/187)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->