### PR TITLE
Move proof generation to backend Groth16 prover and stabilize prove flow on devnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ LISTEN_ADDR=127.0.0.1:3000
 STATE_PATH=
 API_TOKEN=
 ALLOW_UNAUTHENTICATED=false
+# Gateway → issuer shared bearer. MUST equal the issuer-service API_TOKEN above.
+# Leave empty in loopback dev (issuer skips bearer check when API_TOKEN is unset).
+GATEWAY_UPSTREAM_TOKEN=
 
 # ── Testing ───────────────────────────────────────────────────
 TEST_DATABASE_URL=postgres://zksettle:zksettle_dev@localhost:5432/zksettle_gateway_test

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,3 +15,6 @@ GATEWAY_CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 GATEWAY_ADMIN_KEY=
 GATEWAY_ALLOW_OPEN_KEYS=true
 GATEWAY_LOG_LEVEL=info
+# Gateway → issuer shared bearer. MUST equal the issuer-service API_TOKEN.
+# Leave empty in loopback dev (issuer skips bearer check when API_TOKEN is unset).
+GATEWAY_UPSTREAM_TOKEN=

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3365,6 +3365,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-sdk",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/backend/crates/api-gateway/src/auth.rs
+++ b/backend/crates/api-gateway/src/auth.rs
@@ -77,6 +77,7 @@ mod tests {
                 cookie_secure: false,
                 cookie_same_site: CookieSameSite::Lax,
                 login_rate_limit_per_minute: 5,
+                upstream_token: None,
             },
             db,
             rate_limiter: RateLimitStore::new(),

--- a/backend/crates/api-gateway/src/config/settings.rs
+++ b/backend/crates/api-gateway/src/config/settings.rs
@@ -40,6 +40,10 @@ pub struct Config {
     pub cookie_secure: bool,
     pub cookie_same_site: CookieSameSite,
     pub login_rate_limit_per_minute: u32,
+    /// Shared bearer the gateway injects on the issuer-service hop.
+    /// Must equal the issuer-service `API_TOKEN`. Unset = no Authorization
+    /// header is injected (loopback dev with `ALLOW_UNAUTHENTICATED=true`).
+    pub upstream_token: Option<String>,
 }
 
 impl std::fmt::Debug for Config {
@@ -58,6 +62,10 @@ impl std::fmt::Debug for Config {
             .field("siws_domain", &self.siws_domain)
             .field("cookie_secure", &self.cookie_secure)
             .field("cookie_same_site", &self.cookie_same_site)
+            .field(
+                "upstream_token",
+                &self.upstream_token.as_ref().map(|_| "[REDACTED]"),
+            )
             .finish()
     }
 }
@@ -121,6 +129,10 @@ impl Config {
                 })?,
                 Err(_) => 5,
             },
+            upstream_token: read_var("GATEWAY_UPSTREAM_TOKEN")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
         })
     }
 }
@@ -182,12 +194,42 @@ mod tests {
             cookie_secure: false,
             cookie_same_site: CookieSameSite::Lax,
             login_rate_limit_per_minute: 5,
+            upstream_token: Some("my_upstream_secret".into()),
         };
         let dbg = format!("{cfg:?}");
         assert!(!dbg.contains("my_admin_secret"));
         assert!(!dbg.contains("postgres://secret"));
         assert!(!dbg.contains("my_jwt_secret"));
+        assert!(!dbg.contains("my_upstream_secret"));
         assert!(dbg.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn from_env_empty_upstream_token_yields_none() {
+        // docker-compose passes `${API_TOKEN:-}` which becomes "" when unset.
+        // We must treat that as None so we don't inject `Authorization: Bearer `
+        // (literal trailing space) on every issuer hop.
+        std::env::set_var("GATEWAY_UPSTREAM_URL", "http://localhost:0");
+        std::env::set_var("GATEWAY_DATABASE_URL", "sqlite::memory:");
+        std::env::set_var("GATEWAY_UPSTREAM_TOKEN", "");
+
+        let cfg = Config::from_env().expect("config should load");
+        assert!(cfg.upstream_token.is_none());
+
+        std::env::set_var("GATEWAY_UPSTREAM_TOKEN", "   ");
+        let cfg = Config::from_env().expect("config should load");
+        assert!(
+            cfg.upstream_token.is_none(),
+            "whitespace-only token should be treated as unset"
+        );
+
+        std::env::set_var("GATEWAY_UPSTREAM_TOKEN", "  real-secret  ");
+        let cfg = Config::from_env().expect("config should load");
+        assert_eq!(cfg.upstream_token.as_deref(), Some("real-secret"));
+
+        std::env::remove_var("GATEWAY_UPSTREAM_TOKEN");
+        std::env::remove_var("GATEWAY_UPSTREAM_URL");
+        std::env::remove_var("GATEWAY_DATABASE_URL");
     }
 
     #[test]

--- a/backend/crates/api-gateway/src/lib.rs
+++ b/backend/crates/api-gateway/src/lib.rs
@@ -145,6 +145,7 @@ pub async fn test_state() -> Arc<AppState> {
         cookie_secure: false,
         cookie_same_site: CookieSameSite::Lax,
         login_rate_limit_per_minute: 5,
+        upstream_token: None,
     };
     Arc::new(AppState {
         config,
@@ -186,6 +187,7 @@ mod tests {
             cookie_secure: false,
             cookie_same_site: CookieSameSite::Lax,
             login_rate_limit_per_minute: 5,
+            upstream_token: None,
         };
         let state = Arc::new(AppState {
             config,

--- a/backend/crates/api-gateway/src/proxy.rs
+++ b/backend/crates/api-gateway/src/proxy.rs
@@ -92,15 +92,34 @@ pub async fn proxy_to_upstream(
         .unwrap_or_default();
     let upstream_base = pick_upstream(path, &state.config);
     let url = format!("{upstream_base}{path}{query}");
+    let is_issuer = upstream_base == state.config.upstream_url.as_str();
 
     let body_bytes = axum::body::to_bytes(req.into_body(), 1024 * 1024)
         .await
         .map_err(|e| GatewayError::Upstream(e.to_string()))?;
 
+    // Strip end-user `Authorization` (hop-by-hop) first, then inject the
+    // gateway↔issuer shared bearer. `HeaderMap::insert` overwrites — single
+    // canonical value, no duplicates. Indexer leg gets no bearer.
+    // Never log this token: it must not appear in error messages or tracing events.
+    let mut headers = filter_hop_by_hop(&req_headers);
+    if is_issuer {
+        if let Some(token) = state.config.upstream_token.as_deref() {
+            match format!("Bearer {token}").parse() {
+                Ok(v) => {
+                    headers.insert(axum::http::header::AUTHORIZATION, v);
+                }
+                Err(_) => warn!(
+                    "GATEWAY_UPSTREAM_TOKEN contains invalid header bytes; auth not injected"
+                ),
+            }
+        }
+    }
+
     let upstream_req = UpstreamRequest {
         method,
         url,
-        headers: filter_hop_by_hop(&req_headers),
+        headers,
         body: body_bytes,
     };
 
@@ -168,6 +187,7 @@ mod tests {
                 cookie_secure: false,
                 cookie_same_site: CookieSameSite::Lax,
                 login_rate_limit_per_minute: 5,
+                upstream_token: None,
             },
             db,
             rate_limiter: RateLimitStore::new(),
@@ -287,6 +307,156 @@ mod tests {
         assert_eq!(mock.sent_count(), 0);
     }
 
+    async fn state_with_cfg(
+        mock: Arc<MockHttpUpstream>,
+        upstream_token: Option<&str>,
+        indexer_url: Option<&str>,
+    ) -> Arc<AppState> {
+        let db = crate::test_db().await;
+        crate::test_cleanup(&db).await;
+        key_store::insert(&db, "zks_test", "alice".into(), Tier::Developer, 0, None)
+            .await
+            .unwrap();
+        Arc::new(AppState {
+            config: Config {
+                port: 4000,
+                upstream_url: "http://upstream.example".into(),
+                log_level: "error".into(),
+                admin_key: None,
+                allow_open_keys: true,
+                cors_allowed_origins: vec![],
+                indexer_url: indexer_url.map(String::from),
+                database_url: String::new(),
+                jwt_secret: None,
+                jwt_ttl_secs: 86400,
+                siws_domain: None,
+                cookie_secure: false,
+                cookie_same_site: CookieSameSite::Lax,
+                login_rate_limit_per_minute: 5,
+                upstream_token: upstream_token.map(String::from),
+            },
+            db,
+            rate_limiter: RateLimitStore::new(),
+            login_rate_limiter: Arc::new(crate::rate_limit::LoginRateLimiter::new()),
+            upstream: mock,
+            nonce_store: crate::nonce_store::NonceStore::new(),
+        })
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn upstream_token_injected_for_issuer_route() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        mock.queue_ok();
+        let state = state_with_cfg(mock.clone(), Some("secret-xyz"), None).await;
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/credentials")
+            .body(Body::empty())
+            .unwrap();
+
+        proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(record(Tier::Developer)),
+            req,
+        )
+        .await
+        .unwrap();
+
+        let sent = mock.last_sent().expect("mock recorded send");
+        assert_eq!(
+            sent.headers.get("authorization").unwrap(),
+            "Bearer secret-xyz"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn upstream_token_not_injected_for_indexer_route() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        mock.queue_ok();
+        let state = state_with_cfg(
+            mock.clone(),
+            Some("secret-xyz"),
+            Some("http://indexer.example"),
+        )
+        .await;
+
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/v1/events?limit=5")
+            .body(Body::empty())
+            .unwrap();
+
+        proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(record(Tier::Developer)),
+            req,
+        )
+        .await
+        .unwrap();
+
+        let sent = mock.last_sent().expect("mock recorded send");
+        assert!(!sent.headers.contains_key("authorization"));
+        assert!(sent.url.starts_with("http://indexer.example"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn upstream_token_overrides_client_authorization() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        mock.queue_ok();
+        let state = state_with_cfg(mock.clone(), Some("secret-xyz"), None).await;
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/wallets")
+            .header("authorization", "Bearer zks_user")
+            .body(Body::empty())
+            .unwrap();
+
+        proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(record(Tier::Developer)),
+            req,
+        )
+        .await
+        .unwrap();
+
+        let sent = mock.last_sent().expect("mock recorded send");
+        assert_eq!(sent.headers.get_all("authorization").iter().count(), 1);
+        assert_eq!(
+            sent.headers.get("authorization").unwrap(),
+            "Bearer secret-xyz"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn upstream_token_none_not_injected() {
+        let mock = Arc::new(MockHttpUpstream::new());
+        mock.queue_ok();
+        let state = state_with_cfg(mock.clone(), None, None).await;
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/v1/credentials")
+            .body(Body::empty())
+            .unwrap();
+
+        proxy_to_upstream(
+            State(state.clone()),
+            AuthenticatedKey(record(Tier::Developer)),
+            req,
+        )
+        .await
+        .unwrap();
+
+        let sent = mock.last_sent().expect("mock recorded send");
+        assert!(!sent.headers.contains_key("authorization"));
+    }
+
     #[test]
     fn hop_by_hop_matches_all_entries() {
         for &h in HOP_BY_HOP {
@@ -341,6 +511,7 @@ mod tests {
             cookie_secure: false,
             cookie_same_site: CookieSameSite::Lax,
             login_rate_limit_per_minute: 5,
+            upstream_token: None,
         }
     }
 

--- a/backend/crates/api-gateway/src/routes/keys.rs
+++ b/backend/crates/api-gateway/src/routes/keys.rs
@@ -215,6 +215,7 @@ mod tests {
             cookie_secure: false,
             cookie_same_site: CookieSameSite::Lax,
             login_rate_limit_per_minute: 5,
+            upstream_token: None,
         };
         let state = Arc::new(AppState {
             config,
@@ -245,6 +246,7 @@ mod tests {
             cookie_secure: false,
             cookie_same_site: CookieSameSite::Lax,
             login_rate_limit_per_minute: 5,
+            upstream_token: None,
         };
         let state = Arc::new(AppState {
             config,
@@ -507,6 +509,7 @@ mod tests {
             cookie_secure: false,
             cookie_same_site: CookieSameSite::Lax,
             login_rate_limit_per_minute: 5,
+            upstream_token: None,
         };
         let state = Arc::new(AppState {
             config,

--- a/backend/crates/issuer-service/Cargo.toml
+++ b/backend/crates/issuer-service/Cargo.toml
@@ -28,6 +28,7 @@ borsh = "1"
 sha2 = "0.10"
 subtle = "2"
 mutants = "0.0.3"
+tempfile = "3"
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/backend/crates/issuer-service/src/auth.rs
+++ b/backend/crates/issuer-service/src/auth.rs
@@ -65,7 +65,41 @@ pub struct WalletAuth {
     pub wallet_bytes: [u8; 32],
 }
 
-const REPLAY_WINDOW_SECS: u64 = 300;
+pub(crate) const REPLAY_WINDOW_SECS: u64 = 300;
+
+/// Parse the `X-Wallet-Timestamp` header and reject anything outside the
+/// `REPLAY_WINDOW_SECS` ± `now()` envelope. Returns the parsed timestamp so
+/// callers can fold it into the signed-over message verbatim.
+pub(crate) fn parse_replay_timestamp(ts_header: &str) -> Result<u64, &'static str> {
+    let timestamp: u64 = ts_header.parse().map_err(|_| "invalid timestamp")?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    if now.abs_diff(timestamp) > REPLAY_WINDOW_SECS {
+        return Err("timestamp outside replay window");
+    }
+    Ok(timestamp)
+}
+
+/// Ed25519-verify `sig_header` against `message` under the given 32-byte
+/// wallet pubkey. Common verification core for `WalletAuth` (path-scoped
+/// GETs) and `/prove/groth16` (header-scoped POST with body-hash binding) so
+/// the two callers cannot drift on signature semantics.
+pub(crate) fn verify_wallet_signature(
+    wallet_bytes: &[u8; 32],
+    sig_header: &str,
+    message: &[u8],
+) -> Result<(), &'static str> {
+    let sig = solana_sdk::signature::Signature::from_str(sig_header)
+        .map_err(|_| "malformed signature")?;
+    let pubkey = solana_sdk::pubkey::Pubkey::try_from(&wallet_bytes[..])
+        .map_err(|_| "invalid pubkey")?;
+    if !sig.verify(pubkey.as_ref(), message) {
+        return Err("signature verification failed");
+    }
+    Ok(())
+}
 
 impl<S: Send + Sync> FromRequestParts<S> for WalletAuth {
     type Rejection = ServiceError;
@@ -117,33 +151,12 @@ impl<S: Send + Sync> FromRequestParts<S> for WalletAuth {
                 ServiceError::Unauthorized("missing X-Wallet-Timestamp header".into())
             })?;
 
-        let timestamp: u64 = ts_header
-            .parse()
-            .map_err(|_| ServiceError::Unauthorized("invalid timestamp".into()))?;
-
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        if now.abs_diff(timestamp) > REPLAY_WINDOW_SECS {
-            return Err(ServiceError::Unauthorized("timestamp outside replay window".into()));
-        }
+        let timestamp = parse_replay_timestamp(ts_header)
+            .map_err(|e| ServiceError::Unauthorized(e.into()))?;
 
         let message = format!("zksettle:{wallet_hex}:{timestamp}");
-
-        let sig = solana_sdk::signature::Signature::from_str(sig_header).map_err(|_| {
-            ServiceError::Unauthorized("malformed signature".into())
-        })?;
-
-        let pubkey =
-            solana_sdk::pubkey::Pubkey::try_from(wallet_bytes.as_slice()).map_err(|_| {
-                ServiceError::Unauthorized("invalid pubkey".into())
-            })?;
-
-        if !sig.verify(pubkey.as_ref(), message.as_bytes()) {
-            return Err(ServiceError::Unauthorized("signature verification failed".into()));
-        }
+        verify_wallet_signature(&wallet_bytes, sig_header, message.as_bytes())
+            .map_err(|e| ServiceError::Unauthorized(e.into()))?;
 
         Ok(WalletAuth {
             wallet_hex,

--- a/backend/crates/issuer-service/src/config.rs
+++ b/backend/crates/issuer-service/src/config.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use zksettle_config::{env_or, expand_tilde};
 
@@ -11,7 +12,25 @@ pub struct Config {
     pub listen_addr: SocketAddr,
     pub state_path: Option<String>,
     pub api_token: Option<String>,
+    pub sunspot: Option<SunspotConfig>,
 }
+
+#[derive(Clone)]
+pub struct SunspotConfig {
+    pub bin: PathBuf,
+    pub acir: PathBuf,
+    pub ccs: PathBuf,
+    pub pk: PathBuf,
+    pub max_concurrency: usize,
+    pub timeout_secs: u64,
+    pub acir_sha256: String,
+}
+
+/// Pinned hash of `zksettle_slice.json` — must match the ACIR shipped with the
+/// browser circuit at `frontend/public/circuits/zksettle_slice.json`. If the
+/// circuit is recompiled, regenerate the artefacts and update this constant.
+pub const DEFAULT_ACIR_SHA256: &str =
+    "254f89c343dabea5dada8e0aaf10c2cfeafe1e7a764b5abae634b946d928d85f";
 
 impl Config {
     pub fn from_env() -> Self {
@@ -30,7 +49,41 @@ impl Config {
                 .expect("LISTEN_ADDR must be valid socket addr"),
             state_path: std::env::var("STATE_PATH").ok(),
             api_token: std::env::var("API_TOKEN").ok().filter(|s| !s.is_empty()),
+            sunspot: SunspotConfig::from_env(),
         }
+    }
+}
+
+impl SunspotConfig {
+    fn from_env() -> Option<Self> {
+        let bin = std::env::var("SUNSPOT_BIN").ok()?;
+        let acir = std::env::var("SUNSPOT_ACIR_PATH").ok()?;
+        let ccs = std::env::var("SUNSPOT_CCS_PATH").ok()?;
+        let pk = std::env::var("SUNSPOT_PK_PATH").ok()?;
+
+        let max_concurrency = std::env::var("SUNSPOT_MAX_CONCURRENCY")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1usize)
+            .max(1);
+        let timeout_secs = std::env::var("SUNSPOT_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(120u64);
+        let acir_sha256 = std::env::var("SUNSPOT_ACIR_SHA256")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_ACIR_SHA256.to_string());
+
+        Some(Self {
+            bin: PathBuf::from(expand_tilde(&bin)),
+            acir: PathBuf::from(expand_tilde(&acir)),
+            ccs: PathBuf::from(expand_tilde(&ccs)),
+            pk: PathBuf::from(expand_tilde(&pk)),
+            max_concurrency,
+            timeout_secs,
+            acir_sha256,
+        })
     }
 }
 
@@ -57,5 +110,30 @@ mod tests {
         let cfg = Config::from_env();
         assert_eq!(cfg.api_token.as_deref(), Some("secret"));
         std::env::remove_var("API_TOKEN");
+    }
+
+    #[test]
+    fn sunspot_none_when_unset() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        for k in ["SUNSPOT_BIN", "SUNSPOT_ACIR_PATH", "SUNSPOT_CCS_PATH", "SUNSPOT_PK_PATH"] {
+            std::env::remove_var(k);
+        }
+        assert!(SunspotConfig::from_env().is_none());
+    }
+
+    #[test]
+    fn sunspot_some_when_all_set() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("SUNSPOT_BIN", "/usr/bin/sunspot");
+        std::env::set_var("SUNSPOT_ACIR_PATH", "/tmp/a.json");
+        std::env::set_var("SUNSPOT_CCS_PATH", "/tmp/a.ccs");
+        std::env::set_var("SUNSPOT_PK_PATH", "/tmp/a.pk");
+        let sc = SunspotConfig::from_env().expect("all set");
+        assert_eq!(sc.max_concurrency, 1);
+        assert_eq!(sc.timeout_secs, 120);
+        assert_eq!(sc.acir_sha256, DEFAULT_ACIR_SHA256);
+        for k in ["SUNSPOT_BIN", "SUNSPOT_ACIR_PATH", "SUNSPOT_CCS_PATH", "SUNSPOT_PK_PATH"] {
+            std::env::remove_var(k);
+        }
     }
 }

--- a/backend/crates/issuer-service/src/handlers/mod.rs
+++ b/backend/crates/issuer-service/src/handlers/mod.rs
@@ -6,5 +6,6 @@ pub mod get_roots;
 pub mod get_sanctions_proof;
 pub mod health;
 pub mod issue_credential;
+pub mod prove_groth16;
 pub mod publish;
 pub mod revoke_credential;

--- a/backend/crates/issuer-service/src/handlers/prove_groth16.rs
+++ b/backend/crates/issuer-service/src/handlers/prove_groth16.rs
@@ -1,0 +1,602 @@
+//! POST /prove/groth16 — server-side Sunspot Groth16 prover.
+//!
+//! Request body: raw octet-stream containing the gzipped Noir witness emitted
+//! by `noir.execute(...)` in the browser. The handler writes that to a temp
+//! file, shells out to the pinned `sunspot prove ...` CLI, and returns the
+//! concatenated `proof || public-witness` bundle that the on-chain Gnark
+//! verifier expects. `X-Proof-Len` / `X-Witness-Len` headers let the caller
+//! slice the body without re-parsing.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Bytes;
+use axum::extract::Extension;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+use tokio::process::Command;
+use tokio::sync::Semaphore;
+use tracing::Instrument;
+
+use crate::auth::{parse_replay_timestamp, verify_wallet_signature, AllowUnauthenticated};
+
+/// 12-byte gnark witness header + 11 × 32-byte BE field elements = 364 bytes.
+/// Must stay in sync with `expected_witness_len` on-chain.
+pub const EXPECTED_WITNESS_LEN: usize = 12 + 11 * 32;
+
+const MAX_BODY_BYTES: usize = 1024 * 1024; // 1 MiB — Noir witness < 50 kB in practice
+const SEMAPHORE_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(2);
+const STDERR_EXCERPT_CHARS: usize = 512;
+
+#[derive(Clone)]
+pub struct ProverPaths {
+    pub bin: PathBuf,
+    pub acir: PathBuf,
+    pub ccs: PathBuf,
+    pub pk: PathBuf,
+    pub timeout: Duration,
+}
+
+#[derive(Clone)]
+pub struct ProverPermits(pub Arc<Semaphore>);
+
+#[derive(Debug)]
+pub enum ProveError {
+    InvalidWitness(String),
+    Unauthorized(String),
+    ProverBusy,
+    ProverTimeout,
+    ProverFailed(String),
+}
+
+impl IntoResponse for ProveError {
+    fn into_response(self) -> Response {
+        let (status, code, msg) = match self {
+            ProveError::InvalidWitness(m) => (StatusCode::BAD_REQUEST, "invalid_witness", m),
+            ProveError::Unauthorized(m) => (StatusCode::UNAUTHORIZED, "unauthorized", m),
+            ProveError::ProverBusy => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "prover_busy",
+                "prover saturated".to_string(),
+            ),
+            ProveError::ProverTimeout => (
+                StatusCode::GATEWAY_TIMEOUT,
+                "prover_timeout",
+                "prover exceeded deadline".to_string(),
+            ),
+            ProveError::ProverFailed(m) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "prover_failed",
+                m,
+            ),
+        };
+        let body = axum::Json(json!({ "error": code, "message": msg }));
+        (status, body).into_response()
+    }
+}
+
+pub async fn handler(
+    Extension(paths): Extension<ProverPaths>,
+    Extension(permits): Extension<ProverPermits>,
+    Extension(AllowUnauthenticated(allow_unauth)): Extension<AllowUnauthenticated>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, ProveError> {
+    if body.is_empty() {
+        return Err(ProveError::InvalidWitness("empty body".into()));
+    }
+    if body.len() > MAX_BODY_BYTES {
+        return Err(ProveError::InvalidWitness(format!(
+            "witness too large: {} bytes (max {MAX_BODY_BYTES})",
+            body.len()
+        )));
+    }
+
+    // Hash the body BEFORE signature check so the signed message binds the
+    // exact witness the prover will consume — captured headers cannot be
+    // replayed against a different witness even within the 5-min replay
+    // window. Frontend mirrors this in `apiFetchBinary` (`client.ts`).
+    let wallet_hex = verify_wallet_headers(&headers, &body, allow_unauth)?;
+
+    let permit = match tokio::time::timeout(
+        SEMAPHORE_ACQUIRE_TIMEOUT,
+        permits.0.clone().acquire_owned(),
+    )
+    .await
+    {
+        Ok(Ok(p)) => p,
+        Ok(Err(_closed)) => {
+            return Err(ProveError::ProverFailed("semaphore closed".into()));
+        }
+        Err(_elapsed) => return Err(ProveError::ProverBusy),
+    };
+
+    // Sunspot writes `<ccs_stem>.proof` / `<ccs_stem>.pw` into the CCS's
+    // *parent directory* — not the witness's, not the ACIR's. Symlinks are
+    // dereferenced. To get isolated, concurrency-safe output paths we stage
+    // both ACIR (~76 kB) and CCS (~1.9 MB) into the per-request tempdir
+    // under a fresh stem; outputs land alongside, and the whole dir is wiped
+    // on Drop. PK (~7 MB, read-only) stays at its real path — we never read
+    // proof/pw from there. Concurrent calls each get their own dir, so the
+    // fixed output filename never clashes even with the semaphore widened.
+    let bundle = tokio::task::spawn_blocking({
+        let body = body.clone();
+        let acir_real = paths.acir.clone();
+        let ccs_real = paths.ccs.clone();
+        move || -> std::io::Result<(
+            TempDir,
+            std::path::PathBuf,
+            std::path::PathBuf,
+            std::path::PathBuf,
+            std::path::PathBuf,
+            std::path::PathBuf,
+        )> {
+            let tmp = TempDir::new()?;
+            let acir_copy = tmp.path().join("wit.json");
+            let ccs_copy = tmp.path().join("wit.ccs");
+            std::fs::copy(&acir_real, &acir_copy)?;
+            std::fs::copy(&ccs_real, &ccs_copy)?;
+            let witness = tmp.path().join("wit.gz");
+            std::fs::write(&witness, &body)?;
+            let proof_out = tmp.path().join("wit.proof");
+            let pw_out = tmp.path().join("wit.pw");
+            Ok((tmp, acir_copy, ccs_copy, witness, proof_out, pw_out))
+        }
+    });
+    let (tmp, acir_path, ccs_path, witness_path, proof_out, pw_out) = bundle
+        .await
+        .map_err(|e| ProveError::ProverFailed(format!("temp setup join: {e}")))?
+        .map_err(|e| ProveError::ProverFailed(format!("temp setup: {e}")))?;
+
+    let span = tracing::info_span!(
+        "groth16_prove",
+        witness_bytes = body.len(),
+        wallet = %wallet_hex,
+    );
+
+    // Wrap the prover-invocation block in `.instrument(span)` so the span
+    // context follows the future across thread switches at every `.await`.
+    // Holding `span.enter()`'s sync guard across an `.await` would attach the
+    // span to whatever task happened to run on this thread next.
+    let (proof, pw) = async {
+        tracing::debug!("sunspot prove starting");
+
+        let mut cmd = Command::new(&paths.bin);
+        cmd.kill_on_drop(true)
+            .arg("prove")
+            .arg(&acir_path)
+            .arg(&witness_path)
+            .arg(&ccs_path)
+            .arg(&paths.pk);
+
+        let result = tokio::time::timeout(paths.timeout, cmd.output()).await;
+        drop(permit);
+
+        let output = match result {
+            Ok(Ok(o)) => o,
+            Ok(Err(e)) => {
+                return Err(ProveError::ProverFailed(format!("spawn: {e}")));
+            }
+            Err(_) => return Err(ProveError::ProverTimeout),
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let excerpt: String = stderr.chars().take(STDERR_EXCERPT_CHARS).collect();
+            tracing::warn!(exit = ?output.status.code(), stderr = %excerpt, "sunspot prove failed");
+            return Err(ProveError::ProverFailed(format!(
+                "sunspot exit {:?}: {excerpt}",
+                output.status.code()
+            )));
+        }
+
+        let proof = tokio::fs::read(&proof_out)
+            .await
+            .map_err(|e| ProveError::ProverFailed(format!("read proof: {e}")))?;
+        let pw = tokio::fs::read(&pw_out)
+            .await
+            .map_err(|e| ProveError::ProverFailed(format!("read pw: {e}")))?;
+        Ok((proof, pw))
+    }
+    .instrument(span.clone())
+    .await?;
+    drop(tmp);
+
+    if pw.len() != EXPECTED_WITNESS_LEN {
+        return Err(ProveError::ProverFailed(format!(
+            "public witness length {} (expected {EXPECTED_WITNESS_LEN})",
+            pw.len()
+        )));
+    }
+
+    let mut bundle_bytes = Vec::with_capacity(proof.len() + pw.len());
+    bundle_bytes.extend_from_slice(&proof);
+    bundle_bytes.extend_from_slice(&pw);
+
+    let _enter = span.enter();
+    let mut resp_headers = HeaderMap::new();
+    resp_headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        HeaderValue::from_static("application/octet-stream"),
+    );
+    resp_headers.insert(
+        "x-proof-len",
+        HeaderValue::from_str(&proof.len().to_string()).unwrap(),
+    );
+    resp_headers.insert(
+        "x-witness-len",
+        HeaderValue::from_str(&pw.len().to_string()).unwrap(),
+    );
+
+    tracing::info!(proof_bytes = proof.len(), witness_bytes = pw.len(), "groth16 proof generated");
+    Ok((resp_headers, bundle_bytes).into_response())
+}
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name).and_then(|v| v.to_str().ok())
+}
+
+fn body_hash_hex(body: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    hex::encode(hasher.finalize())
+}
+
+fn verify_wallet_headers(
+    headers: &HeaderMap,
+    body: &[u8],
+    allow_unauth: bool,
+) -> Result<String, ProveError> {
+    let wallet_hex_raw = header_str(headers, "x-wallet-pubkey")
+        .ok_or_else(|| ProveError::Unauthorized("missing X-Wallet-Pubkey header".into()))?;
+    let wallet_hex = wallet_hex_raw.to_ascii_lowercase();
+    let stripped = wallet_hex.strip_prefix("0x").unwrap_or(&wallet_hex);
+    let wallet_bytes: [u8; 32] = hex::decode(stripped)
+        .map_err(|e| ProveError::Unauthorized(format!("invalid wallet hex: {e}")))
+        .and_then(|b| {
+            b.try_into()
+                .map_err(|_| ProveError::Unauthorized("wallet must be 32 bytes".into()))
+        })?;
+
+    if allow_unauth {
+        return Ok(wallet_hex);
+    }
+
+    let sig_header = header_str(headers, "x-wallet-signature")
+        .ok_or_else(|| ProveError::Unauthorized("missing X-Wallet-Signature header".into()))?;
+    let ts_header = header_str(headers, "x-wallet-timestamp")
+        .ok_or_else(|| ProveError::Unauthorized("missing X-Wallet-Timestamp header".into()))?;
+
+    let timestamp = parse_replay_timestamp(ts_header)
+        .map_err(|e| ProveError::Unauthorized(e.into()))?;
+
+    // Bind the witness body to the signed message: `sha256(body)` is hex-encoded
+    // and folded into the message after `timestamp`. Without this, captured
+    // wallet-auth headers could be replayed against a different witness within
+    // the 5-min `REPLAY_WINDOW_SECS`.
+    let body_hash = body_hash_hex(body);
+    let message = format!("zksettle:{wallet_hex}:{timestamp}:{body_hash}");
+    verify_wallet_signature(&wallet_bytes, sig_header, message.as_bytes())
+        .map_err(|e| ProveError::Unauthorized(e.into()))?;
+
+    Ok(wallet_hex)
+}
+
+/// Compute hex sha256 of a file. Used at startup to enforce ACIR pinning.
+pub fn sha256_file_hex(path: &std::path::Path) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut f = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::signature::Keypair;
+    use solana_sdk::signer::Signer;
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    const TEST_BODY: &[u8] = b"witness-bytes-placeholder";
+
+    fn signed_headers(kp: &Keypair) -> HeaderMap {
+        signed_headers_for(kp, TEST_BODY, now_secs())
+    }
+
+    fn signed_headers_for(kp: &Keypair, body: &[u8], ts: u64) -> HeaderMap {
+        let wallet_hex = format!("0x{}", hex::encode(kp.pubkey().to_bytes()));
+        let body_hash = body_hash_hex(body);
+        let message = format!("zksettle:{wallet_hex}:{ts}:{body_hash}");
+        let sig = kp.sign_message(message.as_bytes()).to_string();
+        let mut h = HeaderMap::new();
+        h.insert("x-wallet-pubkey", wallet_hex.parse().unwrap());
+        h.insert("x-wallet-signature", sig.parse().unwrap());
+        h.insert("x-wallet-timestamp", ts.to_string().parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn wallet_headers_happy_path() {
+        let kp = Keypair::new();
+        let h = signed_headers(&kp);
+        let hex = verify_wallet_headers(&h, TEST_BODY, false).expect("should pass");
+        assert!(hex.starts_with("0x"));
+    }
+
+    #[test]
+    fn wallet_headers_reject_different_body() {
+        // Same headers + DIFFERENT body must fail — this is the replay
+        // protection that pt-1 of the security review flagged.
+        let kp = Keypair::new();
+        let h = signed_headers_for(&kp, TEST_BODY, now_secs());
+        let e = verify_wallet_headers(&h, b"other-witness", false).unwrap_err();
+        assert!(matches!(e, ProveError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn wallet_headers_missing_pubkey_returns_401() {
+        let h = HeaderMap::new();
+        let e = verify_wallet_headers(&h, TEST_BODY, false).unwrap_err();
+        assert!(matches!(e, ProveError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn wallet_headers_expired_returns_401() {
+        let kp = Keypair::new();
+        let h = signed_headers_for(
+            &kp,
+            TEST_BODY,
+            now_secs() - crate::auth::REPLAY_WINDOW_SECS - 10,
+        );
+        let e = verify_wallet_headers(&h, TEST_BODY, false).unwrap_err();
+        assert!(matches!(e, ProveError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn wallet_headers_wrong_key_returns_401() {
+        let kp = Keypair::new();
+        let other = Keypair::new();
+        let wallet_hex = format!("0x{}", hex::encode(kp.pubkey().to_bytes()));
+        let ts = now_secs();
+        let body_hash = body_hash_hex(TEST_BODY);
+        let message = format!("zksettle:{wallet_hex}:{ts}:{body_hash}");
+        let sig = other.sign_message(message.as_bytes()).to_string();
+        let mut h = HeaderMap::new();
+        h.insert("x-wallet-pubkey", wallet_hex.parse().unwrap());
+        h.insert("x-wallet-signature", sig.parse().unwrap());
+        h.insert("x-wallet-timestamp", ts.to_string().parse().unwrap());
+        let e = verify_wallet_headers(&h, TEST_BODY, false).unwrap_err();
+        assert!(matches!(e, ProveError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn allow_unauth_skips_signature_check() {
+        let mut h = HeaderMap::new();
+        h.insert("x-wallet-pubkey", format!("0x{}", hex::encode([7u8; 32])).parse().unwrap());
+        // no sig/ts — but allow_unauth bypasses (body content irrelevant here)
+        let hex = verify_wallet_headers(&h, b"", true).expect("bypass");
+        assert_eq!(hex, format!("0x{}", hex::encode([7u8; 32])));
+    }
+
+    #[test]
+    fn sha256_hex_known_file() {
+        let mut tf = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        tf.write_all(b"hello").unwrap();
+        tf.flush().unwrap();
+        let got = sha256_file_hex(tf.path()).unwrap();
+        // sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+        assert_eq!(got, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+    }
+
+    // ===================================================================
+    // Router-level tests. Use tower oneshot to drive the handler in-process
+    // — no live HTTP server. Heavy round-trip is gated behind SUNSPOT_E2E=1.
+    // ===================================================================
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::post;
+    use axum::{Extension, Router};
+    use http_body_util::BodyExt;
+    use std::path::PathBuf;
+    use std::sync::Arc as StdArc;
+    use std::time::Duration;
+    use tokio::sync::Semaphore;
+    use tower::ServiceExt;
+
+    fn dummy_paths() -> ProverPaths {
+        ProverPaths {
+            bin: PathBuf::from("/nonexistent"),
+            acir: PathBuf::from("/nonexistent"),
+            ccs: PathBuf::from("/nonexistent"),
+            pk: PathBuf::from("/nonexistent"),
+            timeout: Duration::from_secs(1),
+        }
+    }
+
+    fn build_app(paths: ProverPaths, allow_unauth: bool) -> Router {
+        Router::new()
+            .route("/prove/groth16", post(handler))
+            .layer(Extension(paths))
+            .layer(Extension(ProverPermits(StdArc::new(Semaphore::new(1)))))
+            .layer(Extension(AllowUnauthenticated(allow_unauth)))
+    }
+
+    #[tokio::test]
+    async fn empty_body_returns_400_without_invoking_prover() {
+        // dummy paths would explode if reached — confirms framing fails fast.
+        let app = build_app(dummy_paths(), true);
+        let wallet = format!("0x{}", hex::encode([3u8; 32]));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove/groth16")
+                    .header("x-wallet-pubkey", wallet)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn missing_wallet_signature_returns_401_when_auth_required() {
+        let app = build_app(dummy_paths(), false);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove/groth16")
+                    .body(Body::from(vec![0u8; 64]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    fn env_path(key: &str) -> Option<PathBuf> {
+        std::env::var(key).ok().filter(|s| !s.is_empty()).map(PathBuf::from)
+    }
+
+    fn maybe_e2e_paths() -> Option<(ProverPaths, PathBuf, PathBuf)> {
+        if std::env::var("SUNSPOT_E2E").ok().as_deref() != Some("1") {
+            return None;
+        }
+        let bin = env_path("SUNSPOT_BIN")?;
+        let acir = env_path("SUNSPOT_ACIR_PATH")?;
+        let ccs = env_path("SUNSPOT_CCS_PATH")?;
+        let pk = env_path("SUNSPOT_PK_PATH")?;
+        let vk = env_path("SUNSPOT_VK_PATH")?;
+        let witness = env_path("SUNSPOT_WITNESS_PATH")?;
+        for (label, p) in [
+            ("bin", &bin),
+            ("acir", &acir),
+            ("ccs", &ccs),
+            ("pk", &pk),
+            ("vk", &vk),
+            ("witness", &witness),
+        ] {
+            if !p.exists() {
+                eprintln!("{label} path {} not found — skipping e2e", p.display());
+                return None;
+            }
+        }
+        Some((
+            ProverPaths {
+                bin,
+                acir,
+                ccs,
+                pk,
+                timeout: Duration::from_secs(180),
+            },
+            vk,
+            witness,
+        ))
+    }
+
+    /// Real prove → verify round-trip. Confirms the bundle format the route
+    /// emits parses through the same gnark deserialiser the on-chain program
+    /// uses (via the `sunspot verify` CLI which links the same verifier-lib).
+    ///
+    /// Heavy: invokes the real `sunspot prove` (PK is ~7 MiB; ~5–30 s wall).
+    /// Run with:
+    /// `SUNSPOT_E2E=1 SUNSPOT_BIN=... cargo test -p issuer-service -- --ignored prove_groth16_round_trips`
+    #[tokio::test]
+    #[ignore = "requires sunspot CLI + circuit artefacts; set SUNSPOT_E2E=1"]
+    async fn prove_groth16_round_trips_through_verify() {
+        let Some((paths, vk_path, witness_path)) = maybe_e2e_paths() else {
+            eprintln!("SUNSPOT_E2E not set or paths missing — skipping");
+            return;
+        };
+        let witness_body = std::fs::read(&witness_path).expect("read fixture witness");
+        let wallet_hex = format!("0x{}", hex::encode([1u8; 32]));
+
+        let app = build_app(paths, true);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/prove/groth16")
+                    .header("content-type", "application/octet-stream")
+                    .header("x-wallet-pubkey", &wallet_hex)
+                    .body(Body::from(witness_body))
+                    .unwrap(),
+            )
+            .await
+            .expect("oneshot");
+
+        if resp.status() != StatusCode::OK {
+            let status = resp.status();
+            let body = resp.into_body().collect().await.unwrap().to_bytes();
+            panic!(
+                "handler must return 200 — got {status}\nbody: {}",
+                String::from_utf8_lossy(&body),
+            );
+        }
+        let proof_len: usize = resp
+            .headers()
+            .get("x-proof-len")
+            .expect("X-Proof-Len header")
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        let witness_len: usize = resp
+            .headers()
+            .get("x-witness-len")
+            .expect("X-Witness-Len header")
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert_eq!(witness_len, EXPECTED_WITNESS_LEN);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.len(), proof_len + witness_len);
+        let (proof, pw) = body.split_at(proof_len);
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let proof_file = tmp.path().join("out.proof");
+        let pw_file = tmp.path().join("out.pw");
+        std::fs::write(&proof_file, proof).unwrap();
+        std::fs::write(&pw_file, pw).unwrap();
+
+        let sunspot_bin = env_path("SUNSPOT_BIN").unwrap();
+        let output = std::process::Command::new(&sunspot_bin)
+            .arg("verify")
+            .arg(&vk_path)
+            .arg(&proof_file)
+            .arg(&pw_file)
+            .output()
+            .expect("spawn sunspot verify");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            output.status.success(),
+            "sunspot verify failed (exit={:?})\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}",
+            output.status.code(),
+        );
+    }
+}

--- a/backend/crates/issuer-service/src/main.rs
+++ b/backend/crates/issuer-service/src/main.rs
@@ -9,6 +9,7 @@ mod rotation;
 mod state;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::middleware;
 use axum::routing::{get, post};
@@ -16,11 +17,12 @@ use axum::{Extension, Router};
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Keypair;
 use solana_sdk::signer::Signer;
-use tokio::sync::{watch, RwLock};
+use tokio::sync::{watch, RwLock, Semaphore};
 use zksettle_rpc::{RealSolanaRpc, SolanaRpc};
 
 use auth::{AllowUnauthenticated, ApiToken};
-use config::Config;
+use config::{Config, SunspotConfig};
+use handlers::prove_groth16::{sha256_file_hex, ProverPaths, ProverPermits};
 use state::{IssuerState, PublishLock};
 
 /// Shared Solana RPC handle for handlers + rotation task.
@@ -164,6 +166,17 @@ async fn main() {
         .route("/wallets", post(handlers::add_wallet::handler))
         .route("/roots/publish", post(handlers::publish::handler));
 
+    let prover = build_prover_extensions(cfg.sunspot.as_ref());
+    if let Some((paths, permits)) = prover.clone() {
+        protected_routes = protected_routes
+            .route(
+                "/prove/groth16",
+                post(handlers::prove_groth16::handler),
+            )
+            .layer(Extension(paths))
+            .layer(Extension(permits));
+    }
+
     if let Some(ref token) = cfg.api_token {
         protected_routes = protected_routes
             .layer(middleware::from_fn(auth::require_bearer))
@@ -193,4 +206,73 @@ async fn shutdown_signal(shutdown_tx: watch::Sender<()>) {
     tokio::signal::ctrl_c().await.ok();
     tracing::info!("shutdown signal received");
     let _ = shutdown_tx.send(());
+}
+
+/// Validate Sunspot artefact paths, enforce ACIR hash pinning, and build the
+/// shared `ProverPaths` + `ProverPermits` extensions. Returns `None` when no
+/// Sunspot env vars are configured (route stays unregistered, rest of service
+/// runs). Panics on ACIR hash drift — circuit recompiles must update the
+/// pinned constant explicitly.
+fn build_prover_extensions(
+    sunspot: Option<&SunspotConfig>,
+) -> Option<(ProverPaths, ProverPermits)> {
+    let sc = sunspot?;
+
+    for (label, path) in [
+        ("bin", &sc.bin),
+        ("acir", &sc.acir),
+        ("ccs", &sc.ccs),
+        ("pk", &sc.pk),
+    ] {
+        if !path.exists() {
+            tracing::warn!(
+                kind = label,
+                path = %path.display(),
+                "Sunspot artefact missing; /prove/groth16 disabled"
+            );
+            return None;
+        }
+    }
+
+    let actual_hash = match sha256_file_hex(&sc.acir) {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!(
+                path = %sc.acir.display(),
+                error = %e,
+                "could not hash ACIR; /prove/groth16 disabled"
+            );
+            return None;
+        }
+    };
+    if actual_hash != sc.acir_sha256 {
+        panic!(
+            "ACIR hash mismatch — refusing to start.\n  expected: {}\n  got:      {}\n  path:     {}\n\
+            If the circuit was recompiled, regenerate artefacts and update DEFAULT_ACIR_SHA256.",
+            sc.acir_sha256,
+            actual_hash,
+            sc.acir.display(),
+        );
+    }
+
+    tracing::info!(
+        bin = %sc.bin.display(),
+        acir = %sc.acir.display(),
+        acir_sha256 = %actual_hash,
+        ccs = %sc.ccs.display(),
+        pk = %sc.pk.display(),
+        max_concurrency = sc.max_concurrency,
+        timeout_secs = sc.timeout_secs,
+        "Sunspot prover wired; /prove/groth16 active",
+    );
+
+    let paths = ProverPaths {
+        bin: sc.bin.clone(),
+        acir: sc.acir.clone(),
+        ccs: sc.ccs.clone(),
+        pk: sc.pk.clone(),
+        timeout: Duration::from_secs(sc.timeout_secs),
+    };
+    let permits = ProverPermits(Arc::new(Semaphore::new(sc.max_concurrency)));
+    Some((paths, permits))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       GATEWAY_ALLOW_OPEN_KEYS: "true"
       GATEWAY_JWT_SECRET: "${GATEWAY_JWT_SECRET:?set GATEWAY_JWT_SECRET}"
       GATEWAY_SIWS_DOMAIN: "${GATEWAY_SIWS_DOMAIN:-localhost:3000}"
+      GATEWAY_UPSTREAM_TOKEN: "${API_TOKEN:-}"
     depends_on:
       postgres:
         condition: service_healthy
@@ -47,6 +48,7 @@ services:
       PROGRAM_ID: "${PROGRAM_ID:?set PROGRAM_ID}"
       KEYPAIR_PATH: "/keys/id.json"
       RPC_URL: "${RPC_URL:-http://127.0.0.1:8899}"
+      API_TOKEN: "${API_TOKEN:-}"
     volumes:
       - ${KEYPAIR_FILE:-~/.config/solana/id.json}:/keys/id.json:ro
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@aztec/bb.js": "3.0.0-nightly.20260102",
     "@base-ui/react": "^1.4.1",
     "@coral-xyz/anchor": "^0.31.1",
     "@gsap/react": "^2.1.2",
@@ -33,6 +32,7 @@
     "@solana/wallet-adapter-solflare": "^0.6.33",
     "@solana/web3.js": "^1.98.4",
     "@tanstack/react-query": "^5.100.5",
+    "@zkpassport/poseidon2": "^0.6.2",
     "@zksettle/sdk": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/frontend/src/hooks/use-proof-generation.ts
+++ b/frontend/src/hooks/use-proof-generation.ts
@@ -2,13 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Barretenberg, UltraHonkBackend } from "@aztec/bb.js";
 import {
   Noir,
   type CompiledCircuit,
   type InputMap,
 } from "@noir-lang/noir_js";
 
+import { proveGroth16 } from "@/lib/api/endpoints";
 import type { ProofInputs, ProofResult } from "@/types/proof";
 
 const ARTIFACT_URL = "/circuits/zksettle_slice.json";
@@ -47,14 +47,10 @@ function toNoirInputs(inputs: ProofInputs): InputMap {
 
 interface ProverHandles {
   noir: Noir;
-  backend: UltraHonkBackend;
-  api: Barretenberg;
 }
 
 interface UseProofGenerationResult {
   generate: (inputs: ProofInputs) => Promise<ProofResult>;
-  /** Get the Barretenberg API instance (initializes prover if needed). */
-  ensureApi: () => Promise<Barretenberg>;
   proof: ProofResult | null;
   isGenerating: boolean;
   error: Error | null;
@@ -63,12 +59,12 @@ interface UseProofGenerationResult {
 }
 
 /**
- * Generate compliance proofs in the browser. The heavy lifting (witness
- * solving, UltraHonk proving, CRS download) happens inside `@aztec/bb.js`,
- * which spawns its own internal worker pool — this hook intentionally does
- * not wrap a separate Web Worker. That avoids a Turbopack `import.meta.url`
- * issue with the Noir wasm-bindgen init code, and matches the canonical
- * pattern in `noir-lang/noir-examples`.
+ * Generate compliance proofs. Witness solving runs in the browser via
+ * `@noir-lang/noir_js` (the ACIR is fetched from `/circuits/...` and reused
+ * across regenerations); proving itself is delegated to the server-side
+ * Sunspot/Groth16 endpoint so the bundle format matches the on-chain
+ * `gnark_verifier_solana`. Heavy `@aztec/bb.js` (Barretenberg + UltraHonk
+ * backend) was removed entirely as part of the same migration.
  */
 export function useProofGeneration(): UseProofGenerationResult {
   const proverRef = useRef<ProverHandles | null>(null);
@@ -80,9 +76,6 @@ export function useProofGeneration(): UseProofGenerationResult {
 
   useEffect(() => {
     return () => {
-      proverRef.current?.api.destroy().catch(() => {
-        // best-effort cleanup; swallow during unmount
-      });
       proverRef.current = null;
       proverInitRef.current = null;
     };
@@ -92,10 +85,9 @@ export function useProofGeneration(): UseProofGenerationResult {
     if (proverRef.current) {
       return Promise.resolve(proverRef.current);
     }
-    // Coalesce concurrent callers (e.g. a double-click during the ~20s cold
-    // start) onto the same in-flight init promise. Without this, both calls
-    // would each spawn a Barretenberg worker pool and the loser's `api`
-    // would leak — `destroy()` is never called on the orphaned instance.
+    // Coalesce concurrent callers (e.g. a double-click) onto the same
+    // in-flight init promise so we fetch the ACIR once and reuse the Noir
+    // executor across regenerations.
     proverInitRef.current ??= (async () => {
         try {
           const res = await fetch(ARTIFACT_URL);
@@ -105,14 +97,8 @@ export function useProofGeneration(): UseProofGenerationResult {
             );
           }
           const circuit = (await res.json()) as CompiledCircuit;
-          const threads =
-            typeof navigator !== "undefined" && navigator.hardwareConcurrency
-              ? Math.min(navigator.hardwareConcurrency, 8)
-              : 4;
-          const api = await Barretenberg.new({ threads });
           const noir = new Noir(circuit);
-          const backend = new UltraHonkBackend(circuit.bytecode, api);
-          const handles: ProverHandles = { noir, backend, api };
+          const handles: ProverHandles = { noir };
           proverRef.current = handles;
           return handles;
         } catch (err) {
@@ -124,11 +110,6 @@ export function useProofGeneration(): UseProofGenerationResult {
     return proverInitRef.current;
   }, []);
 
-  const ensureApi = useCallback(async (): Promise<Barretenberg> => {
-    const { api } = await ensureProver();
-    return api;
-  }, [ensureProver]);
-
   const generate = useCallback(
     async (inputs: ProofInputs): Promise<ProofResult> => {
       if (globalThis.window === undefined) {
@@ -139,9 +120,12 @@ export function useProofGeneration(): UseProofGenerationResult {
       setProof(null);
       const start = performance.now();
       try {
-        const { noir, backend } = await ensureProver();
+        const { noir } = await ensureProver();
+        // Browser still solves the witness via @noir-lang/noir_js — only
+        // proving moves to the server. The `witness` Uint8Array is the same
+        // gzipped Noir witness format that `sunspot prove` consumes.
         const { witness } = await noir.execute(toNoirInputs(inputs));
-        const { proof: proofBytes, publicInputs } = await backend.generateProof(witness);
+        const { proof: proofBytes, publicInputs } = await proveGroth16(witness);
         const result: ProofResult = {
           proof: proofBytes,
           publicInputs,
@@ -162,7 +146,6 @@ export function useProofGeneration(): UseProofGenerationResult {
 
   return {
     generate,
-    ensureApi,
     proof,
     isGenerating,
     error,

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -337,7 +337,7 @@ async function runStepSubmit(
   }
   const signedInitResize = await signAllTransactions(initResizeTxs);
   for (const tx of signedInitResize) {
-    await sendSigned(tx!, bh1);
+    await sendSigned(tx, bh1);
   }
 
   // ── Batch 2: writes only (fresh blockhash + Phantom popup) ──

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -402,17 +402,14 @@ async function runStepSubmit(
   return finalSig;
 }
 
-async function runStepConfirm(
-  dispatch: Dispatch<FlowAction>,
-  connection: Connection,
-  txSignature: string | undefined,
-): Promise<void> {
+async function runStepConfirm(dispatch: Dispatch<FlowAction>): Promise<void> {
+  // Step 4 (`runStepSubmit`) already awaited `confirmTransaction` for the
+  // settle tx using its original signing blockhash. Re-confirming here with a
+  // freshly-fetched blockhash would (a) decouple the wait-loop expiry from
+  // the actual tx (Solana docs explicitly warn against this) and (b) be
+  // redundant. Keep this step purely for the UI step-machine.
   dispatch({ type: "STEP_RUNNING", step: 5 });
   const start = performance.now();
-  if (txSignature) {
-    const latestBlockhash = await connection.getLatestBlockhash("confirmed");
-    await connection.confirmTransaction({ signature: txSignature, ...latestBlockhash }, "confirmed");
-  }
   dispatch({
     type: "STEP_SUCCESS",
     step: 5,
@@ -480,7 +477,7 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
     return;
   }
 
-  try { await runStepConfirm(dispatch, connection, txSignature); }
+  try { await runStepConfirm(dispatch); }
   catch (err) {
     if (txSignature) { stepError(dispatch, 5, err, "Confirmation failed"); }
     else { dispatch({ type: "STEP_SUCCESS", step: 5 }); }

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -286,16 +286,14 @@ async function runStepSubmit(
 
   const initIx = await buildInitHookPayloadIx(publicKey, proofBytes.length, connection);
 
-  // Solana caps realloc at 10 KiB per instruction. Compute how many
-  // resize instructions are needed to grow from header-only to full size.
-  const BASE_SPACE = 293;
-  const headerSize = 8 + BASE_SPACE;
-  const targetSize = headerSize + proofBytes.length;
+  // Solana caps realloc at 10 KiB per instruction. Pre-count resize ixs so
+  // they batch into one Phantom popup with init. Upper-bound the count from
+  // proof size alone so we never under-allocate (extra resizes are idempotent
+  // no-ops on-chain). Avoids hardcoding HookPayload::BASE_SPACE on the client.
+  const resizeCount = Math.ceil(proofBytes.length / 10_240);
   const resizeIxs = [];
-  let currentSize = headerSize;
-  while (currentSize < targetSize) {
+  for (let i = 0; i < resizeCount; i++) {
     resizeIxs.push(await buildResizeHookPayloadIx(publicKey, connection));
-    currentSize = Math.min(targetSize, currentSize + 10_240);
   }
 
   const writeIxs = [];

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -138,7 +138,6 @@ async function runStepProofGeneration(
   publicKey: PublicKey,
   credential: { issued_at: number; wallet: number[]; leaf_index: number; jurisdiction: string; revoked: boolean },
   paths: Awaited<ReturnType<typeof runStepMerklePaths>>,
-  ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>,
   generate: (inputs: ProofInputs) => Promise<ProofResult>,
   transferParams: TransferParams,
 ) {
@@ -149,17 +148,23 @@ async function runStepProofGeneration(
   const recipientPubkey = new SolPublicKey(transferParams.recipient);
   const mintBytes = mintPubkey.toBytes();
   const recipientBytes = recipientPubkey.toBytes();
-  const mintLo = toHex(mintBytes.slice(0, 16));
-  const mintHi = toHex(mintBytes.slice(16, 32));
-  const recipientLo = toHex(recipientBytes.slice(0, 16));
-  const recipientHi = toHex(recipientBytes.slice(16, 32));
+  // Limb split must match on-chain `pubkey_to_limbs`
+  // (programs/zksettle/src/instructions/verify_proof/helpers.rs:32): the LOW
+  // limb carries the *trailing* 16 bytes of the pubkey, the HIGH limb the
+  // *leading* 16. Swapping these silently passes the circuit (which just
+  // hashes whatever it gets) but trips `check_bindings`' `MintMismatch` /
+  // `RecipientMismatch` on `settle_hook`, since the on-chain re-derive uses
+  // the canonical order against the witness positions.
+  const mintLo = toHex(mintBytes.slice(16, 32));
+  const mintHi = toHex(mintBytes.slice(0, 16));
+  const recipientLo = toHex(recipientBytes.slice(16, 32));
+  const recipientHi = toHex(recipientBytes.slice(0, 16));
   const epoch = String(Math.floor(Date.now() / 1000 / 86400));
   const amount = String(transferParams.amount);
-  const timestamp = String(Math.floor(Date.now() / 1000));
+  const timestamp = String(Number(epoch) * 86_400);
   const credentialExpiry = String(credential.issued_at + CREDENTIAL_VALIDITY_SECS);
 
-  const api = await ensureApi();
-  const nullifier = await computeNullifier(api, {
+  const nullifier = await computeNullifier({
     privateKey: zkPrivateKey,
     mintLo,
     mintHi,
@@ -217,7 +222,7 @@ async function runStepSubmit(
   dispatch({ type: "STEP_RUNNING", step: 4 });
 
   const start = performance.now();
-  const [sdk, { BN }, { PublicKey: SolPublicKey, Transaction }] = await Promise.all([
+  const [sdk, { BN }, { PublicKey: SolPublicKey, Transaction, ComputeBudgetProgram }] = await Promise.all([
     import("@zksettle/sdk"),
     import("@coral-xyz/anchor"),
     import("@solana/web3.js"),
@@ -227,7 +232,6 @@ async function runStepSubmit(
     checkHookPayloadExists, buildCloseHookPayloadIx,
     buildInitHookPayloadIx, buildResizeHookPayloadIx,
     buildWriteChunkIx, buildFinalizeHookPayloadIx,
-    buildSettleHookIx,
     CHUNK_SIZE,
   } = sdk;
 
@@ -242,14 +246,24 @@ async function runStepSubmit(
   // expiry and can yield false timeouts / false success (Solana docs).
   // Always pass the bh that was set on `tx.recentBlockhash` before signing.
   type Blockhash = { blockhash: string; lastValidBlockHeight: number };
+  type ConfirmCommitment = "processed" | "confirmed" | "finalized";
   const CONFIRM_FALLBACK_TIMEOUT_MS = 30_000;
   const CONFIRM_FALLBACK_INITIAL_DELAY_MS = 1_000;
   const CONFIRM_FALLBACK_MAX_DELAY_MS = 4_000;
-  const confirmTx = async (sig: string, bh: Blockhash) => {
+  // Intermediate batches (init/resize/writes/finalize) use "processed" to skip
+  // the ~5-15s confirmed-commitment wait. The next batch fetches a fresh
+  // "confirmed" blockhash before signing, so account-state visibility is still
+  // covered for the leader. Settle stays at "confirmed" — it's the final tx
+  // and the indexer keys off ProofSettled landing in a confirmed block.
+  const confirmTx = async (
+    sig: string,
+    bh: Blockhash,
+    commitment: ConfirmCommitment = "confirmed",
+  ) => {
     try {
       await connection.confirmTransaction(
         { signature: sig, blockhash: bh.blockhash, lastValidBlockHeight: bh.lastValidBlockHeight },
-        "confirmed",
+        commitment,
       );
     } catch (err) {
       // Narrow: only fall back on the strategy's edge-window expiry.
@@ -266,11 +280,15 @@ async function runStepSubmit(
         const { value } = await connection.getSignatureStatus(sig, {
           searchTransactionHistory: true,
         });
-        if (
-          value?.confirmationStatus === "confirmed" ||
-          value?.confirmationStatus === "finalized"
-        ) {
-          if (value.err) {
+        const reached =
+          commitment === "processed"
+            ? value?.confirmationStatus === "processed" ||
+              value?.confirmationStatus === "confirmed" ||
+              value?.confirmationStatus === "finalized"
+            : value?.confirmationStatus === "confirmed" ||
+              value?.confirmationStatus === "finalized";
+        if (reached) {
+          if (value?.err) {
             throw new Error("tx landed but failed on chain", { cause: value.err });
           }
           return;
@@ -282,12 +300,18 @@ async function runStepSubmit(
     }
   };
 
-  const sendSigned = async (signed: Transaction, bh: Blockhash) => {
+  type SendOpts = { skipPreflight?: boolean; maxRetries?: number };
+  const sendSigned = async (
+    signed: Transaction,
+    bh: Blockhash,
+    commitment: ConfirmCommitment = "confirmed",
+    sendOpts: SendOpts = {},
+  ) => {
     const sig = await connection.sendRawTransaction(signed.serialize(), {
-      skipPreflight: true,
-      maxRetries: 3,
+      skipPreflight: sendOpts.skipPreflight ?? true,
+      maxRetries: sendOpts.maxRetries ?? 3,
     });
-    await confirmTx(sig, bh);
+    await confirmTx(sig, bh, commitment);
     return sig;
   };
 
@@ -306,7 +330,7 @@ async function runStepSubmit(
     const bhRegister = await connection.getLatestBlockhash("confirmed");
     tx.recentBlockhash = bhRegister.blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed!, bhRegister);
+    await sendSigned(signed!, bhRegister, "processed");
   }
 
   const stalePayload = await checkHookPayloadExists(publicKey, connection);
@@ -317,7 +341,7 @@ async function runStepSubmit(
     const bhClose = await connection.getLatestBlockhash("confirmed");
     tx.recentBlockhash = bhClose.blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed!, bhClose);
+    await sendSigned(signed!, bhClose, "processed");
   }
 
   // ── Build ALL proof upload transactions upfront ──
@@ -371,7 +395,7 @@ async function runStepSubmit(
   }
   const signedInitResize = await signAllTransactions(initResizeTxs);
   for (const tx of signedInitResize) {
-    await sendSigned(tx, bh1);
+    await sendSigned(tx, bh1, "processed");
   }
 
   // ── Batch 2: writes only (fresh blockhash + Phantom popup) ──
@@ -401,30 +425,24 @@ async function runStepSubmit(
 
   // Confirming the last write guarantees all prior writes landed (each
   // write's offset must match the cumulative high_water_mark).
-  if (lastWriteSig) await confirmTx(lastWriteSig, bh2);
+  if (lastWriteSig) await confirmTx(lastWriteSig, bh2, "processed");
 
   // ── Batch 3: finalize (own fresh blockhash + Phantom popup) ──
-  const finalizeTx = new Transaction().add(finalizeIx);
+  // Finalize is the final on-chain tx in this flow (settle_hook integration
+  // pending Light CPI wiring). Attach a priority fee + bump maxRetries so the
+  // tx survives Alchemy devnet congestion: w/o a fee, leaders skip the tx and
+  // the blockhash window (60-90s) expires before inclusion, surfacing as
+  // `TransactionExpiredBlockheightExceededError`. 50k µLamports/CU × default
+  // 200K CU ≈ 10,000 lamports ≈ 0.00001 SOL — negligible vs rent already paid.
+  const finalizeCuPriceIx = ComputeBudgetProgram.setComputeUnitPrice({ microLamports: 50_000 });
+  const finalizeTx = new Transaction().add(finalizeCuPriceIx).add(finalizeIx);
   const bh3 = await connection.getLatestBlockhash("confirmed");
   finalizeTx.feePayer = publicKey;
   finalizeTx.recentBlockhash = bh3.blockhash;
   const [signedFinalize] = await signAllTransactions([finalizeTx]);
-  await sendSigned(signedFinalize!, bh3);
-
-  // ── Batch 4: settle_hook — invokes gnark verifier, emits ProofSettled,
-  // closes the payload PDA and refunds rent. Without this the indexer
-  // never sees a ProofSettled event and the events table stays empty.
-  const settleIx = await buildSettleHookIx(
-    publicKey,
-    new BN(transferParams.amount),
-    connection,
-  );
-  const settleTx = new Transaction().add(settleIx);
-  const bh4 = await connection.getLatestBlockhash("confirmed");
-  settleTx.feePayer = publicKey;
-  settleTx.recentBlockhash = bh4.blockhash;
-  const [signedSettle] = await signAllTransactions([settleTx]);
-  const finalSig = await sendSigned(signedSettle!, bh4);
+  const finalSig = await sendSigned(signedFinalize!, bh3, "confirmed", {
+    maxRetries: 10,
+  });
 
   dispatch({ type: "SET_TX", signature: finalSig });
   dispatch({
@@ -438,8 +456,8 @@ async function runStepSubmit(
 
 async function runStepConfirm(dispatch: Dispatch<FlowAction>): Promise<void> {
   // Step 4 (`runStepSubmit`) already awaited `confirmTransaction` for the
-  // settle tx using its original signing blockhash. Re-confirming here with a
-  // freshly-fetched blockhash would (a) decouple the wait-loop expiry from
+  // finalize tx using its original signing blockhash. Re-confirming here with
+  // a freshly-fetched blockhash would (a) decouple the wait-loop expiry from
   // the actual tx (Solana docs explicitly warn against this) and (b) be
   // redundant. Keep this step purely for the UI step-machine.
   dispatch({ type: "STEP_RUNNING", step: 5 });
@@ -464,7 +482,6 @@ interface LiveFlowContext {
   connection: Connection;
   signAllTransactions: (txs: Transaction[]) => Promise<Transaction[]>;
   generate: (inputs: ProofInputs) => Promise<ProofResult>;
-  ensureApi: () => Promise<import("@aztec/bb.js").Barretenberg>;
   derivePrivateKey: () => Promise<string>;
   transferParams: TransferParams;
 }
@@ -490,7 +507,7 @@ function handleSubmitError(dispatch: Dispatch<FlowAction>, err: unknown): void {
 }
 
 async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
-  const { dispatch, walletHex, publicKey, connection, signAllTransactions, generate, ensureApi, derivePrivateKey, transferParams } = ctx;
+  const { dispatch, walletHex, publicKey, connection, signAllTransactions, generate, derivePrivateKey, transferParams } = ctx;
   let credential;
   try { credential = await runStepCredential(dispatch, walletHex); }
   catch (err) { handleCredentialError(dispatch, err); return; }
@@ -500,7 +517,7 @@ async function runLiveFlow(ctx: LiveFlowContext): Promise<void> {
   catch (err) { stepError(dispatch, 2, err, "Failed to fetch Merkle paths"); return; }
 
   let step3Result;
-  try { step3Result = await runStepProofGeneration(dispatch, publicKey, credential, paths, ensureApi, generate, transferParams); }
+  try { step3Result = await runStepProofGeneration(dispatch, publicKey, credential, paths, generate, transferParams); }
   catch (err) { stepError(dispatch, 3, err, "Proof generation failed"); return; }
 
   let txSignature: string | undefined;
@@ -529,7 +546,7 @@ export function useProveFlow(): UseProveFlowReturn {
     ? bytesToHex(Array.from(publicKey.toBytes()))
     : null;
 
-  const { generate, ensureApi } = useProofGeneration();
+  const { generate } = useProofGeneration();
   const { derivePrivateKey } = useZkPrivateKey();
 
   const runningRef = useRef(false);
@@ -569,10 +586,10 @@ export function useProveFlow(): UseProveFlowReturn {
         return;
       }
 
-      await runLiveFlow({ dispatch, walletHex, publicKey, connection, signAllTransactions, generate, ensureApi, derivePrivateKey, transferParams: params });
+      await runLiveFlow({ dispatch, walletHex, publicKey, connection, signAllTransactions, generate, derivePrivateKey, transferParams: params });
       } finally { runningRef.current = false; }
     },
-    [connected, publicKey, walletHex, connection, signAllTransactions, generate, ensureApi, derivePrivateKey],
+    [connected, publicKey, walletHex, connection, signAllTransactions, generate, derivePrivateKey],
   );
 
   const startFlow = useCallback((params: TransferParams) => runFlow("live", params), [runFlow]);

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -226,6 +226,7 @@ async function runStepSubmit(
     checkHookPayloadExists, buildCloseHookPayloadIx,
     buildInitHookPayloadIx, buildResizeHookPayloadIx,
     buildWriteChunkIx, buildFinalizeHookPayloadIx,
+    buildSettleHookIx,
     CHUNK_SIZE,
   } = sdk;
 
@@ -366,7 +367,22 @@ async function runStepSubmit(
   finalizeTx.feePayer = publicKey;
   finalizeTx.recentBlockhash = bh3.blockhash;
   const [signedFinalize] = await signAllTransactions([finalizeTx]);
-  const finalSig = await sendSigned(signedFinalize!);
+  await sendSigned(signedFinalize!);
+
+  // ── Batch 4: settle_hook — invokes gnark verifier, emits ProofSettled,
+  // closes the payload PDA and refunds rent. Without this the indexer
+  // never sees a ProofSettled event and the events table stays empty.
+  const settleIx = await buildSettleHookIx(
+    publicKey,
+    new BN(transferParams.amount),
+    connection,
+  );
+  const settleTx = new Transaction().add(settleIx);
+  const bh4 = await connection.getLatestBlockhash("confirmed");
+  settleTx.feePayer = publicKey;
+  settleTx.recentBlockhash = bh4.blockhash;
+  const [signedSettle] = await signAllTransactions([settleTx]);
+  const finalSig = await sendSigned(signedSettle!);
 
   dispatch({ type: "SET_TX", signature: finalSig });
   dispatch({

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -242,10 +242,32 @@ async function runStepSubmit(
   // Always pass the bh that was set on `tx.recentBlockhash` before signing.
   type Blockhash = { blockhash: string; lastValidBlockHeight: number };
   const confirmTx = async (sig: string, bh: Blockhash) => {
-    await connection.confirmTransaction(
-      { signature: sig, blockhash: bh.blockhash, lastValidBlockHeight: bh.lastValidBlockHeight },
-      "confirmed",
-    );
+    try {
+      await connection.confirmTransaction(
+        { signature: sig, blockhash: bh.blockhash, lastValidBlockHeight: bh.lastValidBlockHeight },
+        "confirmed",
+      );
+    } catch (err) {
+      // BlockheightBasedTransactionConfirmationStrategy returns the moment
+      // current height passes lastValidBlockHeight, even if the tx lands at
+      // the edge of the validity window. Fall back to direct signature-status
+      // polling so a late inclusion isn't reported as a false-negative expiry.
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        const { value } = await connection.getSignatureStatus(sig, {
+          searchTransactionHistory: true,
+        });
+        if (
+          value?.confirmationStatus === "confirmed" ||
+          value?.confirmationStatus === "finalized"
+        ) {
+          if (value.err) throw new Error(`tx landed but failed: ${JSON.stringify(value.err)}`);
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 1500));
+      }
+      throw err;
+    }
   };
 
   const sendSigned = async (signed: Transaction, bh: Blockhash) => {

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -235,17 +235,25 @@ async function runStepSubmit(
     return new Uint8Array(clean.match(/.{1,2}/g)?.map((b) => Number.parseInt(b, 16)) ?? []);
   };
 
-  const confirmTx = async (sig: string) => {
-    const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash("confirmed");
-    await connection.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight }, "confirmed");
+  // `confirmTransaction({signature, blockhash, lastValidBlockHeight})` ties
+  // the wait-loop expiry to the SAME blockhash the tx was signed with.
+  // Fetching a fresh blockhash here decouples the timeout from actual tx
+  // expiry and can yield false timeouts / false success (Solana docs).
+  // Always pass the bh that was set on `tx.recentBlockhash` before signing.
+  type Blockhash = { blockhash: string; lastValidBlockHeight: number };
+  const confirmTx = async (sig: string, bh: Blockhash) => {
+    await connection.confirmTransaction(
+      { signature: sig, blockhash: bh.blockhash, lastValidBlockHeight: bh.lastValidBlockHeight },
+      "confirmed",
+    );
   };
 
-  const sendSigned = async (signed: Transaction) => {
+  const sendSigned = async (signed: Transaction, bh: Blockhash) => {
     const sig = await connection.sendRawTransaction(signed.serialize(), {
       skipPreflight: true,
       maxRetries: 3,
     });
-    await confirmTx(sig);
+    await confirmTx(sig, bh);
     return sig;
   };
 
@@ -261,9 +269,10 @@ async function runStepSubmit(
     }, connection);
     const tx = new Transaction().add(ix);
     tx.feePayer = publicKey;
-    tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
+    const bhRegister = await connection.getLatestBlockhash("confirmed");
+    tx.recentBlockhash = bhRegister.blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed!);
+    await sendSigned(signed!, bhRegister);
   }
 
   const stalePayload = await checkHookPayloadExists(publicKey, connection);
@@ -271,9 +280,10 @@ async function runStepSubmit(
     const ix = await buildCloseHookPayloadIx(publicKey, connection);
     const tx = new Transaction().add(ix);
     tx.feePayer = publicKey;
-    tx.recentBlockhash = (await connection.getLatestBlockhash("confirmed")).blockhash;
+    const bhClose = await connection.getLatestBlockhash("confirmed");
+    tx.recentBlockhash = bhClose.blockhash;
     const [signed] = await signAllTransactions([tx]);
-    await sendSigned(signed!);
+    await sendSigned(signed!, bhClose);
   }
 
   // ── Build ALL proof upload transactions upfront ──
@@ -327,7 +337,7 @@ async function runStepSubmit(
   }
   const signedInitResize = await signAllTransactions(initResizeTxs);
   for (const tx of signedInitResize) {
-    await sendSigned(tx!);
+    await sendSigned(tx!, bh1);
   }
 
   // ── Batch 2: writes only (fresh blockhash + Phantom popup) ──
@@ -357,7 +367,7 @@ async function runStepSubmit(
 
   // Confirming the last write guarantees all prior writes landed (each
   // write's offset must match the cumulative high_water_mark).
-  if (lastWriteSig) await confirmTx(lastWriteSig);
+  if (lastWriteSig) await confirmTx(lastWriteSig, bh2);
 
   // ── Batch 3: finalize (own fresh blockhash + Phantom popup) ──
   const finalizeTx = new Transaction().add(finalizeIx);
@@ -365,7 +375,7 @@ async function runStepSubmit(
   finalizeTx.feePayer = publicKey;
   finalizeTx.recentBlockhash = bh3.blockhash;
   const [signedFinalize] = await signAllTransactions([finalizeTx]);
-  await sendSigned(signedFinalize!);
+  await sendSigned(signedFinalize!, bh3);
 
   // ── Batch 4: settle_hook — invokes gnark verifier, emits ProofSettled,
   // closes the payload PDA and refunds rent. Without this the indexer
@@ -380,7 +390,7 @@ async function runStepSubmit(
   settleTx.feePayer = publicKey;
   settleTx.recentBlockhash = bh4.blockhash;
   const [signedSettle] = await signAllTransactions([settleTx]);
-  const finalSig = await sendSigned(signedSettle!);
+  const finalSig = await sendSigned(signedSettle!, bh4);
 
   dispatch({ type: "SET_TX", signature: finalSig });
   dispatch({

--- a/frontend/src/hooks/use-prove-flow.ts
+++ b/frontend/src/hooks/use-prove-flow.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useReducer, useRef, type Dispatch } from "react";
+import { TransactionExpiredBlockheightExceededError } from "@solana/web3.js";
 import type { Connection, PublicKey, Transaction } from "@solana/web3.js";
 
 import { useWallet, useConnection } from "@/hooks/use-wallet-connection";
@@ -241,6 +242,9 @@ async function runStepSubmit(
   // expiry and can yield false timeouts / false success (Solana docs).
   // Always pass the bh that was set on `tx.recentBlockhash` before signing.
   type Blockhash = { blockhash: string; lastValidBlockHeight: number };
+  const CONFIRM_FALLBACK_TIMEOUT_MS = 30_000;
+  const CONFIRM_FALLBACK_INITIAL_DELAY_MS = 1_000;
+  const CONFIRM_FALLBACK_MAX_DELAY_MS = 4_000;
   const confirmTx = async (sig: string, bh: Blockhash) => {
     try {
       await connection.confirmTransaction(
@@ -248,11 +252,16 @@ async function runStepSubmit(
         "confirmed",
       );
     } catch (err) {
+      // Narrow: only fall back on the strategy's edge-window expiry.
+      // Other errors (RPC/network/SendTransactionError) re-throw immediately
+      // so we don't burn 30s polling on a failure that won't resolve.
+      if (!(err instanceof TransactionExpiredBlockheightExceededError)) throw err;
       // BlockheightBasedTransactionConfirmationStrategy returns the moment
       // current height passes lastValidBlockHeight, even if the tx lands at
-      // the edge of the validity window. Fall back to direct signature-status
-      // polling so a late inclusion isn't reported as a false-negative expiry.
-      const deadline = Date.now() + 30_000;
+      // the edge of the validity window. Poll getSignatureStatus directly
+      // so a late inclusion isn't surfaced as a false-negative expiry.
+      const deadline = Date.now() + CONFIRM_FALLBACK_TIMEOUT_MS;
+      let delay = CONFIRM_FALLBACK_INITIAL_DELAY_MS;
       while (Date.now() < deadline) {
         const { value } = await connection.getSignatureStatus(sig, {
           searchTransactionHistory: true,
@@ -261,10 +270,13 @@ async function runStepSubmit(
           value?.confirmationStatus === "confirmed" ||
           value?.confirmationStatus === "finalized"
         ) {
-          if (value.err) throw new Error(`tx landed but failed: ${JSON.stringify(value.err)}`);
+          if (value.err) {
+            throw new Error("tx landed but failed on chain", { cause: value.err });
+          }
           return;
         }
-        await new Promise((r) => setTimeout(r, 1500));
+        await new Promise((r) => setTimeout(r, delay));
+        delay = Math.min(delay * 2, CONFIRM_FALLBACK_MAX_DELAY_MS);
       }
       throw err;
     }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -2,6 +2,18 @@ import { getWalletAuthHeaders, isWalletScopedPath } from "./wallet-auth";
 
 const PROXY_BASE = "/api/proxy";
 
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  // Copy into a fresh ArrayBuffer to satisfy the Web Crypto signature without
+  // pulling SharedArrayBuffer into the type. Body is already small.
+  const buf = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buf).set(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  const view = new Uint8Array(digest);
+  let out = "";
+  for (const b of view) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
 export class ApiError extends Error {
   constructor(
     public status: number,
@@ -40,4 +52,79 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
   }
 
   return (await res.json()) as T;
+}
+
+export interface BinaryResponse {
+  body: Uint8Array;
+  headers: Headers;
+}
+
+export interface BinaryRequestInit {
+  method?: string;
+  body?: Uint8Array | ArrayBuffer;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Counterpart of `apiFetch` for endpoints that exchange `application/octet-stream`
+ * payloads (e.g. server-side Groth16 prover). Wallet-auth headers are attached
+ * for paths that match `isWalletScopedPath`, mirroring `apiFetch`'s behaviour;
+ * the response Headers are surfaced so callers can read out-of-band metadata
+ * like `X-Proof-Len` without re-parsing the body.
+ */
+export async function apiFetchBinary(
+  path: string,
+  init: BinaryRequestInit = {},
+): Promise<BinaryResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/octet-stream",
+    Accept: "application/octet-stream",
+    ...init.headers,
+  };
+
+  if (isWalletScopedPath(path)) {
+    // Bind the signed wallet-auth message to sha256(body) so captured headers
+    // cannot be replayed against a different payload within the 5-min replay
+    // window. Mirrors `body_hash_hex` in the issuer service's
+    // `prove_groth16::verify_wallet_headers`. GET-style wallet-scoped paths
+    // arrive here with no body and fall through to the bodyless signature.
+    const bodyBytes = init.body
+      ? init.body instanceof Uint8Array
+        ? init.body
+        : new Uint8Array(init.body)
+      : undefined;
+    const bodyHashHex = bodyBytes
+      ? await sha256Hex(bodyBytes)
+      : undefined;
+    const walletHeaders = await getWalletAuthHeaders({ bodyHashHex });
+    Object.assign(headers, walletHeaders);
+  }
+
+  const res = await fetch(`${PROXY_BASE}${path}`, {
+    method: init.method ?? "POST",
+    body: init.body as BodyInit | undefined,
+    headers,
+    credentials: "same-origin",
+  });
+
+  if (!res.ok) {
+    let parsed: unknown = {};
+    try {
+      parsed = await res.clone().json();
+    } catch {
+      try {
+        parsed = await res.text();
+      } catch {
+        // give up — leave parsed as {}
+      }
+    }
+    throw new ApiError(
+      res.status,
+      parsed,
+      `${res.status} ${res.statusText} on ${path}`,
+    );
+  }
+
+  const buf = new Uint8Array(await res.arrayBuffer());
+  return { body: buf, headers: res.headers };
 }

--- a/frontend/src/lib/api/endpoints.ts
+++ b/frontend/src/lib/api/endpoints.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client";
+import { apiFetch, apiFetchBinary } from "./client";
 import {
   ApiKeyResponseSchema,
   CredentialSchema,
@@ -73,6 +73,79 @@ export const revokeCredential = (wallet: string) =>
 
 export const publishRoots = () =>
   apiFetch<{ slot: number; registered: boolean }>("/v1/roots/publish", { method: "POST" });
+
+const GROTH16_WITNESS_HEADER_LEN = 12;
+const GROTH16_FIELD_LEN = 32;
+const GROTH16_NUM_PUBLIC_INPUTS = 11;
+const GROTH16_PUBLIC_WITNESS_LEN =
+  GROTH16_WITNESS_HEADER_LEN + GROTH16_NUM_PUBLIC_INPUTS * GROTH16_FIELD_LEN;
+// Real proofs are 388 B; cap well above that to prevent a malformed
+// `x-proof-len` header from triggering a runaway Uint8Array allocation
+// before the length-mismatch check fires.
+const GROTH16_PROOF_MAX_LEN = 4096;
+
+export interface Groth16ProofBundle {
+  /**
+   * Concatenated `proof || public-witness` bytes — what the on-chain verifier
+   * deserialises from `hook_payload.proof_and_witness`. `split_proof_and_witness`
+   * peels the trailing `12 + 11*32 = 364` witness bytes back off, so the bundle
+   * MUST contain both halves; uploading only the proof slice yields a
+   * `ProofConversionError` on-chain.
+   */
+  proof: Uint8Array;
+  /** 11 BE 32-byte field elements parsed from the public-witness, as `0x`-hex strings. */
+  publicInputs: string[];
+}
+
+/**
+ * Server-side Sunspot Groth16 prover. Posts the gzipped Noir witness emitted
+ * by `noir.execute(...)` and returns the bundle the on-chain `gnark_verifier_solana`
+ * verifier consumes. `publicInputs` mirrors the legacy `bb.js` shape so callers
+ * keep `ProofResult` unchanged.
+ */
+export const proveGroth16 = async (witnessGz: Uint8Array): Promise<Groth16ProofBundle> => {
+  const { body, headers } = await apiFetchBinary("/v1/prove/groth16", {
+    method: "POST",
+    body: witnessGz,
+  });
+
+  const proofLen = Number.parseInt(headers.get("x-proof-len") ?? "", 10);
+  const witnessLen = Number.parseInt(headers.get("x-witness-len") ?? "", 10);
+  if (!Number.isFinite(proofLen) || !Number.isFinite(witnessLen)) {
+    throw new Error(
+      `proveGroth16: missing/invalid length headers (proof=${proofLen}, witness=${witnessLen})`,
+    );
+  }
+  if (proofLen < 0 || proofLen > GROTH16_PROOF_MAX_LEN) {
+    throw new Error(
+      `proveGroth16: proof length ${proofLen} outside sane bounds (0..${GROTH16_PROOF_MAX_LEN})`,
+    );
+  }
+  if (proofLen + witnessLen !== body.length) {
+    throw new Error(
+      `proveGroth16: length mismatch (proof=${proofLen} + witness=${witnessLen} != body=${body.length})`,
+    );
+  }
+  if (witnessLen !== GROTH16_PUBLIC_WITNESS_LEN) {
+    throw new Error(
+      `proveGroth16: unexpected public-witness length ${witnessLen} (expected ${GROTH16_PUBLIC_WITNESS_LEN})`,
+    );
+  }
+
+  const pwBody = body.subarray(proofLen + GROTH16_WITNESS_HEADER_LEN, proofLen + witnessLen);
+  const publicInputs: string[] = [];
+  for (let i = 0; i < GROTH16_NUM_PUBLIC_INPUTS; i++) {
+    const off = i * GROTH16_FIELD_LEN;
+    const field = pwBody.subarray(off, off + GROTH16_FIELD_LEN);
+    let hex = "0x";
+    for (const b of field) hex += b.toString(16).padStart(2, "0");
+    publicInputs.push(hex);
+  }
+  // Copy the full `proof || public-witness` bundle so callers don't accidentally
+  // retain the backing fetch buffer. This is exactly what `uploadProofChunked`
+  // stages into `hook_payload.proof_and_witness`.
+  return { proof: new Uint8Array(body), publicInputs };
+};
 
 export const createApiKey = async (owner: string): Promise<ApiKeyResponse> =>
   ApiKeyResponseSchema.parse(

--- a/frontend/src/lib/api/wallet-auth.ts
+++ b/frontend/src/lib/api/wallet-auth.ts
@@ -69,30 +69,40 @@ export function isWalletScopedPath(path: string): boolean {
     path.includes("/credentials/") ||
     path.includes("/proofs/membership/") ||
     path.includes("/proofs/sanctions/") ||
-    path.includes("/proofs/jurisdiction/")
+    path.includes("/proofs/jurisdiction/") ||
+    path.includes("/prove/groth16")
   );
 }
 
 async function signAndCache(
   publicKey: PublicKey,
   signMessage: SignMessageFn,
+  bodyHashHex?: string,
 ): Promise<Record<string, string>> {
   const walletHex = bytesToHex(Array.from(publicKey.toBytes()));
   const now = Date.now();
   const timestamp = Math.floor(now / 1000);
-  const message = `zksettle:${walletHex}:${timestamp}`;
+  const message = bodyHashHex
+    ? `zksettle:${walletHex}:${timestamp}:${bodyHashHex}`
+    : `zksettle:${walletHex}:${timestamp}`;
   const encoded = new TextEncoder().encode(message);
   const signatureBytes = await signMessage(encoded);
   const signature = encodeBase58(signatureBytes);
 
-  cached = {
-    walletHex,
-    signature,
-    timestamp,
-    expiresAt: now + REPLAY_WINDOW_MS,
-  };
+  // Body-bound signatures are unique per request — caching them would just
+  // burn memory since the next call has a different body hash. Only cache
+  // the bodyless variant, which is what GETs (membership/sanctions/etc) reuse.
+  if (!bodyHashHex) {
+    cached = {
+      walletHex,
+      signature,
+      timestamp,
+      expiresAt: now + REPLAY_WINDOW_MS,
+    };
+  }
 
   return {
+    "x-wallet-pubkey": walletHex,
     "x-wallet-signature": signature,
     "x-wallet-timestamp": String(timestamp),
   };
@@ -112,7 +122,20 @@ function getPhantomFallback(): RegisteredSigner | null {
   };
 }
 
-export async function getWalletAuthHeaders(): Promise<Record<string, string>> {
+export interface WalletAuthOptions {
+  /**
+   * Hex-encoded sha256 of the request body. When set, the wallet signs
+   * `zksettle:{wallet}:{ts}:{bodyHashHex}` instead of the cached bodyless
+   * message — binding the auth headers to a specific request body so that
+   * captured headers cannot be replayed against a different payload. Caller
+   * must pass the SAME bytes the server will hash (raw request body).
+   */
+  bodyHashHex?: string;
+}
+
+export async function getWalletAuthHeaders(
+  opts: WalletAuthOptions = {},
+): Promise<Record<string, string>> {
   const signer = registeredSigner ?? getPhantomFallback();
   if (!signer) return {};
 
@@ -120,8 +143,15 @@ export async function getWalletAuthHeaders(): Promise<Record<string, string>> {
   const walletHex = bytesToHex(Array.from(publicKey.toBytes()));
   const now = Date.now();
 
+  // Body-bound auth cannot reuse the cached bodyless signature. Also skip
+  // the inflight-dedup — different bodies legitimately need different sigs.
+  if (opts.bodyHashHex) {
+    return signAndCache(publicKey, signMessage, opts.bodyHashHex);
+  }
+
   if (cached?.walletHex === walletHex && now < cached.expiresAt) {
     return {
+      "x-wallet-pubkey": walletHex,
       "x-wallet-signature": cached.signature,
       "x-wallet-timestamp": String(cached.timestamp),
     };

--- a/frontend/src/lib/nullifier.test.ts
+++ b/frontend/src/lib/nullifier.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { computeNullifier, type NullifierInputs } from "./nullifier";
+
+// Regression vectors pin the `@zkpassport/poseidon2` (`poseidon2Hash`) output
+// for fixed seven-field inputs. Drift here means either the dependency
+// changed its parameters/IV/sponge layout or `computeNullifier`'s field
+// ordering changed — either way the on-chain `nullifier_hash` binding to
+// `Issuer.nullifiers` (`programs/zksettle/src/state/issuer.rs`) would silently
+// fork and orphan every pre-existing nullifier.
+//
+// Outputs computed against `@zkpassport/poseidon2@0.6.2`. When upgrading the
+// dependency, regenerate with `node` against the new module and cross-check
+// at least one vector against `@aztec/bb.js` `poseidon2Hash` before pinning.
+describe("computeNullifier — Poseidon2 regression vectors", () => {
+  const PRIME =
+    21888242871839275222246405745257275088548364400416034343698204186575808495617n;
+
+  const cases: Array<{
+    name: string;
+    inputs: NullifierInputs;
+    expected: string;
+  }> = [
+    {
+      name: "sequential 1..7",
+      inputs: {
+        privateKey: "1",
+        mintLo: "2",
+        mintHi: "3",
+        epoch: "4",
+        recipientLo: "5",
+        recipientHi: "6",
+        amount: "7",
+      },
+      expected:
+        "0x16f929bc0d216df4b05bdc44222463edf2b9791bd949ab926eebda06a502d238",
+    },
+    {
+      name: "mixed wide values",
+      inputs: {
+        privateKey: "0x0123456789abcdef",
+        mintLo: "0xfedcba9876543210",
+        mintHi: "100",
+        epoch: "86400",
+        recipientLo: "0xdeadbeef",
+        recipientHi: "0xcafebabe",
+        amount: "1000000",
+      },
+      expected:
+        "0x083493f3f4a133bb2ad73a06e77fb3f6475a43b9acee58606bf8f986dfbb9fe7",
+    },
+    {
+      name: "all zeros",
+      inputs: {
+        privateKey: "0",
+        mintLo: "0",
+        mintHi: "0",
+        epoch: "0",
+        recipientLo: "0",
+        recipientHi: "0",
+        amount: "0",
+      },
+      expected:
+        "0x0c98aea3cf46e23f09b3de79dd0f85080820f47f0aa9371a2defe633a487cdc8",
+    },
+  ];
+
+  for (const { name, inputs, expected } of cases) {
+    it(name, async () => {
+      const got = await computeNullifier(inputs);
+      expect(got).toBe(expected);
+    });
+  }
+
+  it("rejects negative inputs", async () => {
+    await expect(
+      computeNullifier({
+        privateKey: "-1",
+        mintLo: "0",
+        mintHi: "0",
+        epoch: "0",
+        recipientLo: "0",
+        recipientHi: "0",
+        amount: "0",
+      }),
+    ).rejects.toThrow(/outside BN254/);
+  });
+
+  it("rejects inputs >= field prime", async () => {
+    await expect(
+      computeNullifier({
+        privateKey: PRIME.toString(),
+        mintLo: "0",
+        mintHi: "0",
+        epoch: "0",
+        recipientLo: "0",
+        recipientHi: "0",
+        amount: "0",
+      }),
+    ).rejects.toThrow(/outside BN254/);
+  });
+
+  it("output is always 32-byte 0x-hex", async () => {
+    const got = await computeNullifier({
+      privateKey: "1",
+      mintLo: "0",
+      mintHi: "0",
+      epoch: "0",
+      recipientLo: "0",
+      recipientHi: "0",
+      amount: "0",
+    });
+    expect(got).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+});

--- a/frontend/src/lib/nullifier.ts
+++ b/frontend/src/lib/nullifier.ts
@@ -1,4 +1,4 @@
-import type { Barretenberg } from "@aztec/bb.js";
+import { poseidon2Hash } from "@zkpassport/poseidon2";
 
 export interface NullifierInputs {
   privateKey: string;
@@ -10,41 +10,45 @@ export interface NullifierInputs {
   amount: string;
 }
 
-export async function computeNullifier(
-  api: Barretenberg,
-  fields: NullifierInputs,
-): Promise<string> {
-  const inputs = [
-    fields.privateKey,
-    fields.mintLo,
-    fields.mintHi,
-    fields.epoch,
-    fields.recipientLo,
-    fields.recipientHi,
-    fields.amount,
-  ].map(fieldToBytes32);
+// BN254 scalar field modulus. `poseidon2Hash` silently reduces inputs mod p,
+// so reject out-of-range values at the boundary instead of letting a
+// malformed caller mint a nullifier that aliases a different field element.
+const BN254_PRIME =
+  21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 
-  const { hash } = await api.poseidon2Hash({ inputs });
-  return (
-    "0x" +
-    Array.from(hash)
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("")
-  );
-}
+/**
+ * Aztec-style Poseidon2 sponge over BN254 for the seven fields the circuit
+ * absorbs at `circuits/src/main.nr:127`. `@zkpassport/poseidon2` is a pure-TS
+ * impl whose IV (`N * 2^64`), sponge layout (t=4, rate=3, capacity slot 3),
+ * permutation parameters, and squeeze convention match Barretenberg's
+ * `poseidon2Hash` byte-for-byte — verified against `@aztec/bb.js` on the full
+ * seven-field input vector before the prover-side `bb.js` removal. The legacy
+ * `Barretenberg` argument is gone; callers don't need a wasm handle anymore.
+ */
+export async function computeNullifier(fields: NullifierInputs): Promise<string> {
+  const labelled: ReadonlyArray<readonly [keyof NullifierInputs, string]> = [
+    ["privateKey", fields.privateKey],
+    ["mintLo", fields.mintLo],
+    ["mintHi", fields.mintHi],
+    ["epoch", fields.epoch],
+    ["recipientLo", fields.recipientLo],
+    ["recipientHi", fields.recipientHi],
+    ["amount", fields.amount],
+  ];
+  const inputs = labelled.map(([name, raw]) => {
+    const n = BigInt(raw);
+    if (n < 0n || n >= BN254_PRIME) {
+      throw new RangeError(
+        `Nullifier input "${name}" outside BN254 scalar field: ${raw}`,
+      );
+    }
+    return n;
+  });
 
-const BN254_MAX = (1n << 254n) - 1n;
-
-function fieldToBytes32(value: string): Uint8Array {
-  const n = BigInt(value);
-  if (n < 0n || n > BN254_MAX) {
-    throw new RangeError(`Field value out of BN254 range: ${value}`);
+  const hash = poseidon2Hash(inputs);
+  const hex = hash.toString(16);
+  if (hex.length > 64) {
+    throw new RangeError(`Poseidon2 output overflowed 32 bytes: 0x${hex}`);
   }
-  const buf = new Uint8Array(32);
-  let rem = n;
-  for (let i = 31; i >= 0; i--) {
-    buf[i] = Number(rem & 0xffn);
-    rem >>= 8n;
-  }
-  return buf;
+  return "0x" + hex.padStart(64, "0");
 }

--- a/frontend/src/types/proof.ts
+++ b/frontend/src/types/proof.ts
@@ -39,7 +39,12 @@ export interface ProofInputs {
 }
 
 export interface ProofResult {
-  /** UltraHonk proof bytes. */
+  /**
+   * Groth16 bundle: `proof || public-witness` bytes (~752B). This is exactly
+   * what `uploadProofChunked` stages into `hook_payload.proof_and_witness`;
+   * the on-chain `split_proof_and_witness` peels the trailing 364 witness
+   * bytes off before deserialising the gnark proof.
+   */
   proof: Uint8Array;
   /** Public inputs in the order declared by the circuit (length 11). */
   publicInputs: string[];

--- a/gotchas.md
+++ b/gotchas.md
@@ -8,15 +8,17 @@ Program flow requires: `init_hook_payload` → `resize_hook_payload` → `write_
 
 For proofs > ~10 KB the client must call `resizeHookPayload()` multiple times until `data_len >= target`.
 
-## Helius webhook auth: `Bearer ` prefix required
+<!-- markdownlint-disable-next-line MD038 -->
+## Helius webhook auth: `Bearer ` prefix required (with trailing space)
 
-Indexer `verify_auth` (routes/webhook.rs) strips `Bearer ` prefix from `Authorization` header. Helius sends the auth header value verbatim, so the dashboard's "Authentication Header" field must include `Bearer ` prefix:
+<!-- markdownlint-disable-next-line MD038 -->
+Indexer `verify_auth` (`backend/crates/indexer/src/routes/webhook.rs:107`) strips the literal 7-character prefix `Bearer ` from the `Authorization` header. The trailing space matters — Helius sends the dashboard's "Authentication Header" value verbatim, so it must be exactly:
 
-```
+```text
 Bearer <INDEXER_HELIUS_AUTH_TOKEN value>
 ```
 
-Without prefix → 401. After fix → 200.
+Without the prefix (or with the space missing) → 401. After fix → 200.
 
 ## Frontend prove flow was missing `settle_hook` call entirely
 
@@ -27,3 +29,23 @@ Settlement path (direct call) needs ~13 accounts including `registry.merkle_tree
 ## SDK `uploadProofChunked` skipped resize step
 
 Same bug as the original `transfer.ts`: helper exported from the SDK but built `init → write → finalize` only. Fortunately nothing outside the SDK called it, so no production impact — but the helper itself would have panicked on first use. Fixed to include `resize_hook_payload` loop matching the on-chain realloc cap (10 KiB / ix).
+
+## `confirmTransaction` MUST use the same blockhash the tx was signed with
+
+In `@solana/web3.js`, `connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, commitment)` ties the wait-loop's expiry to the supplied `lastValidBlockHeight`. Confirming a tx using a **fresh** `getLatestBlockhash()` instead of the one that was set on `tx.recentBlockhash` decouples the timeout from the actual tx expiry — Solana docs explicitly warn this yields incorrect results (false timeouts or false success). The string-only deprecated overload `confirmTransaction(sig, commitment)` is safer than passing a mismatched strategy because it just polls signature status. Pattern in this repo: capture `bh = await getLatestBlockhash("confirmed")`, set `tx.recentBlockhash = bh.blockhash`, sign+send, then confirm using the *same* `bh`.
+
+## Anchor 0.31 `new Program(idl, provider)` uses `idl.address`, not a separate `programId` arg
+
+`@coral-xyz/anchor` 0.31 dropped the `programId` parameter from the `Program` constructor. The program address comes from `idl.address`. If a wrapper helper accepts a `programId` override and derives PDAs from it but constructs the `Program` from the raw IDL, the helper will derive PDAs for one program while encoding the instruction with the IDL's embedded address — silent mismatch. Always clone the IDL and override `idl.address = programId.toBase58()` before `new Program(...)` when honoring a programId override.
+
+## `signAndSend` callbacks: confirmation contract must be explicit
+
+In `ChunkedUploadOptions.signAndSend(tx) => Promise<string>` (SDK `uploadProofChunked`) the contract did not require the callback to confirm — only sign+send. Reading `getAccountInfo` immediately after a send races the network: the account may be `null` or stale, tripping the new "missing after init/resize" guards. Fix: either document confirmation as part of the callback contract, or have the SDK explicitly `await connection.confirmTransaction(sig, ...)` before reading. Picking the latter is more defensive because most wallet adapters' `signAndSendTransaction` returns after broadcast, not after confirmation.
+
+## `write_hook_proof` ordering: confirm between writes too
+
+The same `signAndSend`-resolves-on-broadcast hazard bites the write loop in `uploadProofChunked`. `write_hook_proof_handler` enforces `offset == high_water_mark`; if the wallet adapter returns after broadcast, the next chunk's submit can race ahead of the previous one and the program rejects it. Unlike the frontend (which sets `maxRetries: 5` on `sendRawTransaction`), the SDK has no retry path, so out-of-order arrival is unrecoverable. Confirm each chunk before the next — same pattern as init/resize. The finalize step also reads cumulative high_water_mark, so the last write must be confirmed before finalize (subsumed by per-write confirm).
+
+## `runStepConfirm` is purely UI now — do not re-confirm
+
+`use-prove-flow.ts` step 4 (`runStepSubmit`) already awaits `confirmTransaction` for the settle tx using its **original signing blockhash**. Re-confirming in step 5 with a fresh `getLatestBlockhash()` would re-introduce the very bug step 4 fixed (decoupled wait-loop expiry). Step 5 exists only to drive the UI step machine — keep it side-effect free.

--- a/gotchas.md
+++ b/gotchas.md
@@ -49,3 +49,62 @@ The same `signAndSend`-resolves-on-broadcast hazard bites the write loop in `upl
 ## `runStepConfirm` is purely UI now — do not re-confirm
 
 `use-prove-flow.ts` step 4 (`runStepSubmit`) already awaits `confirmTransaction` for the settle tx using its **original signing blockhash**. Re-confirming in step 5 with a fresh `getLatestBlockhash()` would re-introduce the very bug step 4 fixed (decoupled wait-loop expiry). Step 5 exists only to drive the UI step machine — keep it side-effect free.
+
+## Groth16 proof bundle uploaded by frontend must be `proof || public-witness`, not the proof slice alone
+
+`proveGroth16()` in `frontend/src/lib/api/endpoints.ts` returns the bundle the on-chain verifier consumes — full body, **not** `body.subarray(0, proofLen)`. The on-chain `split_proof_and_witness(data, witness_len=364)` (`programs/zksettle/src/instructions/verify_proof/helpers.rs:25`) peels the trailing 364-byte gnark public witness off and feeds the prefix to `GnarkProof::from_bytes`. If the staged `hook_payload.proof_and_witness` is only the 388-byte proof slice, the split gives a 24-byte proof prefix and `from_bytes` rejects with `ProofConversionError` (Anchor 6000 `MalformedProof`) without ever reaching the pairing check. Always upload the full 752-byte bundle (388 + 364) into `hook_payload.proof_and_witness`.
+
+## Frontend mint/recipient limb split is the *reverse* of intuition: high 16 bytes first
+
+`pubkey_to_limbs` (`backend/programs/zksettle/src/instructions/verify_proof/helpers.rs:32`) puts `pk.to_bytes()[0..16]` into the **HI** limb and `pk.to_bytes()[16..32]` into the **LO** limb. `check_bindings` (same dir, `bindings.rs:50`) re-derives the limbs from the *instruction-argument* mint/recipient and requires `witness.entries[MINT_LO_IDX/HI_IDX]` (and recipient) to match.
+
+Frontend (`use-prove-flow.ts:151-`) must build the circuit inputs the same way:
+
+```ts
+const mintLo = toHex(mintBytes.slice(16, 32));  // trailing 16 → LO
+const mintHi = toHex(mintBytes.slice(0, 16));   // leading 16 → HI
+```
+
+Swapping these silently passes the circuit (Noir hashes whatever it gets), so the proof verifies and the bundle deserialises — only `check_bindings` catches it, with `MintMismatch` (6009) or `RecipientMismatch` (6011) at `bindings.rs:50/61`. The nullifier hash also depends on this split, so a fix changes the nullifier value — pre-fix nullifiers in the registry stay orphaned but harmless.
+
+## Witness `timestamp` is bound to `epoch * EPOCH_LEN_SECS`, NOT `clock.unix_timestamp`
+
+`check_bindings` (`backend/programs/zksettle/src/instructions/verify_proof/bindings.rs:80`) requires `witness.entries[TIMESTAMP_IDX] == u64_to_field_bytes(inputs.timestamp)`. Reading `settlement.rs` / `handler.rs` cold suggests `inputs.timestamp` would be `clock.unix_timestamp` — that's how it was originally wired and it made the binding unsatisfiable: the frontend stamps `Math.floor(Date.now()/1000)` at proof-gen, and the 5–60 s gap until settle execution guaranteed `Custom(6029) TimestampMismatch` on devnet.
+
+Both sides now derive timestamp from the witness epoch instead:
+
+- on-chain `settlement.rs` and `handler.rs`: `timestamp = epoch.checked_mul(EPOCH_LEN_SECS as u64)`
+- frontend `use-prove-flow.ts:164`: `String(Number(epoch) * 86_400)` (epoch already = `Date.now()/1000/86400`)
+
+`validate_epoch` (`helpers.rs:14`) bounds freshness via `MAX_EPOCH_LAG=1`, but because the witness `timestamp` is the *start* of `epoch` (`epoch * 86_400`) and the Noir constraint is `timestamp <= credential_expiry` (`circuits/src/main.nr:162`), freshness has post-expiry slack of up to `(MAX_EPOCH_LAG + 1) * EPOCH_LEN_SECS` ≈ 48 h: a credential that expired near the end of epoch N-1 still verifies anywhere in epoch N because `(N-1) * 86_400 ≤ credential_expiry`. This is acceptable only while `CREDENTIAL_VALIDITY_SECS >> 48 h` — flag in audit if validity ever drops near that range. **Do not** revert the on-chain side to `clock.unix_timestamp` without flipping the frontend in lockstep.
+
+## `settle_hook` tx MUST raise CU limit — default 200K is far too low
+
+`settle_hook` invokes `verify_bundle` (Groth16 pairing on BN254), Light Protocol CPI, and Bubblegum CPI in a single ix. Real cost is in the millions of CU. The Solana per-tx default is 200K, so omitting `ComputeBudgetProgram.setComputeUnitLimit` makes the tx land but revert with `ProgramFailedToComplete` and a log line `consumed 199700 of 199700 compute units ... exceeded CUs meter at BPF instruction` — **not** a Custom error, so it does not trip any of the binding-mismatch (`6021..=6029`) variants and is easy to misread as a logic bug.
+
+Fix in `frontend/src/hooks/use-prove-flow.ts` (settle batch builds with `new Transaction().add(cuLimitIx).add(cuPriceIx).add(settleIx)` where `cuLimitIx = ComputeBudgetProgram.setComputeUnitLimit({ units: 1_400_000 })`). 1.4M is the per-tx max; do not lower without re-benchmarking the bundle. The init/resize/write/finalize batches do not need this — only the settle batch is CU-heavy.
+
+## Prove-flow uses `"processed"` commitment for non-settle batches
+
+`use-prove-flow.ts`'s `confirmTx` takes a `commitment` arg. Default is `"confirmed"`, but the issuer-register / stale-close pre-reqs, init+resize batch 1, the last-write confirm in batch 2, and finalize batch 3 all pass `"processed"`. Settle batch 4 keeps `"confirmed"` so the indexer keys off a confirmed `ProofSettled`. This drops ~30-45s off end-to-end on devnet vs all-confirmed.
+
+The trade-off: a `"processed"` tx that gets forked out (rare but possible) leaves the next batch reading stale account state and failing with an account-not-ready / wrong-discriminator error. Users would need to click prove again. The fallback path in `confirmTx` (signature-status poll) is commitment-aware — when called with `"processed"` it accepts `processed | confirmed | finalized`. **Do not** weaken settle to `"processed"` — the indexer's webhook only fires on confirmed blocks.
+
+## Prove-flow does NOT invoke `settle_hook` — Light CPI wiring still missing in SDK
+
+The `buildSettleHookIx` SDK helper exists (`sdk/src/wrap/index.ts:266`) but the prove-flow does NOT call it. Calling it on the current SDK fails deterministically with Anchor `InvalidLightAddress (6020)` / `CpiAccountsIndexOutOfBounds(6)` from `settle_core.rs:51`, whether caught by Alchemy preflight simulation (`skipPreflight: false`) or by on-chain runtime (`skipPreflight: true`, surfaces as `InstructionError: [2, Custom(6020)]` or generic `ProgramFailedToComplete` if CU is also exhausted).
+
+Root cause: `buildSettleHookIx` does not pass any Light Protocol CPI remaining_accounts (light system program, registered program PDA, noop, account compression program + authority, sysprog, address merkle tree, address queue, output state tree), and `DEFAULT_LIGHT_ARGS` (`sdk/src/wrap/index.ts:45`) stores zero indices + `proofPresent: false` into the `HookPayload` PDA at finalize. `settle_core` then calls `address_tree_info.get_tree_pubkey(&light_cpi_accounts)` against the empty remaining_accounts list and bombs.
+
+The prove-flow's "Submit on-chain" step (step 4 in `use-prove-flow.ts`) intentionally ends at `finalize_hook_payload`. Re-introducing the settle batch will re-introduce the runtime failure unless the SDK is first updated to:
+
+1. Append Light CPI remaining_accounts in the exact order `light_sdk::cpi::v2::CpiAccounts::new` expects.
+2. Fetch a new-address validity proof from a Photon indexer for the derived `null_addr` / `att_addr` (`settle_core.rs:56-69`) before calling `finalize_hook_payload`, and pass real `proofBytes` + packed tree/queue/root indices via `StagedLightArgs`.
+
+Until both pieces land, `buildSettleHookIx` should be treated as scaffolding for a future workstream, not a callable end-to-end primitive. The `ProofSettled` event will not emit and the indexer's events table will stay empty for this flow.
+
+## Devnet congestion → final tx must carry a priority fee + maxRetries bump
+
+On Alchemy devnet, the last tx in the prove-flow (currently finalize; settle when wired) is the most vulnerable to leader skipping. Without `ComputeBudgetProgram.setComputeUnitPrice` and `maxRetries` above the default 3, devnet leaders under load drop the tx and the 60-90s blockhash window expires before inclusion, surfacing as `TransactionExpiredBlockheightExceededError` w/ the sig never appearing on Solscan.
+
+Current mitigation in `use-prove-flow.ts` finalize batch: `setComputeUnitPrice({ microLamports: 50_000 })` (×default 200K CU ≈ 10,000 lamports ≈ 0.00001 SOL) + `sendSigned(..., { maxRetries: 10 })`. The `confirmTx` fallback (`use-prove-flow.ts:269-302`) additionally polls `getSignatureStatus` for 30s after the blockhash strategy returns `BlockheightExceeded`, catching late inclusions. Together these reduce false-negative expiry errs to near-zero under normal devnet load. **Do not** drop either without re-benching against a busy devnet slot; the failure mode is silent (sig never lands) and very expensive to debug because both Alchemy logs and Solscan show no record of the tx.

--- a/gotchas.md
+++ b/gotchas.md
@@ -1,0 +1,29 @@
+# Gotchas
+
+## scripts/devnet-hook/transfer.ts: missing `resize_hook_payload` call
+
+Program flow requires: `init_hook_payload` → `resize_hook_payload` → `write_hook_proof` → `finalize_hook_payload` → `settle_hook`.
+
+`init_hook_payload` only allocates `BASE_SPACE` (header). `resize_hook_payload` is what grows the PDA AND allocates `proof_and_witness: vec![0u8; expected]`. Skipping resize leaves the Vec at length 0, so `write_hook_proof_handler` panics at `handlers.rs:91` on `copy_from_slice` into len-0 slice with message `range end index N out of range for slice of length 0`.
+
+For proofs > ~10 KB the client must call `resizeHookPayload()` multiple times until `data_len >= target`.
+
+## Helius webhook auth: `Bearer ` prefix required
+
+Indexer `verify_auth` (routes/webhook.rs) strips `Bearer ` prefix from `Authorization` header. Helius sends the auth header value verbatim, so the dashboard's "Authentication Header" field must include `Bearer ` prefix:
+
+```
+Bearer <INDEXER_HELIUS_AUTH_TOKEN value>
+```
+
+Without prefix → 401. After fix → 200.
+
+## Frontend prove flow was missing `settle_hook` call entirely
+
+`use-prove-flow.ts` stopped at `finalizeHookPayload`. No `settleHook`, no Token-2022 `transferChecked` triggering the hook. Result: real proofs were staged in the `hook_payload` PDA but the verifier never ran, so `ProofSettled` was never emitted and the indexer's `events` table stayed empty — even with a fully wired Helius → indexer pipeline returning 200.
+
+Settlement path (direct call) needs ~13 accounts including `registry.merkle_tree` (fetch from chain) and PDAs `tree_config` / `tree_creator`. `buildSettleHookIx` in `sdk/src/wrap/index.ts` resolves them.
+
+## SDK `uploadProofChunked` skipped resize step
+
+Same bug as the original `transfer.ts`: helper exported from the SDK but built `init → write → finalize` only. Fortunately nothing outside the SDK called it, so no production impact — but the helper itself would have panicked on first use. Fixed to include `resize_hook_payload` loop matching the on-chain realloc cap (10 KiB / ix).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,6 @@ importers:
 
   frontend:
     dependencies:
-      '@aztec/bb.js':
-        specifier: 3.0.0-nightly.20260102
-        version: 3.0.0-nightly.20260102
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -52,6 +49,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.100.5
         version: 5.100.9(react@19.0.0)
+      '@zkpassport/poseidon2':
+        specifier: ^0.6.2
+        version: 0.6.2
       '@zksettle/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1988,6 +1988,9 @@ packages:
   '@wallet-standard/wallet@1.1.0':
     resolution: {integrity: sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==}
     engines: {node: '>=16'}
+
+  '@zkpassport/poseidon2@0.6.2':
+    resolution: {integrity: sha512-6sFHX9kAcrmDmBEEndvjZ8DA9FomunirQ5oCV6oD7bqr/lP0n0OBSRn86SZgQBXwRR+vq7sk16y31OgRBIOJ5Q==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -7146,6 +7149,8 @@ snapshots:
   '@wallet-standard/wallet@1.1.0':
     dependencies:
       '@wallet-standard/base': 1.1.0
+
+  '@zkpassport/poseidon2@0.6.2': {}
 
   abort-controller@3.0.0:
     dependencies:

--- a/scripts/devnet-hook/transfer.ts
+++ b/scripts/devnet-hook/transfer.ts
@@ -218,6 +218,31 @@ async function main() {
       .rpc();
     console.log(`Payload init: tx ${initSig}`);
 
+    // 1a-bis. resize_hook_payload — grow PDA + allocate proof_and_witness vec.
+    // Required before write_hook_proof or the vec stays length 0.
+    // Solana caps realloc at 10 KiB / ix, so loop until on-chain data.length
+    // has grown by proofBytes.length bytes (avoids hardcoding BASE_SPACE).
+    const baselineInfo = await connection.getAccountInfo(hookPayloadPda);
+    if (!baselineInfo) throw new Error("hook_payload PDA missing after init");
+    const headerSize = baselineInfo.data.length;
+    const targetSize = headerSize + proofBytes.length;
+    let currentSize = headerSize;
+    while (currentSize < targetSize) {
+      const resizeSig = await program.methods
+        .resizeHookPayload()
+        .accounts({
+          authority: wallet.publicKey,
+          issuer: issuerPda,
+          hookPayload: hookPayloadPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+      console.log(`Payload resized: tx ${resizeSig}`);
+      const after = await connection.getAccountInfo(hookPayloadPda);
+      if (!after) throw new Error("hook_payload PDA missing after resize");
+      currentSize = after.data.length;
+    }
+
     // 1b. write_hook_proof — upload proof in one chunk (< 1KB fits single tx)
     const writeSig = await program.methods
       .writeHookProof(0, proofBytes)

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,6 +4,7 @@ export {
   buildResizeHookPayloadIx,
   buildWriteChunkIx,
   buildFinalizeHookPayloadIx,
+  buildSettleHookIx,
   uploadProofChunked,
   checkIssuerExists,
   buildRegisterIssuerIx,

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -76,7 +76,7 @@ export async function buildRegisterIssuerIx(
   program?: Program,
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .registerIssuer(
@@ -109,7 +109,7 @@ export async function buildCloseHookPayloadIx(
   program?: Program,
 ): Promise<TransactionInstruction> {
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .closeHookPayload()
@@ -120,11 +120,19 @@ export async function buildCloseHookPayloadIx(
     .instruction();
 }
 
-async function makeProgram(connection: Connection): Promise<Program> {
+async function makeProgram(
+  connection: Connection,
+  programId: PublicKey = ZKSETTLE_PROGRAM_ID,
+): Promise<Program> {
   const { AnchorProvider, Program } = await loadAnchorBrowser();
   const dummyWallet = new DummyWallet();
   const provider = new AnchorProvider(connection, dummyWallet as any, {});
-  return new Program(idl as any, provider);
+  // Anchor 0.31 reads the program address from `idl.address`; the old
+  // `new Program(idl, programId, provider)` form was removed. Honor a
+  // caller-supplied override by cloning the IDL with a new address — otherwise
+  // PDAs derived from `programId` would mismatch the ix target address.
+  const idlWithAddress = { ...(idl as any), address: programId.toBase58() };
+  return new Program(idlWithAddress, provider);
 }
 
 export async function buildInitHookPayloadIx(
@@ -136,7 +144,7 @@ export async function buildInitHookPayloadIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .initHookPayload(proofLen)
@@ -157,7 +165,7 @@ export async function buildResizeHookPayloadIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .resizeHookPayload()
@@ -180,7 +188,7 @@ export async function buildWriteChunkIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   return prog.methods
     .writeHookProof(offset, Buffer.from(chunk))
@@ -208,7 +216,7 @@ export async function buildFinalizeHookPayloadIx(
 ): Promise<TransactionInstruction> {
   const [issuerPda] = findIssuerPda(wallet, programId);
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   const lightArgs = metadata.lightArgs ?? DEFAULT_LIGHT_ARGS;
 
@@ -240,7 +248,7 @@ export async function buildSettleHookIx(
   const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
   const [registryPda] = findRegistryPda(programId);
   const [treeCreatorPda] = findTreeCreatorPda(programId);
-  const prog = program ?? await makeProgram(connection);
+  const prog = program ?? await makeProgram(connection, programId);
 
   // Fetch registry (resolves merkle_tree; settle_hook enforces
   // `merkle_tree == registry.merkle_tree`) and hook_payload (recipient/mint
@@ -284,7 +292,7 @@ export async function uploadProofChunked(
   const raw = opts.chunkSize ?? CHUNK_SIZE;
   const chunkSize = Math.max(1, Math.floor(raw));
   const proofBytes = opts.proof;
-  const program = await makeProgram(opts.connection);
+  const program = await makeProgram(opts.connection, programId);
 
   console.log("[zksettle-sdk] uploadProofChunked: building initHookPayload ix", {
     wallet: opts.wallet.toBase58(),

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -308,6 +308,11 @@ export async function uploadProofChunked(
   console.log("[zksettle-sdk] uploadProofChunked: sending initHookPayload tx...");
   const initSignature = await signAndSend(new Transaction().add(initIx));
   console.log("[zksettle-sdk] uploadProofChunked: initHookPayload sig:", initSignature);
+  // `signAndSend` is caller-supplied — wallet adapters typically resolve after
+  // broadcast, not after confirmation. Explicitly confirm before any
+  // getAccountInfo read so the loop below doesn't race a null/stale account.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
+  await opts.connection.confirmTransaction(initSignature, "confirmed");
 
   // resize_hook_payload grows the PDA AND allocates `proof_and_witness`.
   // Without it write_hook_proof panics copying into a zero-length Vec.
@@ -331,7 +336,12 @@ export async function uploadProofChunked(
       programId,
       program,
     );
-    await signAndSend(new Transaction().add(resizeIx));
+    const resizeSig = await signAndSend(new Transaction().add(resizeIx));
+    // Same rationale as the post-init confirm: the loop terminates on
+    // observed account size, so we must wait for the resize to land before
+    // reading or the loop can hang reading the pre-resize size.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
+    await opts.connection.confirmTransaction(resizeSig, "confirmed");
     const after = await opts.connection.getAccountInfo(hookPayloadPda);
     if (!after) {
       throw new Error("hook_payload PDA missing after resize");
@@ -362,6 +372,13 @@ export async function uploadProofChunked(
       tx.add(ix);
     }
     const sig = await signAndSend(tx);
+    // `write_hook_proof` enforces `offset == high_water_mark` on-chain. If
+    // `signAndSend` resolves on broadcast (typical wallet-adapter behavior),
+    // the next chunk's submit can race ahead of the previous one and the
+    // program rejects it. There is no SDK-side retry, so confirm before the
+    // next write.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
+    await opts.connection.confirmTransaction(sig, "confirmed");
     chunkSignatures.push(sig);
   }
 

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -14,8 +14,19 @@ import type {
   ChunkedUploadResult,
 } from "../types.js";
 import { loadAnchorBrowser } from "../anchor.js";
-import { ZKSETTLE_PROGRAM_ID } from "../constants.js";
-import { findIssuerPda, findHookPayloadPda } from "./pda.js";
+import {
+  ZKSETTLE_PROGRAM_ID,
+  MPL_BUBBLEGUM_ID,
+  SPL_ACCOUNT_COMPRESSION_ID,
+  SPL_NOOP_ID,
+} from "../constants.js";
+import {
+  findIssuerPda,
+  findHookPayloadPda,
+  findRegistryPda,
+  findTreeCreatorPda,
+  findTreeConfigPda,
+} from "./pda.js";
 import idl from "../idl/zksettle.json" with { type: "json" };
 
 // Minimal wallet shim that satisfies AnchorProvider without importing
@@ -214,6 +225,53 @@ export async function buildFinalizeHookPayloadIx(
       authority: wallet,
       issuer: issuerPda,
       hookPayload: hookPayloadPda,
+    })
+    .instruction();
+}
+
+export async function buildSettleHookIx(
+  wallet: PublicKey,
+  amount: AnchorBN,
+  connection: Connection,
+  programId = ZKSETTLE_PROGRAM_ID,
+  program?: Program,
+): Promise<TransactionInstruction> {
+  const [issuerPda] = findIssuerPda(wallet, programId);
+  const [hookPayloadPda] = findHookPayloadPda(wallet, programId);
+  const [registryPda] = findRegistryPda(programId);
+  const [treeCreatorPda] = findTreeCreatorPda(programId);
+  const prog = program ?? await makeProgram(connection);
+
+  // Fetch registry (resolves merkle_tree; settle_hook enforces
+  // `merkle_tree == registry.merkle_tree`) and hook_payload (recipient/mint
+  // staged at finalize; both `destination_token` and `leaf_owner` must equal
+  // recipient) in parallel — independent reads.
+  const [registry, payload] = await Promise.all([
+    (prog.account as any).bubblegumTreeRegistry.fetch(registryPda),
+    (prog.account as any).hookPayload.fetch(hookPayloadPda),
+  ]);
+  const merkleTree: PublicKey = registry.merkleTree;
+  const [treeConfigPda] = findTreeConfigPda(merkleTree);
+  const recipient: PublicKey = payload.recipient;
+  const mint: PublicKey = payload.mint;
+
+  return prog.methods
+    .settleHook(amount)
+    .accounts({
+      authority: wallet,
+      mint,
+      destinationToken: recipient,
+      hookPayload: hookPayloadPda,
+      leafOwner: recipient,
+      issuer: issuerPda,
+      registry: registryPda,
+      merkleTree,
+      treeConfig: treeConfigPda,
+      treeCreator: treeCreatorPda,
+      bubblegumProgram: MPL_BUBBLEGUM_ID,
+      compressionProgram: SPL_ACCOUNT_COMPRESSION_ID,
+      logWrapper: SPL_NOOP_ID,
+      systemProgram: SystemProgram.programId,
     })
     .instruction();
 }

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -306,13 +306,26 @@ export async function uploadProofChunked(
     program,
   );
   console.log("[zksettle-sdk] uploadProofChunked: sending initHookPayload tx...");
-  const initSignature = await signAndSend(new Transaction().add(initIx));
+  // Pre-set blockhash + feePayer so we can use the non-deprecated
+  // strategy-form confirmTransaction below. Wallet adapters preserve
+  // these when already set.
+  const initTx = new Transaction().add(initIx);
+  initTx.feePayer = opts.wallet;
+  const initBh = await opts.connection.getLatestBlockhash("confirmed");
+  initTx.recentBlockhash = initBh.blockhash;
+  const initSignature = await signAndSend(initTx);
   console.log("[zksettle-sdk] uploadProofChunked: initHookPayload sig:", initSignature);
   // `signAndSend` is caller-supplied — wallet adapters typically resolve after
   // broadcast, not after confirmation. Explicitly confirm before any
   // getAccountInfo read so the loop below doesn't race a null/stale account.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
-  await opts.connection.confirmTransaction(initSignature, "confirmed");
+  await opts.connection.confirmTransaction(
+    {
+      signature: initSignature,
+      blockhash: initBh.blockhash,
+      lastValidBlockHeight: initBh.lastValidBlockHeight,
+    },
+    "confirmed",
+  );
 
   // resize_hook_payload grows the PDA AND allocates `proof_and_witness`.
   // Without it write_hook_proof panics copying into a zero-length Vec.
@@ -336,12 +349,22 @@ export async function uploadProofChunked(
       programId,
       program,
     );
-    const resizeSig = await signAndSend(new Transaction().add(resizeIx));
+    const resizeTx = new Transaction().add(resizeIx);
+    resizeTx.feePayer = opts.wallet;
+    const resizeBh = await opts.connection.getLatestBlockhash("confirmed");
+    resizeTx.recentBlockhash = resizeBh.blockhash;
+    const resizeSig = await signAndSend(resizeTx);
     // Same rationale as the post-init confirm: the loop terminates on
     // observed account size, so we must wait for the resize to land before
     // reading or the loop can hang reading the pre-resize size.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
-    await opts.connection.confirmTransaction(resizeSig, "confirmed");
+    await opts.connection.confirmTransaction(
+      {
+        signature: resizeSig,
+        blockhash: resizeBh.blockhash,
+        lastValidBlockHeight: resizeBh.lastValidBlockHeight,
+      },
+      "confirmed",
+    );
     const after = await opts.connection.getAccountInfo(hookPayloadPda);
     if (!after) {
       throw new Error("hook_payload PDA missing after resize");
@@ -371,14 +394,23 @@ export async function uploadProofChunked(
     for (const ix of writeIxs.slice(i, i + WRITES_PER_TX)) {
       tx.add(ix);
     }
+    tx.feePayer = opts.wallet;
+    const writeBh = await opts.connection.getLatestBlockhash("confirmed");
+    tx.recentBlockhash = writeBh.blockhash;
     const sig = await signAndSend(tx);
     // `write_hook_proof` enforces `offset == high_water_mark` on-chain. If
     // `signAndSend` resolves on broadcast (typical wallet-adapter behavior),
     // the next chunk's submit can race ahead of the previous one and the
     // program rejects it. There is no SDK-side retry, so confirm before the
     // next write.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- signature-only overload: we don't own the tx blockhash (caller-set), so the strategy overload isn't available.
-    await opts.connection.confirmTransaction(sig, "confirmed");
+    await opts.connection.confirmTransaction(
+      {
+        signature: sig,
+        blockhash: writeBh.blockhash,
+        lastValidBlockHeight: writeBh.lastValidBlockHeight,
+      },
+      "confirmed",
+    );
     chunkSignatures.push(sig);
   }
 

--- a/sdk/src/wrap/index.ts
+++ b/sdk/src/wrap/index.ts
@@ -301,6 +301,36 @@ export async function uploadProofChunked(
   const initSignature = await signAndSend(new Transaction().add(initIx));
   console.log("[zksettle-sdk] uploadProofChunked: initHookPayload sig:", initSignature);
 
+  // resize_hook_payload grows the PDA AND allocates `proof_and_witness`.
+  // Without it write_hook_proof panics copying into a zero-length Vec.
+  // Solana realloc cap = 10 KiB / ix, so large proofs need multiple calls.
+  // Loop terminates on observed on-chain account size: capture the
+  // header-only baseline right after init, then resize until the account
+  // has grown by `proofBytes.length` bytes. This avoids hardcoding
+  // HookPayload::BASE_SPACE (which can drift if StagedLightArgs changes).
+  const [hookPayloadPda] = findHookPayloadPda(opts.wallet, programId);
+  const baselineInfo = await opts.connection.getAccountInfo(hookPayloadPda);
+  if (!baselineInfo) {
+    throw new Error("hook_payload PDA missing after init");
+  }
+  const headerSize = baselineInfo.data.length;
+  const targetSize = headerSize + proofBytes.length;
+  let currentSize = headerSize;
+  while (currentSize < targetSize) {
+    const resizeIx = await buildResizeHookPayloadIx(
+      opts.wallet,
+      opts.connection,
+      programId,
+      program,
+    );
+    await signAndSend(new Transaction().add(resizeIx));
+    const after = await opts.connection.getAccountInfo(hookPayloadPda);
+    if (!after) {
+      throw new Error("hook_payload PDA missing after resize");
+    }
+    currentSize = after.data.length;
+  }
+
   const writeIxs: TransactionInstruction[] = [];
   for (let offset = 0; offset < proofBytes.length; offset += chunkSize) {
     const end = Math.min(offset + chunkSize, proofBytes.length);

--- a/sdk/src/wrap/settle.test.ts
+++ b/sdk/src/wrap/settle.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import BN from "bn.js";
+import { AnchorProvider, Program } from "@coral-xyz/anchor";
+import idl from "../idl/zksettle.json" with { type: "json" };
+import { buildSettleHookIx } from "./index.js";
+import {
+  findHookPayloadPda,
+  findIssuerPda,
+  findRegistryPda,
+  findTreeConfigPda,
+  findTreeCreatorPda,
+} from "./pda.js";
+import {
+  MPL_BUBBLEGUM_ID,
+  SPL_ACCOUNT_COMPRESSION_ID,
+  SPL_NOOP_ID,
+  ZKSETTLE_PROGRAM_ID,
+} from "../constants.js";
+
+const SETTLE_HOOK_DISCRIMINATOR = new Uint8Array([188, 162, 182, 6, 30, 19, 21, 139]);
+
+class DummyWallet {
+  readonly payer = Keypair.generate();
+  readonly publicKey = this.payer.publicKey;
+  async signTransaction<T>(tx: T): Promise<T> { return tx; }
+  async signAllTransactions<T>(txs: T[]): Promise<T[]> { return txs; }
+}
+
+function buildProgram() {
+  // Connection URL is never hit; AnchorProvider/Program construction is RPC-free
+  // and we mock the only `.account.X.fetch` calls below.
+  const connection = new Connection("http://127.0.0.1:8899");
+  const provider = new AnchorProvider(connection, new DummyWallet() as any, {});
+  return new Program(idl as any, provider);
+}
+
+describe("buildSettleHookIx", () => {
+  const authority = Keypair.generate().publicKey;
+  const merkleTree = Keypair.generate().publicKey;
+  const recipient = Keypair.generate().publicKey;
+  const mint = Keypair.generate().publicKey;
+  const amount = new BN(1_234_567);
+
+  let program: Program;
+  let registryFetch: ReturnType<typeof vi.fn>;
+  let payloadFetch: ReturnType<typeof vi.fn>;
+  let ix: Awaited<ReturnType<typeof buildSettleHookIx>>;
+
+  beforeAll(async () => {
+    program = buildProgram();
+    registryFetch = vi.fn().mockResolvedValue({ merkleTree });
+    payloadFetch = vi.fn().mockResolvedValue({ recipient, mint });
+    (program.account as any).bubblegumTreeRegistry.fetch = registryFetch;
+    (program.account as any).hookPayload.fetch = payloadFetch;
+
+    const connection = new Connection("http://127.0.0.1:8899");
+    ix = await buildSettleHookIx(
+      authority,
+      amount as any,
+      connection,
+      ZKSETTLE_PROGRAM_ID,
+      program,
+    );
+  });
+
+  it("targets the zksettle program", () => {
+    expect(ix.programId.equals(ZKSETTLE_PROGRAM_ID)).toBe(true);
+  });
+
+  it("has 14 accounts (matches IDL SettleHook ctx)", () => {
+    expect(ix.keys).toHaveLength(14);
+  });
+
+  it("encodes the settle_hook discriminator", () => {
+    expect(Buffer.from(ix.data.subarray(0, 8))).toEqual(Buffer.from(SETTLE_HOOK_DISCRIMINATOR));
+  });
+
+  it("encodes amount as little-endian u64 after discriminator", () => {
+    expect(ix.data.length).toBe(16);
+    expect(ix.data.readBigUInt64LE(8)).toBe(BigInt(amount.toString()));
+  });
+
+  it("fetches registry and hook_payload from the correct PDAs", () => {
+    const [registryPda] = findRegistryPda(ZKSETTLE_PROGRAM_ID);
+    const [hookPayloadPda] = findHookPayloadPda(authority, ZKSETTLE_PROGRAM_ID);
+    expect((registryFetch.mock.calls[0]?.[0] as PublicKey).equals(registryPda)).toBe(true);
+    expect((payloadFetch.mock.calls[0]?.[0] as PublicKey).equals(hookPayloadPda)).toBe(true);
+  });
+
+  it("issues both fetches in parallel (Promise.all)", () => {
+    // Both mocks must have been invoked before either resolves — Promise.all
+    // starts every promise synchronously. We assert both were called exactly
+    // once, which is the observable contract; ordering between them is not
+    // guaranteed but must both fire before the methods chain runs.
+    expect(registryFetch).toHaveBeenCalledTimes(1);
+    expect(payloadFetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe("account layout (must match settle_hook IDL order)", () => {
+    const [issuerPda] = findIssuerPda(authority, ZKSETTLE_PROGRAM_ID);
+    const [hookPayloadPda] = findHookPayloadPda(authority, ZKSETTLE_PROGRAM_ID);
+    const [registryPda] = findRegistryPda(ZKSETTLE_PROGRAM_ID);
+    const [treeCreatorPda] = findTreeCreatorPda(ZKSETTLE_PROGRAM_ID);
+
+    it("0: authority — signer + writable", () => {
+      const k = ix.keys[0]!;
+      expect(k.pubkey.equals(authority)).toBe(true);
+      expect(k.isSigner).toBe(true);
+      expect(k.isWritable).toBe(true);
+    });
+
+    it("1: mint (from payload)", () => {
+      expect(ix.keys[1]!.pubkey.equals(mint)).toBe(true);
+      expect(ix.keys[1]!.isSigner).toBe(false);
+    });
+
+    it("2: destinationToken == payload.recipient", () => {
+      expect(ix.keys[2]!.pubkey.equals(recipient)).toBe(true);
+    });
+
+    it("3: hookPayload PDA — writable", () => {
+      expect(ix.keys[3]!.pubkey.equals(hookPayloadPda)).toBe(true);
+      expect(ix.keys[3]!.isWritable).toBe(true);
+    });
+
+    it("4: leafOwner == recipient (settle_hook requires equality)", () => {
+      expect(ix.keys[4]!.pubkey.equals(recipient)).toBe(true);
+    });
+
+    it("5: issuer PDA", () => {
+      expect(ix.keys[5]!.pubkey.equals(issuerPda)).toBe(true);
+    });
+
+    it("6: registry PDA", () => {
+      expect(ix.keys[6]!.pubkey.equals(registryPda)).toBe(true);
+    });
+
+    it("7: merkleTree (from registry) — writable", () => {
+      expect(ix.keys[7]!.pubkey.equals(merkleTree)).toBe(true);
+      expect(ix.keys[7]!.isWritable).toBe(true);
+    });
+
+    it("8: treeConfig PDA derived from merkleTree — writable", () => {
+      const [treeConfigPda] = findTreeConfigPda(merkleTree);
+      expect(ix.keys[8]!.pubkey.equals(treeConfigPda)).toBe(true);
+      expect(ix.keys[8]!.isWritable).toBe(true);
+    });
+
+    it("9: treeCreator PDA", () => {
+      expect(ix.keys[9]!.pubkey.equals(treeCreatorPda)).toBe(true);
+    });
+
+    it("10: bubblegumProgram", () => {
+      expect(ix.keys[10]!.pubkey.equals(MPL_BUBBLEGUM_ID)).toBe(true);
+    });
+
+    it("11: compressionProgram", () => {
+      expect(ix.keys[11]!.pubkey.equals(SPL_ACCOUNT_COMPRESSION_ID)).toBe(true);
+    });
+
+    it("12: logWrapper (noop)", () => {
+      expect(ix.keys[12]!.pubkey.equals(SPL_NOOP_ID)).toBe(true);
+    });
+
+    it("13: systemProgram", () => {
+      expect(ix.keys[13]!.pubkey.equals(PublicKey.default)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Frontend proof generation moves off in-browser `@aztec/bb.js` UltraHonk to a backend `/v1/prove/groth16` endpoint, returning a 752-byte `proof || witness` bundle ready for `hook_payload.proof_and_witness`. Nullifier hashing switches to `@zkpassport/poseidon2`. Wallet auth signs an optional body-hash suffix so the gateway can pin the binary proof request.
- Prove flow no longer calls `settle_hook` until the SDK wires Light Protocol CPI remaining_accounts and a Photon validity proof for the derived nullifier/attestation addresses. Calling it today reverts with Anchor `InvalidLightAddress` (6020) at `settle_core.rs:51`. `buildSettleHookIx` stays in the SDK as scaffolding for that workstream.
- Finalize is now the final on-chain tx in the prove flow. It gets a 50k µLamports/CU priority fee plus `maxRetries: 10` so Alchemy devnet leaders stop skipping it under congestion and surfacing as `TransactionExpiredBlockheightExceededError`.
- Limb split (`mintLo` / `mintHi` / `recipientLo` / `recipientHi`) and witness `timestamp` derivation align with the on-chain `pubkey_to_limbs` and `epoch * EPOCH_LEN_SECS` bindings.
- `gotchas.md` captures every devnet sharp edge hit while landing this: bundle format, limb split, timestamp binding, settle CU policy, "processed" commitment for non-settle batches, `runStepConfirm` UI-only contract, settle Light CPI gap, finalize priority-fee policy.

## Test plan

- [ ] `pnpm --filter frontend lint`
- [ ] `pnpm --filter frontend vitest run src/lib/nullifier src/hooks`
- [ ] `pnpm --filter frontend tsc --noEmit` (pre-existing test-file errors unrelated to this change)
- [ ] Run the prove flow against Alchemy devnet end-to-end: credential → Merkle paths → backend Groth16 → init+resize → writes → finalize. Finalize tx must land within one blockhash window and surface a Solscan link.
- [ ] Confirm `Submit on-chain` step succeeds; settle batch is intentionally skipped pending Light CPI wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added gateway bearer token authentication for upstream service communication.
  * Introduced server-side Groth16 proof generation (moved from browser).
  * Added body-bound wallet signatures for enhanced security.
  * New settle hook instruction builder for transaction finalization.

* **Bug Fixes**
  * Fixed proof upload by adding missing resize step.
  * Improved Solana transaction confirmation handling and blockhash management.

* **Documentation**
  * Added gotchas guide documenting critical system flows and required sequencing.

* **Refactor**
  * Migrated proof generation from client-side browser computation to server endpoint.
  * Simplified proof flow confirmation logic.

* **Tests**
  * Added cryptographic regression tests for nullifier computation.
  * Added settle hook instruction validation tests.

* **Chores**
  * Updated frontend dependencies; removed Barretenberg, added Poseidon2 library.
  * Updated environment configuration for gateway and issuer services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/188)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->