### PR TITLE
Surface devnet-only warnings across login and dashboard forms

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -42,6 +42,20 @@ export default function LoginPage() {
           </p>
         </div>
 
+        <div
+          role="alert"
+          className="flex w-full flex-col gap-1 rounded-[var(--radius-3)] border border-warning-text/30 bg-warning-bg px-4 py-3 text-left text-warning-text"
+        >
+          <p className="font-mono text-[10px] tracking-[0.1em] uppercase">
+            Devnet only
+          </p>
+          <p className="text-xs leading-relaxed">
+            ZKSettle runs on Solana <strong>devnet</strong>, not mainnet. Connect
+            a wallet configured for devnet — mainnet wallets will not work and
+            no real funds are involved.
+          </p>
+        </div>
+
         {connected ? (
           <div className="flex w-full flex-col gap-3">
             <div className="flex items-center justify-center gap-2 rounded-[var(--radius-3)] border border-border-subtle bg-surface px-4 py-3">

--- a/frontend/src/components/dashboard/prove-flow-panel.tsx
+++ b/frontend/src/components/dashboard/prove-flow-panel.tsx
@@ -226,6 +226,12 @@ function IntroCard({
                   onChange={(e) => onTransferParamsChange({ ...transferParams, mint: e.target.value })}
                   className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
                 />
+                <span className="mt-1 text-[11px] leading-snug text-muted">
+                  Public key of the Token-2022 mint you&apos;re transferring (the
+                  asset itself, not a wallet). Paste an SPL mint deployed on
+                  devnet — e.g. the stablecoin mint configured for this
+                  environment.
+                </span>
               </label>
               <label className="flex flex-col gap-1">
                 <span className="font-mono text-[10px] tracking-[0.1em] text-muted uppercase">Recipient address</span>

--- a/frontend/src/components/dashboard/prove-flow-panel.tsx
+++ b/frontend/src/components/dashboard/prove-flow-panel.tsx
@@ -242,6 +242,9 @@ function IntroCard({
                   onChange={(e) => onTransferParamsChange({ ...transferParams, recipient: e.target.value })}
                   className="h-9 w-full rounded-[var(--radius-2)] border border-border-subtle bg-canvas px-3 font-mono text-xs text-ink placeholder:text-muted transition-colors hover:border-border focus-visible:border-forest focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-forest"
                 />
+                <span className="mt-1 inline-flex items-center gap-1 self-start rounded-[var(--radius-2)] border border-warning-text/40 bg-warning-bg px-1.5 py-0.5 font-mono text-[10px] tracking-[0.05em] text-warning-text uppercase">
+                  Devnet wallet only — no mainnet
+                </span>
               </label>
             </div>
             <label className="flex flex-col gap-1 sm:max-w-[calc(50%-0.375rem)]">

--- a/frontend/src/components/dashboard/wallets-credentials-panel.tsx
+++ b/frontend/src/components/dashboard/wallets-credentials-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Clock, Plus, Search, Trash, Xmark } from "iconoir-react";
+import { Clock, Plus, Search, Trash, WarningTriangle, Xmark } from "iconoir-react";
 import { useEffect, useState, type SyntheticEvent } from "react";
 import { toast } from "sonner";
 
@@ -168,6 +168,18 @@ export function WalletsCredentialsPanel() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          <div
+            role="alert"
+            className="mb-3 flex items-start gap-2 rounded-[var(--radius-3)] border border-warning-text/40 bg-warning-bg px-3 py-2 text-warning-text"
+          >
+            <WarningTriangle aria-hidden="true" className="size-4 shrink-0 mt-0.5" strokeWidth={1.8} />
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[10px] tracking-[0.1em] uppercase">Devnet only</span>
+              <span className="text-xs leading-snug">
+                Paste a <strong>devnet</strong> wallet address. Mainnet addresses will not work here.
+              </span>
+            </div>
+          </div>
           <form
             onSubmit={onRegister}
             className="flex flex-col gap-3 sm:flex-row sm:items-center"
@@ -218,6 +230,18 @@ export function WalletsCredentialsPanel() {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          <div
+            role="alert"
+            className="mb-3 flex items-start gap-2 rounded-[var(--radius-3)] border border-warning-text/40 bg-warning-bg px-3 py-2 text-warning-text"
+          >
+            <WarningTriangle aria-hidden="true" className="size-4 shrink-0 mt-0.5" strokeWidth={1.8} />
+            <div className="flex flex-col gap-0.5">
+              <span className="font-mono text-[10px] tracking-[0.1em] uppercase">Devnet only</span>
+              <span className="text-xs leading-snug">
+                Look up <strong>devnet</strong> wallets only — mainnet addresses are not supported.
+              </span>
+            </div>
+          </div>
           <form onSubmit={lookup} className="flex flex-col gap-3 sm:flex-row sm:items-center">
             <Input
               value={walletInput}


### PR DESCRIPTION
## Summary
- Add a devnet warning banner on the login page so users know mainnet wallets are not supported.
- Add filled devnet alert pills with a warning icon to the wallet register and credential lookup forms in the dashboard.
- Explain what the mint address field expects on the prove-flow form and flag the recipient field as devnet-only with a small badge.

## Test plan
- [ ] Visit \`/login\` while disconnected and confirm the devnet banner renders above the Connect Wallet button.
- [ ] Open the dashboard wallets/credentials panel and confirm both Register and Look-up cards show the devnet alert with the warning icon.
- [ ] Open the prove-flow page and confirm the mint field has a muted helper describing it, and the recipient field shows the \"Devnet wallet only — no mainnet\" badge.
- [ ] \`pnpm -C frontend tsc --noEmit\` shows no new errors in touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prominent devnet-only warnings throughout the app to clarify limitations and usage context
  * Added explanatory guidance text for wallet and mint address inputs describing devnet-specific requirements
  * Added notices clarifying that mainnet wallets and addresses are incompatible with the application
  * Added messaging emphasizing no real funds are involved in the devnet environment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yuribodo/zksettle/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->